### PR TITLE
feat: add git push.autoSetupRemote configuration

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -5,6 +5,8 @@
 	editor = nvim
 [init]
 	defaultBranch = main
+[push]
+	autoSetupRemote = true
 [includeIf "gitdir:/mnt/c/Sertifi/"]
 	path=C:/mnt/c/Sertifi/.gitconfig-work
 [includeIf "gitdir:C/Sertifi/"]


### PR DESCRIPTION
Adds git configuration to automatically set up remote tracking branches when pushing.

This eliminates the need to use 'git push --set-upstream origin branch-name' when pushing a new branch for the first time.

Now you can simply use 'git push' for new branches and tracking will be set up automatically.