### PR TITLE
Add readline config for quick CLI confirmations

### DIFF
--- a/.inputrc
+++ b/.inputrc
@@ -1,0 +1,5 @@
+# ~/.inputrc - Minimal configuration for readline
+# Amazon Q CLI often asks for "y" confirmation prompts
+# This binding allows quick confirmation with Ctrl+Space
+# instead of having to type "y" followed by Enter
+"\C-@": "y\C-m"

--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ https://d-XXXXXXXXXX.awsapps.com/start/#/console?account_id=XXXXXXXXXXXX&role_na
 
 Next step: run `q telemetry disable` - 'nuff said.
 
+**Pro tip:** Check out the `.inputrc` binding (Ctrl+Space → "y" + Enter). Solves the ergonomic friction of "y" being miles from Enter on keyboards. Security without the finger gymnastics.
+
 ### Tmux Config Comparison
 
 To compare different tmux configurations (like at an optometrist):

--- a/README.md
+++ b/README.md
@@ -24,9 +24,11 @@ ln -sf ~/dotfiles/.bash_aliases ~/.bash_aliases
 ln -sf ~/dotfiles/.bash_exports ~/.bash_exports
 ln -sf ~/dotfiles/.gitconfig ~/.gitconfig
 ln -sf ~/dotfiles/.tmux.conf ~/.tmux.conf
+ln -sf ~/dotfiles/.inputrc ~/.inputrc
 
 # Apply changes
 source ~/.bashrc
+bind -f ~/.inputrc
 ```
 
 That's it! Any changes you make to files in this repository will be reflected in your environment.


### PR DESCRIPTION
This PR adds a minimal .inputrc configuration that maps Ctrl+Space to send 'y' followed by Enter.\n\nSolves the ergonomic friction of 'y' being far from Enter on keyboards when responding to Amazon Q permission prompts.\n\nA small quality-of-life improvement that maintains security without the finger gymnastics.