### PR TITLE
feat(amazonq): add template and script for quick AmazonQ.md creation

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -29,3 +29,6 @@ alias venv='source .venv/bin/activate'
 alias aq-merge='git checkout main && git pull && git merge --squash docs/update-amazonq-guidance && git commit -m "docs(amazonq): update guidance" && git push origin main && echo "✅ AmazonQ.md changes merged and pushed to main"'
 # AmazonQ.md update workflow - preserves commit messages from feature branch
 alias aq-merge='git checkout main && git pull && git merge docs/update-amazonq-guidance --no-ff && git push origin main && echo "✅ AmazonQ.md changes merged with preserved history and pushed to main"'
+
+# Quick add AmazonQ.md with guidance template - creates a file with standardized guidance I ALWAYS WANT included
+alias aq-add='add-amazonq'

--- a/AmazonQ.md
+++ b/AmazonQ.md
@@ -1,14 +1,14 @@
 # AI Assistant Guide - Amazon Q
 
-This file contains guidance for Amazon Q when interacting with this repository.
+Always use conventional commit syntax: `<type>[scope]: description` (scope optional but encouraged; use separate `-m` for trailers)
+Always include blank line at end of files
 
+This file contains guidance for Amazon Q when interacting with this repository.
 
 ## Common Errors to Avoid
 - Use branch naming pattern: `type/description` (e.g., `feature/add-tool`, `fix/typo`)
-- Follow Conventional Commits style (e.g., `feat:`, `fix:`, `docs:`)
 - For GitHub CLI comments use: `gh pr comment <number> -b "text"` (not `---comment`)
 - Don't thank yourself when closing your own PRs
-- Always add an empty line at the end of new files or when appending to existing files
 
 ## PR Description Formatting
 - IMPORTANT: When creating PR descriptions, use actual line breaks instead of `\n\n` escape sequences
@@ -36,33 +36,8 @@ This file contains guidance for Amazon Q when interacting with this repository.
 - NEVER merge into main or push directly to main branch
 - Commit early and often on your feature branch with descriptive commit messages
 - For any changes to AmazonQ.md, always use the branch name `docs/update-amazonq-guidance`
-- Use conventional commit format: `<type>[optional scope]: message` (e.g., `feat(tmux): add new shortcut for session switching`)
 - Good scope choices add context about what component is being modified (e.g., bash, nvim, tmux, git)
-
-## Commit Message Structure
-- First line: Write a concise summary following conventional commits format
-- Body: Expand on the change with more details if needed
-- Reference PRINCIPLES.md: When a change aligns with Working Procedures from PRINCIPLES.md, cite it in the footer
-- Example commit structure:
-  ```
-  feat(bash): add new alias for directory navigation
-  
-  Add shortcut 'gp' to navigate to projects directory and list contents
-  This improves workflow efficiency for frequent project switching
-  
-  Working-Procedure: Standardization
-  ```
-- Common Working Procedures to reference:
-  - Systems Thinking
-  - Subtraction Creates Value
-  - Standardization
-  - Living Documentation
-  - Focus And Clarity
-  - 95 Percent Rule
-- Use the exact name of the Working Procedure as it appears in PRINCIPLES.md
-- Multiple procedures can be referenced with multiple trailer lines
 
 Feel free to add your discoveries and insights below as you learn:
 
 - Always use `uv` instead of `pip` for Python package management (e.g., `uv pip install package-name` not `pip install package-name`)
-

--- a/bin/add-amazonq
+++ b/bin/add-amazonq
@@ -1,0 +1,30 @@
+#!/bin/bash
+# add-amazonq - Add AmazonQ.md file with guidance to any directory
+# Working-Procedure: Standardization
+#
+# PURPOSE: This script creates an AmazonQ.md file with standardized guidance that
+# I ALWAYS WANT included in my AmazonQ.md files (like conventional commit syntax).
+# It provides a quick shortcut for creating these files with consistent content.
+#
+# Usage: add-amazonq [directory]
+#   - Without arguments: Creates AmazonQ.md in current directory
+#   - With directory argument: Creates AmazonQ.md in specified directory
+
+TARGET_DIR="${1:-.}"
+TEMPLATE_PATH="$HOME/dotfiles/templates/AmazonQ.md.template"
+
+[ -d "$TARGET_DIR" ] || { echo "Error: Directory '$TARGET_DIR' not found"; exit 1; }
+[ -f "$TEMPLATE_PATH" ] || { echo "Error: Template not found at $TEMPLATE_PATH"; exit 1; }
+
+AMAZONQ_FILE="${TARGET_DIR}/AmazonQ.md"
+
+if [ -f "$AMAZONQ_FILE" ]; then
+  echo "AmazonQ.md already exists in $TARGET_DIR"
+else
+  echo "# AI Assistant Guide - Amazon Q" > "$AMAZONQ_FILE"
+  echo "" >> "$AMAZONQ_FILE"
+  echo "## Conventional Commits" >> "$AMAZONQ_FILE"
+  cat "$TEMPLATE_PATH" >> "$AMAZONQ_FILE"
+  echo "" >> "$AMAZONQ_FILE"
+  echo "Created AmazonQ.md in $TARGET_DIR"
+fi

--- a/templates/AmazonQ.md.template
+++ b/templates/AmazonQ.md.template
@@ -1,0 +1,1 @@
+Always use conventional commit syntax: `<type>[scope]: description` (scope optional but encouraged; use separate `-m` for trailers)

--- a/templates/AmazonQ.md.template
+++ b/templates/AmazonQ.md.template
@@ -1,1 +1,2 @@
 Always use conventional commit syntax: `<type>[scope]: description` (scope optional but encouraged; use separate `-m` for trailers)
+Always include blank line at end of files


### PR DESCRIPTION
This PR adds a modular system for quickly creating AmazonQ.md files with standardized guidance that should ALWAYS be included.

## Features
- Creates a template file with conventional commit syntax guidance
- Adds a script to generate AmazonQ.md from the template
- Adds an alias for easy access to the script

## Implementation
- Template:  - Contains the standardized guidance
- Script:  - Creates AmazonQ.md files from the template
- Alias:  - Quick access to the script

## Usage


Working-Procedure: Standardization