### PR TITLE
refactor: convert secrets management to a flexible framework

### DIFF
--- a/.bash_secrets.example
+++ b/.bash_secrets.example
@@ -3,3 +3,11 @@
 # Jira API token for CLI access
 # Generate from: https://id.atlassian.com/manage-profile/security/api-tokens
 export JIRA_API_TOKEN="your_api_token_here"
+
+# Zephyr Scale API token (Jira test management)
+# Generate from: Jira > Profile icon (top right) > Zephyr Scale API Access Tokens
+export ZEPHYR_API_KEY="your_zephyr_api_token_here"
+
+# Zephyr Scale API token (Jira test management)
+# Generate from: Jira > Profile icon (top right) > Zephyr Scale API Access Tokens
+export ZEPHYR_API_KEY="your_zephyr_api_token_here"

--- a/.bash_secrets.example
+++ b/.bash_secrets.example
@@ -1,13 +1,41 @@
 #!/bin/bash
 
-# Jira API token for CLI access
-# Generate from: https://id.atlassian.com/manage-profile/security/api-tokens
-export JIRA_API_TOKEN="your_api_token_here"
+# =========================================================
+# SECRETS MANAGEMENT FRAMEWORK
+# =========================================================
+# This file provides a template for managing your secrets
+# Copy this to ~/.bash_secrets and customize as needed
+# Your actual secrets file should NEVER be committed to git
+# =========================================================
 
-# Zephyr Scale API token (Jira test management)
-# Generate from: Jira > Profile icon (top right) > Zephyr Scale API Access Tokens
-export ZEPHYR_API_KEY="your_zephyr_api_token_here"
+# ==== AUTHENTICATION TOKENS ====
+# Examples of common authentication tokens
 
-# Test Key Vault access token
-# Generate from: [relevant instructions for generating this token]
-export TESTERKEYVAULT="your_testerkeyvault_token_here"
+# Generic API token example
+# export API_TOKEN="your_api_token_here"
+
+# Git/GitHub personal access token
+# export GITHUB_TOKEN="your_github_token_here"
+
+# ==== CLOUD CREDENTIALS ====
+# Examples for cloud service credentials
+
+# AWS credentials (alternative to ~/.aws/credentials)
+# export AWS_ACCESS_KEY_ID="your_access_key"
+# export AWS_SECRET_ACCESS_KEY="your_secret_key"
+# export AWS_DEFAULT_REGION="us-west-2"
+
+# ==== DEVELOPMENT TOOLS ====
+# Examples for development tool configurations
+
+# Database connection strings
+# export DEV_DB_CONNECTION="postgresql://user:password@localhost:5432/dbname"
+# export TEST_DB_CONNECTION="postgresql://user:password@localhost:5432/test_dbname"
+
+# ==== COMPANY-SPECIFIC SECRETS ====
+# Add your company-specific secrets here
+# Consider maintaining a separate company-specific dotfiles repo
+# with additional secrets templates
+
+# ==== CUSTOM ENVIRONMENT VARIABLES ====
+# Add any custom environment variables needed for your projects

--- a/.bash_secrets.example
+++ b/.bash_secrets.example
@@ -7,7 +7,3 @@ export JIRA_API_TOKEN="your_api_token_here"
 # Zephyr Scale API token (Jira test management)
 # Generate from: Jira > Profile icon (top right) > Zephyr Scale API Access Tokens
 export ZEPHYR_API_KEY="your_zephyr_api_token_here"
-
-# Zephyr Scale API token (Jira test management)
-# Generate from: Jira > Profile icon (top right) > Zephyr Scale API Access Tokens
-export ZEPHYR_API_KEY="your_zephyr_api_token_here"

--- a/.bash_secrets.example
+++ b/.bash_secrets.example
@@ -7,3 +7,7 @@ export JIRA_API_TOKEN="your_api_token_here"
 # Zephyr Scale API token (Jira test management)
 # Generate from: Jira > Profile icon (top right) > Zephyr Scale API Access Tokens
 export ZEPHYR_API_KEY="your_zephyr_api_token_here"
+
+# Test Key Vault access token
+# Generate from: [relevant instructions for generating this token]
+export TESTERKEYVAULT="your_testerkeyvault_token_here"

--- a/README.md
+++ b/README.md
@@ -102,6 +102,21 @@ jira init
 
 For installation instructions, see the [official installation guide](https://github.com/ankitpokhrel/jira-cli/wiki/Installation).
 
+### Zephyr Scale
+
+Zephyr Scale is a test management tool integrated with Jira.
+
+```bash
+# Generate an API token in Jira:
+# 1. Click on your profile icon in the top right corner
+# 2. Select "Zephyr Scale API Access Tokens"
+# 3. Click "Create access token" and follow the instructions
+# 4. Add the token to your ~/.bash_secrets file:
+echo '
+# Zephyr Scale API token (Jira test management)
+export ZEPHYR_API_KEY="your_zephyr_api_token_here"' >> ~/.bash_secrets
+```
+
 ### Neovim
 
 For the latest version of Neovim, build from source:

--- a/README.md
+++ b/README.md
@@ -61,9 +61,14 @@ cp ~/dotfiles/.bash_secrets.example ~/.bash_secrets
 
 # Set proper permissions to protect your secrets
 chmod 600 ~/.bash_secrets
+
+# Edit the file to add your specific secrets
+nano ~/.bash_secrets
 ```
 
-The `.bash_secrets` file is automatically loaded by `.bashrc`.
+The `.bash_secrets` file is automatically loaded by `.bashrc`. It provides a framework for managing your secrets and environment variables, with examples of common patterns. You should customize it based on your needs.
+
+For company-specific secrets, consider maintaining a separate private repository with additional templates and documentation.
 
 ## CLI Tools
 

--- a/README.md
+++ b/README.md
@@ -102,21 +102,6 @@ jira init
 
 For installation instructions, see the [official installation guide](https://github.com/ankitpokhrel/jira-cli/wiki/Installation).
 
-### Zephyr Scale
-
-Zephyr Scale is a test management tool integrated with Jira.
-
-```bash
-# Generate an API token in Jira:
-# 1. Click on your profile icon in the top right corner
-# 2. Select "Zephyr Scale API Access Tokens"
-# 3. Click "Create access token" and follow the instructions
-# 4. Add the token to your ~/.bash_secrets file:
-echo '
-# Zephyr Scale API token (Jira test management)
-export ZEPHYR_API_KEY="your_zephyr_api_token_here"' >> ~/.bash_secrets
-```
-
 ### Neovim
 
 For the latest version of Neovim, build from source:


### PR DESCRIPTION
This PR refactors the secrets management approach to be more of a framework rather than documenting specific secrets.

## Changes
- Created a more flexible framework for secrets management
- Added canonical examples of different types of secrets (authentication tokens, cloud credentials, etc.)
- Organized the template with clear sections and comments
- Updated documentation to emphasize maintaining company-specific secrets separately

This approach shifts responsibility away from the dotfiles repo for documenting every environment variable while still providing a solid framework for secret management.