### PR TITLE
docs: add personal alias example to bash_secrets template

### DIFF
--- a/.bash_secrets.example
+++ b/.bash_secrets.example
@@ -39,3 +39,6 @@
 
 # ==== CUSTOM ENVIRONMENT VARIABLES ====
 # Add any custom environment variables needed for your projects
+
+# ==== PERSONAL SHORTCUTS ====
+# alias cdproj="cd /path/to/your/private/project"  # Keep personal paths out of shared dotfiles


### PR DESCRIPTION
Add a simple example showing how .bash_secrets can be used for personal navigation aliases that shouldn't be in the main dotfiles repository.\n\nThis demonstrates how to keep machine-specific paths and shortcuts private while still having them automatically loaded by your shell.