### PR TITLE
Add simple README with manual symlink instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Dotfiles
+
+## Manual Setup
+
+To use these dotfiles, manually create symlinks from your home directory to this repository:
+
+```bash
+# Create symlinks for configuration files
+ln -sf ~/dotfiles/.bashrc ~/.bashrc
+ln -sf ~/dotfiles/.bash_aliases ~/.bash_aliases
+ln -sf ~/dotfiles/.bash_exports ~/.bash_exports
+ln -sf ~/dotfiles/.gitconfig ~/.gitconfig
+
+# Apply changes
+source ~/.bashrc
+```
+
+That's it! Any changes you make to files in this repository will be reflected in your environment.


### PR DESCRIPTION
This PR adds a minimal README that documents the manual symlink process for setting up dotfiles. It keeps things simple and transparent by explaining how to manually create symlinks rather than using complex automation.