### PR TITLE
docs: add common errors section to AmazonQ.md

### DIFF
--- a/AmazonQ.md
+++ b/AmazonQ.md
@@ -4,6 +4,12 @@ This file contains guidance for Amazon Q when interacting with this repository.
 
 See [VIBE.md](./VIBE.md) for the Vibe Coding Manifesto that guides this repository.
 
+## Common Errors to Avoid
+- Use branch naming pattern: `type/description` (e.g., `feature/add-tool`, `fix/typo`)
+- Follow Conventional Commits style (e.g., `feat:`, `fix:`, `docs:`)
+- For GitHub CLI comments use: `gh pr comment <number> -b "text"` (not `---comment`)
+- Don't thank yourself when closing your own PRs
+
 Feel free to add your discoveries and insights below as you learn:
 
 - 


### PR DESCRIPTION
This PR adds a 'Common Errors to Avoid' section to the AmazonQ.md file based on previously encountered issues. The section includes guidance on:

- Branch naming patterns
- Conventional Commits style
- GitHub CLI comment syntax
- PR etiquette

These additions will help prevent common mistakes when working with the repository.