### PR TITLE
fix: prevent recursive SSH loop when connecting to localhost

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -161,20 +161,27 @@ DOTFILES_DIR="$HOME/dotfiles"
 # Add your scripts directory to the PATH
 export PATH="$DOTFILES_DIR/bin:$PATH"
 
-# Only change to dotfiles directory when NOT in a tmux session
-if [ -z "$TMUX" ]; then
-    cd "$DOTFILES_DIR"
-fi
+# Skip auto-tmux and directory change for SSH connections
+if [[ -n "$SSH_CONNECTION" ]]; then
+    # When connecting via SSH, don't auto-change directory or start tmux
+    # This prevents recursive loops when connecting to localhost
+    :
+else
+    # Only change to dotfiles directory when NOT in a tmux session
+    if [ -z "$TMUX" ]; then
+        cd "$DOTFILES_DIR"
+    fi
 
-# Source Amazon Q environment if installed
-if [ -f "$HOME/.local/bin/env" ]; then
-    . "$HOME/.local/bin/env"
-fi
+    # Source Amazon Q environment if installed
+    if [ -f "$HOME/.local/bin/env" ]; then
+        . "$HOME/.local/bin/env"
+    fi
 
-# Auto-start tmux if not already in a tmux session and it's an interactive shell
-if [ -z "$TMUX" ] && [[ "$-" == *i* ]] && command -v tmux >/dev/null 2>&1; then
-    # Start a new tmux session or attach to an existing one
-    exec tmux new-session -A -s main
+    # Auto-start tmux if not already in a tmux session and it's an interactive shell
+    if [ -z "$TMUX" ] && [[ "$-" == *i* ]] && command -v tmux >/dev/null 2>&1; then
+        # Start a new tmux session or attach to an existing one
+        exec tmux new-session -A -s main
+    fi
 fi
 
 # Amazon Q post block. Keep at the bottom of this file.


### PR DESCRIPTION
## Issue

When running `ssh localhost`, the terminal enters a recursive loop that makes the system unusable.

## Root Cause

The auto-changing directory and auto-starting tmux features in `.bashrc` create an infinite loop when connecting via SSH:
1. SSH loads `.bashrc` as interactive shell
2. Script changes directory to dotfiles
3. Script executes tmux
4. New tmux shell loads `.bashrc` again
5. Loop repeats indefinitely

## Fix

Added a guard clause to skip these features during SSH connections:

```bash
# Skip auto-tmux and directory change for SSH connections
if [[ -n "" ]]; then
    # When connecting via SSH, don't auto-change directory or start tmux
    :
else
    # Rest of the auto-directory and auto-tmux code
    ...
fi
```

This fix prevents the recursive loop while maintaining the convenience features for normal terminal sessions.