### PR TITLE
Update setup script to use Pillars directory structure

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -130,8 +130,6 @@ if grep -q "Raspberry Pi" /proc/cpuinfo 2>/dev/null; then
         echo -e "${YELLOW}No Raspberry Pi setup script found. Skipping Pi-specific setup.${NC}"
     fi
 fi
-    fi
-fi
 
 echo -e "${GREEN}Dotfiles setup complete!${NC}"
 echo -e "${YELLOW}Your development environment is now configured and ready to use.${NC}"

--- a/setup.sh
+++ b/setup.sh
@@ -69,13 +69,13 @@ if [[ "$IS_WSL" == true ]]; then
 fi
 
 # Clone dotfiles repository if it doesn't exist and we're not in WSL
-if [[ ! -d ~/dotfiles && "$IS_WSL" == false ]]; then
+if [[ ! -d ~/Pillars/dotfiles && "$IS_WSL" == false ]]; then
     echo -e "${YELLOW}Cloning dotfiles repository...${NC}"
-    git clone https://github.com/atxtechbro/dotfiles.git ~/dotfiles
+    git clone https://github.com/atxtechbro/dotfiles.git ~/Pillars/dotfiles
     echo -e "${GREEN}Dotfiles repository cloned successfully!${NC}"
-elif [[ -d ~/dotfiles ]]; then
+elif [[ -d ~/Pillars/dotfiles ]]; then
     echo -e "${BLUE}Dotfiles repository already exists, updating...${NC}"
-    cd ~/dotfiles
+    cd ~/Pillars/dotfiles
     git pull
 fi
 
@@ -85,17 +85,17 @@ mkdir -p ~/.config/nvim
 
 # Create symlinks
 echo -e "${YELLOW}Creating symlinks for configuration files...${NC}"
-ln -sf ~/dotfiles/nvim/init.lua ~/.config/nvim/init.lua
-ln -sf ~/dotfiles/.bashrc ~/.bashrc
-ln -sf ~/dotfiles/.bash_aliases ~/.bash_aliases
-ln -sf ~/dotfiles/.bash_exports ~/.bash_exports
-ln -sf ~/dotfiles/.gitconfig ~/.gitconfig
-ln -sf ~/dotfiles/.tmux.conf ~/.tmux.conf
+ln -sf ~/Pillars/dotfiles/nvim/init.lua ~/.config/nvim/init.lua
+ln -sf ~/Pillars/dotfiles/.bashrc ~/.bashrc
+ln -sf ~/Pillars/dotfiles/.bash_aliases ~/.bash_aliases
+ln -sf ~/Pillars/dotfiles/.bash_exports ~/.bash_exports
+ln -sf ~/Pillars/dotfiles/.gitconfig ~/.gitconfig
+ln -sf ~/Pillars/dotfiles/.tmux.conf ~/.tmux.conf
 
 # Create secrets file from template
-if [[ -f ~/dotfiles/.bash_secrets.example && ! -f ~/.bash_secrets ]]; then
+if [[ -f ~/Pillars/dotfiles/.bash_secrets.example && ! -f ~/.bash_secrets ]]; then
     echo -e "${YELLOW}Creating secrets file from template...${NC}"
-    cp ~/dotfiles/.bash_secrets.example ~/.bash_secrets
+    cp ~/Pillars/dotfiles/.bash_secrets.example ~/.bash_secrets
     chmod 600 ~/.bash_secrets
     echo -e "${BLUE}Created ~/.bash_secrets from template. Edit it to add your secrets.${NC}"
 fi
@@ -110,9 +110,9 @@ if command -v pacman &>/dev/null; then
     echo -e "${YELLOW}Detected Arch Linux!${NC}"
     
     # Check if Arch Linux setup script exists
-    if [[ -f ~/dotfiles/arch-linux/setup.sh ]]; then
+    if [[ -f ~/Pillars/dotfiles/arch-linux/setup.sh ]]; then
         echo -e "${YELLOW}Running Arch Linux specific setup...${NC}"
-        bash ~/dotfiles/arch-linux/setup.sh
+        bash ~/Pillars/dotfiles/arch-linux/setup.sh
     else
         echo -e "${YELLOW}No Arch Linux setup script found. Skipping Arch-specific setup.${NC}"
     fi
@@ -123,9 +123,9 @@ if grep -q "Raspberry Pi" /proc/cpuinfo 2>/dev/null; then
     echo -e "${YELLOW}Detected Raspberry Pi hardware!${NC}"
     
     # Check if Raspberry Pi setup script exists
-    if [[ -f ~/dotfiles/raspberry-pi/setup.sh ]]; then
+    if [[ -f ~/Pillars/dotfiles/raspberry-pi/setup.sh ]]; then
         echo -e "${YELLOW}Running Raspberry Pi specific setup...${NC}"
-        bash ~/dotfiles/raspberry-pi/setup.sh
+        bash ~/Pillars/dotfiles/raspberry-pi/setup.sh
     else
         echo -e "${YELLOW}No Raspberry Pi setup script found. Skipping Pi-specific setup.${NC}"
     fi


### PR DESCRIPTION
This PR updates the setup script to use the Pillars directory structure as part of the P.P.V system implementation. All paths have been updated to use ~/Pillars/dotfiles instead of ~/dotfiles.

Changes:
- Updated repository clone location to ~/Pillars/dotfiles
- Updated all symlink paths to point to ~/Pillars/dotfiles
- Updated all file paths in the script to use ~/Pillars/dotfiles