### PR TITLE
fix: move Google Chrome from CLI Tools to Applications section

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ source ~/.bashrc
 
 That's it! Any changes you make to files in this repository will be reflected in your environment.
 
-## CLI Tools
+## Applications
 
 ### Google Chrome
 
@@ -40,6 +40,8 @@ sudo apt install -y google-chrome-stable
 ```
 
 Chrome will automatically update when you run `sudo apt update` and `sudo apt upgrade` as part of your regular system maintenance.
+
+## CLI Tools
 
 ### jira-cli
 
@@ -67,8 +69,6 @@ sudo make install
 This ensures you get the latest version with all features, rather than the potentially outdated version from package repositories.
 
 For more build options, see the [official build instructions](https://github.com/neovim/neovim/blob/master/BUILD.md).
-
-
 
 ## CLI AI tools
 


### PR DESCRIPTION
This PR fixes the classification of Google Chrome in the README.md file. Chrome was incorrectly listed under the 'CLI Tools' section, but it's actually a GUI application. This PR:

1. Creates a new 'Applications' section at the appropriate level
2. Moves the Google Chrome installation instructions to this section
3. Keeps the 'CLI Tools' section for command-line utilities

This change improves the organization and accuracy of the documentation.