### PR TITLE
feat: add pr2branch utility script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,12 @@ sudo apt install -y git gh jq
 
 ## Manual Setup
 
-To use these dotfiles, manually create symlinks from your home directory to this repository:
-
 ```bash
-# Create Neovim config directory if it doesn't exist
-mkdir -p ~/.config/nvim
+# Link dotfiles directory (WSL users)
+ln -sf /mnt/c/dotfiles ~/dotfiles
 
 # Create symlinks for configuration files
+mkdir -p ~/.config/nvim
 ln -sf ~/dotfiles/nvim/init.lua ~/.config/nvim/init.lua
 ln -sf ~/dotfiles/.bashrc ~/.bashrc
 ln -sf ~/dotfiles/.bash_aliases ~/.bash_aliases

--- a/bin/pr-branch
+++ b/bin/pr-branch
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Get branch name from PR number
+#
+# Usage: pr-branch <pr-number>
+
+set -e
+
+if [ -z "$1" ]; then
+  echo "Error: PR number is required"
+  echo "Usage: pr-branch <pr-number>"
+  exit 1
+fi
+
+PR_NUMBER=$1
+
+# Check if gh command is available
+if ! command -v gh &> /dev/null; then
+  echo "Error: GitHub CLI (gh) is not installed"
+  exit 1
+fi
+
+# Get branch name from PR
+BRANCH_NAME=$(gh pr view "$PR_NUMBER" --json headRefName -q .headRefName)
+
+if [ -z "$BRANCH_NAME" ]; then
+  echo "Error: Could not find branch name for PR #$PR_NUMBER"
+  exit 1
+fi
+
+# Output just the branch name
+echo "$BRANCH_NAME"

--- a/bin/pr2branch
+++ b/bin/pr2branch
@@ -1,14 +1,14 @@
 #!/bin/bash
 #
-# Get branch name from PR number
+# Convert PR number (integer) to branch name (string)
 #
-# Usage: pr-branch <pr-number>
+# Usage: pr2branch <pr-number>
 
 set -e
 
 if [ -z "$1" ]; then
   echo "Error: PR number is required"
-  echo "Usage: pr-branch <pr-number>"
+  echo "Usage: pr2branch <pr-number>"
   exit 1
 fi
 


### PR DESCRIPTION
Adds a utility script that converts PR numbers to branch names.

Input: PR number (integer)
Output: Branch name (string)

This makes it easy to quickly find and check out branches associated with PRs without having to look up the branch name manually.