### PR TITLE
feat: add tmux config comparison aliases

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -5,6 +5,6 @@ alias git-tree="git ls-tree -r HEAD --name-only | tree --fromfile"
 alias gha-fails='get-latest-failed-gha-logs.sh'
 
 # Tmux config comparison aliases - toggle between branches like at the optometrist
-alias tmux-main="gh pr checkout main && tmux source-file ~/.tmux.conf"
+alias tmux-main="git checkout main && tmux source-file ~/.tmux.conf"
 alias tmux-pr="gh pr checkout - && tmux source-file ~/.tmux.conf"
 

--- a/.bash_aliases
+++ b/.bash_aliases
@@ -6,5 +6,5 @@ alias gha-fails='get-latest-failed-gha-logs.sh'
 
 # Tmux config comparison aliases - toggle between branches like at the optometrist
 alias tmux-main="git checkout main && tmux source-file ~/.tmux.conf"
-alias tmux-pr="gh pr checkout - && tmux source-file ~/.tmux.conf"
+alias tmux-pr="git checkout - && tmux source-file ~/.tmux.conf"
 

--- a/.bash_aliases
+++ b/.bash_aliases
@@ -4,3 +4,7 @@ alias clip='xclip -selection clipboard'
 alias git-tree="git ls-tree -r HEAD --name-only | tree --fromfile"
 alias gha-fails='get-latest-failed-gha-logs.sh'
 
+# Tmux config comparison aliases - toggle between branches like at the optometrist
+alias tmux-main="gh pr checkout main && tmux source-file ~/.tmux.conf"
+alias tmux-pr="gh pr checkout - && tmux source-file ~/.tmux.conf"
+

--- a/README.md
+++ b/README.md
@@ -123,3 +123,17 @@ The URL typically follows this format:
 ```bash
 https://d-XXXXXXXXXX.awsapps.com/start/#/console?account_id=XXXXXXXXXXXX&role_name=YOUR_ROLE_NAME
 ```
+
+### Tmux Config Comparison
+
+To compare different tmux configurations (like at an optometrist):
+
+```bash
+# Switch to main branch config
+tmux-main
+
+# Switch to PR branch config
+tmux-pr
+```
+
+This is useful when testing different tmux configurations to see which one you prefer. You can quickly toggle between them like at the optometrist ("which is better, 1 or 2?").


### PR DESCRIPTION
Adds simple aliases to easily compare tmux configurations between branches, similar to an optometrist's lens comparison ('which is better, 1 or 2?').