### PR TITLE
ci: add dedicated terminal startup test workflow

### DIFF
--- a/.github/workflows/terminal-startup-test.yml
+++ b/.github/workflows/terminal-startup-test.yml
@@ -1,0 +1,63 @@
+name: Terminal Startup Test
+
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - '.gitignore'
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - '.gitignore'
+  # Run monthly to ensure continued compatibility
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  test-terminal-startup:
+    name: Test Terminal Startup
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        
+      - name: Setup test environment
+        run: |
+          # Create a fake home directory for testing
+          mkdir -p /tmp/test-home
+          export HOME=/tmp/test-home
+          
+          # Setup dotfiles
+          ln -sf $GITHUB_WORKSPACE /tmp/test-home/dotfiles
+
+      - name: Install minimal essential packages
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends git bash
+          
+      - name: Setup dotfiles
+        run: |
+          export HOME=/tmp/test-home
+          
+          # Create required directories
+          mkdir -p $HOME/.config/nvim
+          
+          # Create symlinks (only the critical ones to save time)
+          ln -sf $HOME/dotfiles/nvim/init.lua $HOME/.config/nvim/init.lua
+          ln -sf $HOME/dotfiles/.bashrc $HOME/.bashrc
+          ln -sf $HOME/dotfiles/.bash_aliases $HOME/.bash_aliases
+          ln -sf $HOME/dotfiles/.bash_exports $HOME/.bash_exports
+          ln -sf $HOME/dotfiles/.gitconfig $HOME/.gitconfig
+          ln -sf $HOME/dotfiles/.tmux.conf $HOME/.tmux.conf
+
+      - name: Run terminal startup test
+        run: |
+          export HOME=/tmp/test-home
+          chmod +x $GITHUB_WORKSPACE/tests/terminal_startup_test.sh
+          $GITHUB_WORKSPACE/tests/terminal_startup_test.sh

--- a/.github/workflows/validate-dotfiles.yml
+++ b/.github/workflows/validate-dotfiles.yml
@@ -85,3 +85,9 @@ jobs:
           git config --list || exit 1
           
           echo "All configurations validated successfully"
+          
+      - name: Test terminal startup output
+        run: |
+          export HOME=/tmp/test-home
+          chmod +x $GITHUB_WORKSPACE/tests/terminal_startup_test.sh
+          $GITHUB_WORKSPACE/tests/terminal_startup_test.sh

--- a/AmazonQ.md
+++ b/AmazonQ.md
@@ -10,6 +10,7 @@ See [VIBE.md](./VIBE.md) for the Vibe Coding Manifesto that guides this reposito
 - For GitHub CLI comments use: `gh pr comment <number> -b "text"` (not `---comment`)
 - Don't thank yourself when closing your own PRs
 - Always add an empty line at the end of new files or when appending to existing files
+- Don't use `\n\n` for line breaks in GitHub PR descriptions or comments; use actual line breaks instead
 
 Feel free to add your discoveries and insights below as you learn:
 

--- a/tests/terminal_startup_test.sh
+++ b/tests/terminal_startup_test.sh
@@ -7,10 +7,22 @@ echo "Running terminal startup test..."
 # Create a temporary file to capture output
 TEMP_OUTPUT=$(mktemp)
 
+# Create a non-git directory to test in
+TEST_DIR=$(mktemp -d)
+cd "$TEST_DIR"
+
+# Verify we're not in a git repository
+if git rev-parse --is-inside-work-tree &>/dev/null; then
+    echo "Error: Test directory is unexpectedly a git repository"
+    rm -rf "$TEST_DIR"
+    exit 1
+fi
+
 # Simulate a login shell with dotfiles loaded
 # The -l flag makes bash act as a login shell
 # We redirect both stdout and stderr to our temp file
-bash -l -c "exit" > "$TEMP_OUTPUT" 2>&1
+# The --norc flag ensures we don't use any local .bashrc that might override our dotfiles
+bash --norc -l -c "cd $TEST_DIR && source ~/.bashrc && exit" > "$TEMP_OUTPUT" 2>&1
 
 # Check if there was any output
 if [ -s "$TEMP_OUTPUT" ]; then
@@ -19,9 +31,11 @@ if [ -s "$TEMP_OUTPUT" ]; then
     cat "$TEMP_OUTPUT"
     echo "-----------------------------------"
     rm "$TEMP_OUTPUT"
+    rm -rf "$TEST_DIR"
     exit 1
 else
     echo "✅ Test passed: Terminal startup produced no output"
     rm "$TEMP_OUTPUT"
+    rm -rf "$TEST_DIR"
     exit 0
 fi

--- a/tests/terminal_startup_test.sh
+++ b/tests/terminal_startup_test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Test script to verify that terminal startup produces no unwanted output
+# This simulates opening a new terminal and captures any output
+
+echo "Running terminal startup test..."
+
+# Create a temporary file to capture output
+TEMP_OUTPUT=$(mktemp)
+
+# Simulate a login shell with dotfiles loaded
+# The -l flag makes bash act as a login shell
+# We redirect both stdout and stderr to our temp file
+bash -l -c "exit" > "$TEMP_OUTPUT" 2>&1
+
+# Check if there was any output
+if [ -s "$TEMP_OUTPUT" ]; then
+    echo "❌ Test failed: Terminal startup produced unexpected output:"
+    echo "-----------------------------------"
+    cat "$TEMP_OUTPUT"
+    echo "-----------------------------------"
+    rm "$TEMP_OUTPUT"
+    exit 1
+else
+    echo "✅ Test passed: Terminal startup produced no output"
+    rm "$TEMP_OUTPUT"
+    exit 0
+fi


### PR DESCRIPTION
This PR adds a dedicated CI workflow for testing terminal startup output.

The test has been improved to:
1. Create a non-git directory to run the test in
2. Explicitly verify we're not in a git repository
3. Source the .bashrc file in this non-git context
4. Capture and report any unwanted output

This should catch issues like git error messages appearing on terminal startup in non-git directories.