### PR TITLE
feat: add venv alias for quick virtual environment activation

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -21,3 +21,6 @@ alias tmux-pr="git checkout - && tmux source-file ~/.tmux.conf && echo 'Switched
 # Tmux cheatsheet quick access
 alias tmux-help="less ~/dotfiles/tmux-cheatsheet.md"
 
+# Python virtual environment shortcuts
+alias venv='source .venv/bin/activate'
+


### PR DESCRIPTION
Adds a convenient 'venv' alias to quickly activate Python virtual environments with the command 'venv' instead of typing 'source .venv/bin/activate' each time.

This makes working with Python projects more efficient by reducing keystrokes for a common operation.