### PR TITLE
fix: change tmux auto-start to use unique session names

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -177,10 +177,11 @@ else
         . "$HOME/.local/bin/env"
     fi
 
-    # Auto-start tmux if not already in a tmux session and it's an interactive shell
+    # Auto-start tmux with a unique session name based on timestamp
     if [ -z "$TMUX" ] && [[ "$-" == *i* ]] && command -v tmux >/dev/null 2>&1; then
-        # Start a new tmux session or attach to an existing one
-        exec tmux new-session -A -s main
+        # Create a new session with a unique name (terminal-TIMESTAMP)
+        SESSION_NAME="terminal-$(date +%s)"
+        exec tmux new-session -s "$SESSION_NAME"
     fi
 fi
 


### PR DESCRIPTION
This PR fixes an issue where all new terminal windows would automatically attach to the same tmux session named 'main'.

The fix:
- Changes tmux auto-start to create a unique session name for each terminal using timestamps
- Removes the -A flag to ensure new terminals create fresh sessions rather than attaching to existing ones
- Updates comments to better explain the behavior

This allows for true dual-screen workflows where each terminal window can have its own independent tmux session.