### PR TITLE
fix: explicitly set default status bar color

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -26,3 +26,6 @@ set -g base-index 1
 
 # Don't rename windows automatically
 set-option -g allow-rename off
+
+# Explicitly set default status bar color
+set -g status-style bg=default


### PR DESCRIPTION
Explicitly sets the default status bar color in the main branch configuration to ensure proper toggling between configurations.