### PR TITLE
Fix Git prompt to only run Git commands when in a repository

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -133,7 +133,10 @@ if ! shopt -oq posix; then
 fi
 # Git branch in prompt
 parse_git_branch() {
-  git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/ (\1)/'
+  # Only run git commands if we're in a git repository
+  if git rev-parse --is-inside-work-tree &>/dev/null; then
+    git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/ (\1)/'
+  fi
 }
 
 # Set prompt to show current directory and git branch


### PR DESCRIPTION
This PR fixes the issue where opening a new terminal session outside of a Git repository shows the error message "fatal: not a git repository (or any of the parent directories): .git".\n\nThe fix modifies the parse_git_branch() function to first check if we're in a Git repository before attempting to run any Git commands.