### PR TITLE
fix(bash): add sudo to aq-add alias to fix permission denied error

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -31,4 +31,4 @@ alias aq-merge='git checkout main && git pull && git merge --squash docs/update-
 alias aq-merge='git checkout main && git pull && git merge docs/update-amazonq-guidance --no-ff && git push origin main && echo "✅ AmazonQ.md changes merged with preserved history and pushed to main"'
 
 # Quick add AmazonQ.md with guidance template - creates a file with standardized guidance I ALWAYS WANT included
-alias aq-add='add-amazonq'
+alias aq-add='sudo add-amazonq'


### PR DESCRIPTION
This PR fixes the permission denied error when using the aq-add alias by adding sudo to the command.

The issue occurs because the add-amazonq script needs elevated permissions to create files in certain directories.

Changes:
- Modified .bash_aliases to use 'sudo add-amazonq' instead of just 'add-amazonq'

This ensures the script can write files regardless of directory permissions.