### PR TITLE
fix: check for git repository in scripts before running git commands

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -1,12 +1,12 @@
 alias grabout='PREV_CMD=$(fc -ln -2 -2 | sed "s/^ *//"); (echo "Command: $PREV_CMD" && eval "$PREV_CMD" 2>&1) | xclip -selection clipboard'
 alias grabout='echo -n "$(fc -s -1)" | xclip -in -selection clipboard && echo "Last command copied!"'
 alias clip='xclip -selection clipboard'
-alias git-tree="git ls-tree -r HEAD --name-only | tree --fromfile"
+alias git-tree='if git rev-parse --is-inside-work-tree &>/dev/null; then git ls-tree -r HEAD --name-only | tree --fromfile; else echo "Not in a git repository"; fi'
 alias gha-fails='get-latest-failed-gha-logs.sh'
 
 # Tmux config comparison aliases - toggle between branches like at the optometrist
-alias tmux-main="git checkout main && tmux source-file ~/.tmux.conf && echo 'Switched to main branch config'"
-alias tmux-pr="git checkout - && tmux source-file ~/.tmux.conf && echo 'Switched to branch: $(git branch --show-current)'"
+alias tmux-main="cd ~/dotfiles && git checkout main && tmux source-file ~/.tmux.conf && echo 'Switched to main branch config'"
+alias tmux-pr="cd ~/dotfiles && git checkout - && tmux source-file ~/.tmux.conf && echo 'Switched to branch: $(git branch --show-current)'"
 
 # Tmux cheatsheet quick access
 alias tmux-help="less ~/dotfiles/tmux-cheatsheet.md"

--- a/.bashrc
+++ b/.bashrc
@@ -133,10 +133,8 @@ if ! shopt -oq posix; then
 fi
 # Git branch in prompt
 parse_git_branch() {
-  # Only run git commands if we're in a git repository
-  if git rev-parse --is-inside-work-tree &>/dev/null; then
-    git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/ (\1)/'
-  fi
+  # Redirect stderr to /dev/null to suppress the "not a git repository" error
+  git rev-parse --is-inside-work-tree &>/dev/null 2>&1 && git branch 2>/dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/ (\1)/'
 }
 
 # Set prompt to show current directory and git branch

--- a/.bashrc
+++ b/.bashrc
@@ -133,7 +133,10 @@ if ! shopt -oq posix; then
 fi
 # Git branch in prompt
 parse_git_branch() {
-  git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/ (\1)/'
+  # Only run git commands if we're in a git repository
+  if git rev-parse --is-inside-work-tree &>/dev/null; then
+    git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/ (\1)/'
+  fi
 }
 
 # Set prompt to show current directory and git branch

--- a/bin/get-latest-failed-gha-logs.sh
+++ b/bin/get-latest-failed-gha-logs.sh
@@ -10,13 +10,20 @@ if [[ $# -eq 2 ]]; then
   echo "Repository owner: $repo_owner"
   echo "Repository name: $repo_name"
 elif [[ $# -eq 0 ]]; then
-  # Get the repository owner and name from the origin remote
-  remote_url=$(git remote get-url origin)
-  repo_owner=$(echo "$remote_url" | sed -E 's#.*github.com[:/]([^/]+)/.*#\1#')
-  repo_name=$(echo "$remote_url" | sed -E 's#.*github.com[:/].*/([^/]+).*#\1#' | sed 's/\.git$//') # Remove .git
-  # Log the repository information
-  echo "Repository owner: $repo_owner"
-  echo "Repository name: $repo_name"
+  # Check if we're in a git repository first
+  if git rev-parse --is-inside-work-tree &>/dev/null; then
+    # Get the repository owner and name from the origin remote
+    remote_url=$(git remote get-url origin)
+    repo_owner=$(echo "$remote_url" | sed -E 's#.*github.com[:/]([^/]+)/.*#\1#')
+    repo_name=$(echo "$remote_url" | sed -E 's#.*github.com[:/].*/([^/]+).*#\1#' | sed 's/\.git$//') # Remove .git
+    # Log the repository information
+    echo "Repository owner: $repo_owner"
+    echo "Repository name: $repo_name"
+  else
+    echo "Error: Not in a git repository. Please provide owner and repo name."
+    echo "Usage: $0 [owner] [repo]"
+    exit 1
+  fi
 else
   echo "Usage: $0 [owner] [repo]"
   echo "Or run in a git repository to use the origin remote."

--- a/bin/linusfiles.sh
+++ b/bin/linusfiles.sh
@@ -1,11 +1,15 @@
 alias linusfiles=\"function _linusfiles() {
-    echo \"Listing files tracked by git and copying contents to clipboard, approved by Linus Torvalds himself!\";
-    git ls-files > /tmp/torvalds_files.txt;
-    while IFS= read -r file; do
-        echo \"File: \$file\" >> /tmp/torvalds_content.txt;
-        cat \"\$file\" >> /tmp/torvalds_content.txt;
-        echo -e \"\\n\\n\" >> /tmp/torvalds_content.txt;
-    done < /tmp/torvalds_files.txt;
-    xclip -sel clip < /tmp/torvalds_content.txt;
-    echo \"Done! The files have been copied to your clipboard.\";
+    if git rev-parse --is-inside-work-tree &>/dev/null; then
+        echo \"Listing files tracked by git and copying contents to clipboard, approved by Linus Torvalds himself!\";
+        git ls-files > /tmp/torvalds_files.txt;
+        while IFS= read -r file; do
+            echo \"File: \$file\" >> /tmp/torvalds_content.txt;
+            cat \"\$file\" >> /tmp/torvalds_content.txt;
+            echo -e \"\\n\\n\" >> /tmp/torvalds_content.txt;
+        done < /tmp/torvalds_files.txt;
+        xclip -sel clip < /tmp/torvalds_content.txt;
+        echo \"Done! The files have been copied to your clipboard.\";
+    else
+        echo \"Error: Not in a git repository.\";
+    fi
 }; _linusfiles\"


### PR DESCRIPTION
This PR fixes additional sources of git errors when opening a new terminal in a non-git directory.

Changes:
1. Modified the Starting script to get latest failed workflow logs...
Repository owner: atxtechbro
Repository name: dotfiles
Latest workflow run ID: 14228083716
Workflow run conclusion: success
The latest workflow run was successful.
Script finished. script to check if in a git repository before running git commands
2. Updated the  script to check if in a git repository before running git commands

These changes, along with the previous PRs, should eliminate all 'fatal: not a git repository' errors when opening a new terminal.