### PR TITLE
docs: add Zephyr Scale API token setup instructions

### DIFF
--- a/.bash_secrets.example
+++ b/.bash_secrets.example
@@ -3,3 +3,11 @@
 # Jira API token for CLI access
 # Generate from: https://id.atlassian.com/manage-profile/security/api-tokens
 export JIRA_API_TOKEN="your_api_token_here"
+
+# Zephyr Scale API token (Jira test management)
+# Generate from: Jira > Profile icon (top right) > Zephyr Scale API Access Tokens
+export ZEPHYR_API_KEY="your_zephyr_api_token_here"
+
+# Zephyr Scale API token (Jira test management)
+# Generate from: Jira > Profile icon (top right) > Zephyr Scale API Access Tokens
+export ZEPHYR_API_KEY="your_zephyr_api_token_here"

--- a/.bash_secrets.example
+++ b/.bash_secrets.example
@@ -7,7 +7,3 @@ export JIRA_API_TOKEN="your_api_token_here"
 # Zephyr Scale API token (Jira test management)
 # Generate from: Jira > Profile icon (top right) > Zephyr Scale API Access Tokens
 export ZEPHYR_API_KEY="your_zephyr_api_token_here"
-
-# Zephyr Scale API token (Jira test management)
-# Generate from: Jira > Profile icon (top right) > Zephyr Scale API Access Tokens
-export ZEPHYR_API_KEY="your_zephyr_api_token_here"

--- a/README.md
+++ b/README.md
@@ -102,6 +102,21 @@ jira init
 
 For installation instructions, see the [official installation guide](https://github.com/ankitpokhrel/jira-cli/wiki/Installation).
 
+### Zephyr Scale
+
+Zephyr Scale is a test management tool integrated with Jira.
+
+```bash
+# Generate an API token in Jira:
+# 1. Click on your profile icon in the top right corner
+# 2. Select "Zephyr Scale API Access Tokens"
+# 3. Click "Create access token" and follow the instructions
+# 4. Add the token to your ~/.bash_secrets file:
+echo '
+# Zephyr Scale API token (Jira test management)
+export ZEPHYR_API_KEY="your_zephyr_api_token_here"' >> ~/.bash_secrets
+```
+
 ### Neovim
 
 For the latest version of Neovim, build from source:


### PR DESCRIPTION
Added instructions for generating and storing Zephyr Scale API tokens in the dotfiles setup. This includes:

- Steps to generate the token from the Jira interface
- Command to add the token to ~/.bash_secrets
- Environment variable name (ZEPHYR_API_KEY) for API access