### PR TITLE
Add .gitignore to protect sensitive files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Ignore sensitive files
+*.key
+*.pem
+*.env
+*credentials*
+*.secret
+*.token
+*.password
+*.cert
+*.crt
+*.p12
+*.pfx
+*.jks
+*.keystore
+
+# Private SSH keys
+id_rsa
+id_dsa
+id_ecdsa
+id_ed25519
+
+# Logs
+*.log
+
+# Temporary files
+*.tmp
+*.temp
+*~
+
+# OS specific files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
This PR adds a .gitignore file to prevent accidentally committing sensitive files like private keys, credentials, and tokens. This adds an extra layer of security to the repository.