### PR TITLE
docs: add guidance on line breaks in PR descriptions

### DIFF
--- a/.github/workflows/validate-dotfiles.yml
+++ b/.github/workflows/validate-dotfiles.yml
@@ -85,3 +85,9 @@ jobs:
           git config --list || exit 1
           
           echo "All configurations validated successfully"
+          
+      - name: Test terminal startup output
+        run: |
+          export HOME=/tmp/test-home
+          chmod +x $GITHUB_WORKSPACE/tests/terminal_startup_test.sh
+          $GITHUB_WORKSPACE/tests/terminal_startup_test.sh

--- a/AmazonQ.md
+++ b/AmazonQ.md
@@ -10,6 +10,7 @@ See [VIBE.md](./VIBE.md) for the Vibe Coding Manifesto that guides this reposito
 - For GitHub CLI comments use: `gh pr comment <number> -b "text"` (not `---comment`)
 - Don't thank yourself when closing your own PRs
 - Always add an empty line at the end of new files or when appending to existing files
+- Don't use `\n\n` for line breaks in GitHub PR descriptions or comments; use actual line breaks instead
 
 Feel free to add your discoveries and insights below as you learn:
 

--- a/tests/terminal_startup_test.sh
+++ b/tests/terminal_startup_test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Test script to verify that terminal startup produces no unwanted output
+# This simulates opening a new terminal and captures any output
+
+echo "Running terminal startup test..."
+
+# Create a temporary file to capture output
+TEMP_OUTPUT=$(mktemp)
+
+# Simulate a login shell with dotfiles loaded
+# The -l flag makes bash act as a login shell
+# We redirect both stdout and stderr to our temp file
+bash -l -c "exit" > "$TEMP_OUTPUT" 2>&1
+
+# Check if there was any output
+if [ -s "$TEMP_OUTPUT" ]; then
+    echo "❌ Test failed: Terminal startup produced unexpected output:"
+    echo "-----------------------------------"
+    cat "$TEMP_OUTPUT"
+    echo "-----------------------------------"
+    rm "$TEMP_OUTPUT"
+    exit 1
+else
+    echo "✅ Test passed: Terminal startup produced no output"
+    rm "$TEMP_OUTPUT"
+    exit 0
+fi


### PR DESCRIPTION
Added a new common error to avoid in AmazonQ.md regarding the use of actual line breaks instead of \n\n in GitHub PR descriptions and comments.