### PR TITLE
feat: make tmux-pr alias more flexible

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -5,6 +5,6 @@ alias git-tree="git ls-tree -r HEAD --name-only | tree --fromfile"
 alias gha-fails='get-latest-failed-gha-logs.sh'
 
 # Tmux config comparison aliases - toggle between branches like at the optometrist
-alias tmux-main="git checkout main && tmux source-file ~/.tmux.conf && echo 'Switched to CYAN status bar'"
-alias tmux-pr="git checkout feature/blue-tmux-statusbar && tmux source-file ~/.tmux.conf && echo 'Switched to BLUE status bar'"
+alias tmux-main="git checkout main && tmux source-file ~/.tmux.conf && echo 'Switched to main branch config'"
+alias tmux-pr="git checkout - && tmux source-file ~/.tmux.conf && echo 'Switched to branch: $(git branch --show-current)'"
 


### PR DESCRIPTION
Updates the tmux-pr alias to use 'git checkout -' instead of hardcoding a specific branch name. This makes it more flexible for comparing any PR branch with main. Also updates the echo messages to show which branch you're on.