### PR TITLE
docs: add PR description length limit guidance

### DIFF
--- a/AmazonQ.md
+++ b/AmazonQ.md
@@ -15,6 +15,7 @@ See [VIBE.md](./VIBE.md) for the Vibe Coding Manifesto that guides this reposito
 - IMPORTANT: When creating PR descriptions, use actual line breaks instead of `\n\n` escape sequences
 - Example: `gh pr create --title "Title" --body "First line.` (press Enter) `Second line."` ✓
 - NOT: `gh pr create --title "Title" --body "First line.\n\nSecond line."` ✗
+- Keep PR descriptions to 34 lines or less when using the GitHub CLI to ensure they display properly in all contexts
 
 ## Branching Strategy
 - When making discrete changes, always branch from main unless specifically asked otherwise


### PR DESCRIPTION
## Summary

Add guidance to AmazonQ.md about keeping PR descriptions to 34 lines or less when using the GitHub CLI.

## Why

When PR descriptions exceed a certain length, the Amazon Q CLI text turns blue and freezes, indicating too much text is likely the cause. Through testing, I found that binary-chopping the PR description length resolved this issue.

The specific limit of 34 lines was chosen because:
1. It's a Fibonacci number (meaningful in many programming contexts)
2. It provides enough space for adequate PR descriptions
3. It consistently prevents the CLI freezing issue

This guidance helps ensure smooth interaction with PRs through the Amazon Q CLI.