### PR TITLE
docs: update GitHub issues formatting guidance

### DIFF
--- a/AmazonQ.md
+++ b/AmazonQ.md
@@ -17,6 +17,18 @@ See [VIBE.md](./VIBE.md) for the Vibe Coding Manifesto that guides this reposito
 - NOT: `gh pr create --title "Title" --body "First line.\n\nSecond line."` ✗
 - Keep PR descriptions to 34 lines or less when using the GitHub CLI to ensure they display properly in all contexts
 
+## GitHub Issues Formatting
+- Same rule applies for GitHub issues - use actual line breaks, not escape sequences
+- Example: `gh issue create --title "Title" --body "First line.` (press Enter) `Second line."` ✓
+- NOT: `gh issue create --title "Title" --body "First line.\n\nSecond line."` ✗
+- Keep issue descriptions to 21 lines or less (or use Fibonacci numbers: 1, 2, 3, 5, 8, 13, 21)
+- Prefer concise issues with less context over verbose ones
+- Treat GitHub issues as discussion points and suggestions, not strict mandates
+
+## Quick AmazonQ.md Updates
+- For quick updates to this file, use the standardized branch name: `docs/update-amazonq-guidance`
+- Command: `git checkout main && git pull && git checkout -b docs/update-amazonq-guidance`
+
 ## Branching Strategy
 - When making discrete changes, always branch from main unless specifically asked otherwise
 - Use `git checkout main && git pull && git checkout -b type/description` to ensure clean branches


### PR DESCRIPTION
Added guidance for GitHub issues formatting:

- Added section on GitHub issues formatting
- Specified to use actual line breaks instead of escape sequences
- Added guidance to keep issue descriptions to 21 lines or less
- Suggested using Fibonacci numbers for issue length (1, 2, 3, 5, 8, 13, 21)
- Clarified that issues are discussion points and suggestions
- Added section for quick AmazonQ.md updates with standardized branch name

This PR addresses recurring issues with escape sequences in issue descriptions and provides clearer guidance on issue formatting.