### PR TITLE
feat: add 'prv' alias for quickly viewing PR metadata

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -7,6 +7,9 @@ alias gha-fails='get-latest-failed-gha-logs.sh'
 # Source bashrc quickly with a short alias
 alias src='source ~/.bashrc'
 
+# GitHub PR metadata quick view
+alias prv='gh pr view --json number,title,state,url,author,createdAt,updatedAt,mergeable,reviewDecision --jq '"'"'.{number,title,state,url,author:.author.login,created:.createdAt,updated:.updatedAt,mergeable,reviewDecision}'"'"''
+
 # Tmux config comparison aliases - toggle between branches like at the optometrist
 alias tmux-main="git checkout main && tmux source-file ~/.tmux.conf && echo 'Switched to main branch config'"
 alias tmux-pr="git checkout - && tmux source-file ~/.tmux.conf && echo 'Switched to branch: $(git branch --show-current)'"


### PR DESCRIPTION
Added a 'prv' alias that displays key PR metadata in a clean format using GitHub CLI.

This alias shows the most important PR information at a glance:
- PR number and title
- Current state (open, merged, closed)
- PR URL
- Author
- Creation and update timestamps
- Mergeability status
- Review decision

Usage:
- Without arguments: Shows PR for current branch
- With PR number: 
- With URL: 