### PR TITLE
feat: auto-start tmux in interactive shells

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -171,5 +171,11 @@ if [ -f "$HOME/.local/bin/env" ]; then
     . "$HOME/.local/bin/env"
 fi
 
+# Auto-start tmux if not already in a tmux session and it's an interactive shell
+if [ -z "$TMUX" ] && [ "$-" = *i* ] && command -v tmux >/dev/null 2>&1; then
+    # Start a new tmux session or attach to an existing one
+    exec tmux new-session -A -s main
+fi
+
 # Amazon Q post block. Keep at the bottom of this file.
 [[ -f "${HOME}/.local/share/amazon-q/shell/bashrc.post.bash" ]] && builtin source "${HOME}/.local/share/amazon-q/shell/bashrc.post.bash"

--- a/.bashrc
+++ b/.bashrc
@@ -172,7 +172,7 @@ if [ -f "$HOME/.local/bin/env" ]; then
 fi
 
 # Auto-start tmux if not already in a tmux session and it's an interactive shell
-if [ -z "$TMUX" ] && [ "$-" = *i* ] && command -v tmux >/dev/null 2>&1; then
+if [ -z "$TMUX" ] && [[ "$-" == *i* ]] && command -v tmux >/dev/null 2>&1; then
     # Start a new tmux session or attach to an existing one
     exec tmux new-session -A -s main
 fi


### PR DESCRIPTION
This PR adds functionality to automatically start tmux when opening a new interactive shell if tmux is installed and not already running.

Benefits:
- Ensures consistent terminal environment across sessions
- Prevents the need to manually start tmux each time
- Preserves sessions between terminal restarts

The implementation:
- Checks if tmux is already running
- Verifies it's an interactive shell
- Confirms tmux is installed
- Uses 'exec tmux new-session -A -s main' to either create a new session or attach to an existing one