### PR TITLE
fix: remove duplicate gitsigns.nvim definition

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -45,8 +45,6 @@ require('packer').startup(function(use)
     requires = {{'nvim-lua/plenary.nvim'}}
   }
   -- Git integration with blame support
-  use 'lewis6991/gitsigns.nvim'
-  -- Git integration with blame support
   use {
     'lewis6991/gitsigns.nvim',
     requires = {'nvim-lua/plenary.nvim'}


### PR DESCRIPTION
This PR fixes an issue with the Neovim configuration where gitsigns.nvim was defined twice in the plugin list.

The duplicate definition was causing Packer to behave inconsistently, which could lead to the plugin not being properly installed or loaded.

This change:
- Removes the standalone definition of gitsigns.nvim
- Keeps the more complete definition with proper dependencies

This should resolve issues with git integration in Neovim.