### PR TITLE
refactor: simplify setup script and move package installation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The setup script will:
 - Set up your secrets file from the template
 - Apply configurations immediately
 
-That's it! Any changes you make to files in this repository will be reflected in your environment.
+The script will NOT install packages for you or make assumptions about your package manager.
 
 > **Note:** The setup script requires `git` and `curl`. Most systems have these installed by default, but if you encounter errors, see the package installation section below.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,52 @@ A collection of configuration files for a consistent development environment acr
 
 ## Quick Setup
 
-For a fully automated setup, run:
+### Step 1: Install Essential Packages
+
+First, install the essential packages for your operating system:
+
+<details>
+<summary><b>Ubuntu/Debian</b></summary>
+
+```bash
+sudo apt update
+sudo apt install -y git gh jq tmux curl wget
+```
+</details>
+
+<details>
+<summary><b>Arch Linux</b></summary>
+
+```bash
+sudo pacman -Syu
+sudo pacman -S --needed git github-cli jq tmux curl wget
+```
+</details>
+
+<details>
+<summary><b>Fedora/RHEL</b></summary>
+
+```bash
+sudo dnf update
+sudo dnf install -y git gh jq tmux curl wget
+```
+</details>
+
+<details>
+<summary><b>macOS</b></summary>
+
+```bash
+# Install Homebrew if not already installed
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+# Install essential packages
+brew install git gh jq tmux curl wget
+```
+</details>
+
+### Step 2: Set Up Dotfiles
+
+After installing the essential packages, set up your dotfiles:
 
 ```bash
 # Option 1: Run directly from GitHub
@@ -17,7 +62,6 @@ cd ~/dotfiles
 ```
 
 The setup script will:
-- Install essential packages based on your OS
 - Create all necessary symlinks
 - Set up your secrets file from the template
 - Apply configurations immediately

--- a/README.md
+++ b/README.md
@@ -4,9 +4,29 @@ A collection of configuration files for a consistent development environment acr
 
 ## Quick Setup
 
-### Step 1: Install Essential Packages
+### Set Up Your Dotfiles
 
-First, install the essential packages for your operating system:
+Get started with your personalized environment:
+
+```bash
+# Clone the repository and run setup
+git clone https://github.com/atxtechbro/dotfiles.git ~/dotfiles
+cd ~/dotfiles
+./setup.sh
+```
+
+The setup script will:
+- Create all necessary symlinks
+- Set up your secrets file from the template
+- Apply configurations immediately
+
+That's it! Any changes you make to files in this repository will be reflected in your environment.
+
+> **Note:** The setup script requires `git` and `curl`. Most systems have these installed by default, but if you encounter errors, see the package installation section below.
+
+### Recommended Packages
+
+These packages enhance your development experience but are not required for the dotfiles setup:
 
 <details>
 <summary><b>Ubuntu/Debian</b></summary>
@@ -26,7 +46,6 @@ sudo pacman -S --needed git github-cli jq tmux curl wget
 ```
 </details>
 
-
 <details>
 <summary><b>macOS</b></summary>
 
@@ -38,27 +57,6 @@ sudo pacman -S --needed git github-cli jq tmux curl wget
 brew install git gh jq tmux curl wget
 ```
 </details>
-
-### Step 2: Set Up Dotfiles
-
-After installing the essential packages, set up your dotfiles:
-
-```bash
-# Option 1: Run directly from GitHub
-curl -fsSL https://raw.githubusercontent.com/atxtechbro/dotfiles/main/setup.sh | bash
-
-# Option 2: Clone first, then run setup
-git clone https://github.com/atxtechbro/dotfiles.git ~/dotfiles
-cd ~/dotfiles
-./setup.sh
-```
-
-The setup script will:
-- Create all necessary symlinks
-- Set up your secrets file from the template
-- Apply configurations immediately
-
-That's it! Any changes you make to files in this repository will be reflected in your environment.
 
 ## Applications
 

--- a/README.md
+++ b/README.md
@@ -26,14 +26,6 @@ sudo pacman -S --needed git github-cli jq tmux curl wget
 ```
 </details>
 
-<details>
-<summary><b>Fedora/RHEL</b></summary>
-
-```bash
-sudo dnf update
-sudo dnf install -y git gh jq tmux curl wget
-```
-</details>
 
 <details>
 <summary><b>macOS</b></summary>


### PR DESCRIPTION
This PR simplifies our approach to dotfiles setup by:

- Moving package installation instructions to the README with OS-specific sections
- Simplifying the setup.sh script to focus only on configuration and symlinks
- Adding basic checks for essential tools before proceeding with setup
- Updating documentation to reflect the new two-step process

This approach provides several benefits:
1. Better separation of concerns - package management is documented, configuration is automated
2. Improved maintainability - no need to handle different package managers in code
3. More transparency for users about what's being installed
4. Easier to adapt to new environments without code changes

The PR targets feature/combined-setup as we're refining the approach before merging to main.