### PR TITLE
Refactor: Use DOTFILES_PATH variable for DRY principle

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -130,8 +130,6 @@ if grep -q "Raspberry Pi" /proc/cpuinfo 2>/dev/null; then
         echo -e "${YELLOW}No Raspberry Pi setup script found. Skipping Pi-specific setup.${NC}"
     fi
 fi
-    fi
-fi
 
 echo -e "${GREEN}Dotfiles setup complete!${NC}"
 echo -e "${YELLOW}Your development environment is now configured and ready to use.${NC}"

--- a/setup.sh
+++ b/setup.sh
@@ -11,7 +11,6 @@ BLUE='\033[0;34m'
 RED='\033[0;31m'
 NC='\033[0m' # No Color
 
-# Define dotfiles path - CHANGE THIS ONE VARIABLE to update all paths
 DOT_DEN="$HOME/Pillars/dotfiles"
 
 echo -e "${GREEN}Starting dotfiles setup...${NC}"

--- a/setup.sh
+++ b/setup.sh
@@ -12,7 +12,7 @@ RED='\033[0;31m'
 NC='\033[0m' # No Color
 
 # Define dotfiles path - CHANGE THIS ONE VARIABLE to update all paths
-DOTFILES_PATH="$HOME/Pillars/dotfiles"
+DOT_DEN="$HOME/Pillars/dotfiles"
 
 echo -e "${GREEN}Starting dotfiles setup...${NC}"
 
@@ -67,19 +67,19 @@ if [[ "$IS_WSL" == true ]]; then
     echo -e "${YELLOW}Setting up WSL-specific configuration...${NC}"
     if [[ -d "/mnt/c/dotfiles" ]]; then
         echo -e "${BLUE}Found dotfiles in Windows filesystem, creating symlink...${NC}"
-        ln -sf /mnt/c/dotfiles "$DOTFILES_PATH"
+        ln -sf /mnt/c/dotfiles "$DOT_DEN"
     fi
 fi
 
 # Clone dotfiles repository if it doesn't exist and we're not in WSL
-if [[ ! -d "$DOTFILES_PATH" && "$IS_WSL" == false ]]; then
+if [[ ! -d "$DOT_DEN" && "$IS_WSL" == false ]]; then
     echo -e "${YELLOW}Cloning dotfiles repository...${NC}"
-    mkdir -p "$(dirname "$DOTFILES_PATH")"
-    git clone https://github.com/atxtechbro/dotfiles.git "$DOTFILES_PATH"
+    mkdir -p "$(dirname "$DOT_DEN")"
+    git clone https://github.com/atxtechbro/dotfiles.git "$DOT_DEN"
     echo -e "${GREEN}Dotfiles repository cloned successfully!${NC}"
-elif [[ -d "$DOTFILES_PATH" ]]; then
+elif [[ -d "$DOT_DEN" ]]; then
     echo -e "${BLUE}Dotfiles repository already exists, updating...${NC}"
-    cd "$DOTFILES_PATH"
+    cd "$DOT_DEN"
     git pull
 fi
 
@@ -89,17 +89,17 @@ mkdir -p ~/.config/nvim
 
 # Create symlinks
 echo -e "${YELLOW}Creating symlinks for configuration files...${NC}"
-ln -sf "$DOTFILES_PATH/nvim/init.lua" ~/.config/nvim/init.lua
-ln -sf "$DOTFILES_PATH/.bashrc" ~/.bashrc
-ln -sf "$DOTFILES_PATH/.bash_aliases" ~/.bash_aliases
-ln -sf "$DOTFILES_PATH/.bash_exports" ~/.bash_exports
-ln -sf "$DOTFILES_PATH/.gitconfig" ~/.gitconfig
-ln -sf "$DOTFILES_PATH/.tmux.conf" ~/.tmux.conf
+ln -sf "$DOT_DEN/nvim/init.lua" ~/.config/nvim/init.lua
+ln -sf "$DOT_DEN/.bashrc" ~/.bashrc
+ln -sf "$DOT_DEN/.bash_aliases" ~/.bash_aliases
+ln -sf "$DOT_DEN/.bash_exports" ~/.bash_exports
+ln -sf "$DOT_DEN/.gitconfig" ~/.gitconfig
+ln -sf "$DOT_DEN/.tmux.conf" ~/.tmux.conf
 
 # Create secrets file from template
-if [[ -f "$DOTFILES_PATH/.bash_secrets.example" && ! -f ~/.bash_secrets ]]; then
+if [[ -f "$DOT_DEN/.bash_secrets.example" && ! -f ~/.bash_secrets ]]; then
     echo -e "${YELLOW}Creating secrets file from template...${NC}"
-    cp "$DOTFILES_PATH/.bash_secrets.example" ~/.bash_secrets
+    cp "$DOT_DEN/.bash_secrets.example" ~/.bash_secrets
     chmod 600 ~/.bash_secrets
     echo -e "${BLUE}Created ~/.bash_secrets from template. Edit it to add your secrets.${NC}"
 fi
@@ -114,9 +114,9 @@ if command -v pacman &>/dev/null; then
     echo -e "${YELLOW}Detected Arch Linux!${NC}"
     
     # Check if Arch Linux setup script exists
-    if [[ -f "$DOTFILES_PATH/arch-linux/setup.sh" ]]; then
+    if [[ -f "$DOT_DEN/arch-linux/setup.sh" ]]; then
         echo -e "${YELLOW}Running Arch Linux specific setup...${NC}"
-        bash "$DOTFILES_PATH/arch-linux/setup.sh"
+        bash "$DOT_DEN/arch-linux/setup.sh"
     else
         echo -e "${YELLOW}No Arch Linux setup script found. Skipping Arch-specific setup.${NC}"
     fi
@@ -127,9 +127,9 @@ if grep -q "Raspberry Pi" /proc/cpuinfo 2>/dev/null; then
     echo -e "${YELLOW}Detected Raspberry Pi hardware!${NC}"
     
     # Check if Raspberry Pi setup script exists
-    if [[ -f "$DOTFILES_PATH/raspberry-pi/setup.sh" ]]; then
+    if [[ -f "$DOT_DEN/raspberry-pi/setup.sh" ]]; then
         echo -e "${YELLOW}Running Raspberry Pi specific setup...${NC}"
-        bash "$DOTFILES_PATH/raspberry-pi/setup.sh"
+        bash "$DOT_DEN/raspberry-pi/setup.sh"
     else
         echo -e "${YELLOW}No Raspberry Pi setup script found. Skipping Pi-specific setup.${NC}"
     fi

--- a/setup.sh
+++ b/setup.sh
@@ -11,6 +11,9 @@ BLUE='\033[0;34m'
 RED='\033[0;31m'
 NC='\033[0m' # No Color
 
+# Define dotfiles path - CHANGE THIS ONE VARIABLE to update all paths
+DOTFILES_PATH="$HOME/Pillars/dotfiles"
+
 echo -e "${GREEN}Starting dotfiles setup...${NC}"
 
 # Check for essential tools
@@ -64,18 +67,19 @@ if [[ "$IS_WSL" == true ]]; then
     echo -e "${YELLOW}Setting up WSL-specific configuration...${NC}"
     if [[ -d "/mnt/c/dotfiles" ]]; then
         echo -e "${BLUE}Found dotfiles in Windows filesystem, creating symlink...${NC}"
-        ln -sf /mnt/c/dotfiles ~/dotfiles
+        ln -sf /mnt/c/dotfiles "$DOTFILES_PATH"
     fi
 fi
 
 # Clone dotfiles repository if it doesn't exist and we're not in WSL
-if [[ ! -d ~/Pillars/dotfiles && "$IS_WSL" == false ]]; then
+if [[ ! -d "$DOTFILES_PATH" && "$IS_WSL" == false ]]; then
     echo -e "${YELLOW}Cloning dotfiles repository...${NC}"
-    git clone https://github.com/atxtechbro/dotfiles.git ~/Pillars/dotfiles
+    mkdir -p "$(dirname "$DOTFILES_PATH")"
+    git clone https://github.com/atxtechbro/dotfiles.git "$DOTFILES_PATH"
     echo -e "${GREEN}Dotfiles repository cloned successfully!${NC}"
-elif [[ -d ~/Pillars/dotfiles ]]; then
+elif [[ -d "$DOTFILES_PATH" ]]; then
     echo -e "${BLUE}Dotfiles repository already exists, updating...${NC}"
-    cd ~/Pillars/dotfiles
+    cd "$DOTFILES_PATH"
     git pull
 fi
 
@@ -85,17 +89,17 @@ mkdir -p ~/.config/nvim
 
 # Create symlinks
 echo -e "${YELLOW}Creating symlinks for configuration files...${NC}"
-ln -sf ~/Pillars/dotfiles/nvim/init.lua ~/.config/nvim/init.lua
-ln -sf ~/Pillars/dotfiles/.bashrc ~/.bashrc
-ln -sf ~/Pillars/dotfiles/.bash_aliases ~/.bash_aliases
-ln -sf ~/Pillars/dotfiles/.bash_exports ~/.bash_exports
-ln -sf ~/Pillars/dotfiles/.gitconfig ~/.gitconfig
-ln -sf ~/Pillars/dotfiles/.tmux.conf ~/.tmux.conf
+ln -sf "$DOTFILES_PATH/nvim/init.lua" ~/.config/nvim/init.lua
+ln -sf "$DOTFILES_PATH/.bashrc" ~/.bashrc
+ln -sf "$DOTFILES_PATH/.bash_aliases" ~/.bash_aliases
+ln -sf "$DOTFILES_PATH/.bash_exports" ~/.bash_exports
+ln -sf "$DOTFILES_PATH/.gitconfig" ~/.gitconfig
+ln -sf "$DOTFILES_PATH/.tmux.conf" ~/.tmux.conf
 
 # Create secrets file from template
-if [[ -f ~/Pillars/dotfiles/.bash_secrets.example && ! -f ~/.bash_secrets ]]; then
+if [[ -f "$DOTFILES_PATH/.bash_secrets.example" && ! -f ~/.bash_secrets ]]; then
     echo -e "${YELLOW}Creating secrets file from template...${NC}"
-    cp ~/Pillars/dotfiles/.bash_secrets.example ~/.bash_secrets
+    cp "$DOTFILES_PATH/.bash_secrets.example" ~/.bash_secrets
     chmod 600 ~/.bash_secrets
     echo -e "${BLUE}Created ~/.bash_secrets from template. Edit it to add your secrets.${NC}"
 fi
@@ -110,9 +114,9 @@ if command -v pacman &>/dev/null; then
     echo -e "${YELLOW}Detected Arch Linux!${NC}"
     
     # Check if Arch Linux setup script exists
-    if [[ -f ~/Pillars/dotfiles/arch-linux/setup.sh ]]; then
+    if [[ -f "$DOTFILES_PATH/arch-linux/setup.sh" ]]; then
         echo -e "${YELLOW}Running Arch Linux specific setup...${NC}"
-        bash ~/Pillars/dotfiles/arch-linux/setup.sh
+        bash "$DOTFILES_PATH/arch-linux/setup.sh"
     else
         echo -e "${YELLOW}No Arch Linux setup script found. Skipping Arch-specific setup.${NC}"
     fi
@@ -123,9 +127,9 @@ if grep -q "Raspberry Pi" /proc/cpuinfo 2>/dev/null; then
     echo -e "${YELLOW}Detected Raspberry Pi hardware!${NC}"
     
     # Check if Raspberry Pi setup script exists
-    if [[ -f ~/Pillars/dotfiles/raspberry-pi/setup.sh ]]; then
+    if [[ -f "$DOTFILES_PATH/raspberry-pi/setup.sh" ]]; then
         echo -e "${YELLOW}Running Raspberry Pi specific setup...${NC}"
-        bash ~/Pillars/dotfiles/raspberry-pi/setup.sh
+        bash "$DOTFILES_PATH/raspberry-pi/setup.sh"
     else
         echo -e "${YELLOW}No Raspberry Pi setup script found. Skipping Pi-specific setup.${NC}"
     fi
@@ -186,4 +190,3 @@ if ! command -v uv >/dev/null 2>&1; then
   curl -Ls https://astral.sh/uv/install.sh | sh
   echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"
 fi
-

--- a/setup.sh
+++ b/setup.sh
@@ -69,13 +69,13 @@ if [[ "$IS_WSL" == true ]]; then
 fi
 
 # Clone dotfiles repository if it doesn't exist and we're not in WSL
-if [[ ! -d ~/dotfiles && "$IS_WSL" == false ]]; then
+if [[ ! -d ~/Pillars/dotfiles && "$IS_WSL" == false ]]; then
     echo -e "${YELLOW}Cloning dotfiles repository...${NC}"
-    git clone https://github.com/atxtechbro/dotfiles.git ~/dotfiles
+    git clone https://github.com/atxtechbro/dotfiles.git ~/Pillars/dotfiles
     echo -e "${GREEN}Dotfiles repository cloned successfully!${NC}"
-elif [[ -d ~/dotfiles ]]; then
+elif [[ -d ~/Pillars/dotfiles ]]; then
     echo -e "${BLUE}Dotfiles repository already exists, updating...${NC}"
-    cd ~/dotfiles
+    cd ~/Pillars/dotfiles
     git pull
 fi
 
@@ -85,17 +85,17 @@ mkdir -p ~/.config/nvim
 
 # Create symlinks
 echo -e "${YELLOW}Creating symlinks for configuration files...${NC}"
-ln -sf ~/dotfiles/nvim/init.lua ~/.config/nvim/init.lua
-ln -sf ~/dotfiles/.bashrc ~/.bashrc
-ln -sf ~/dotfiles/.bash_aliases ~/.bash_aliases
-ln -sf ~/dotfiles/.bash_exports ~/.bash_exports
-ln -sf ~/dotfiles/.gitconfig ~/.gitconfig
-ln -sf ~/dotfiles/.tmux.conf ~/.tmux.conf
+ln -sf ~/Pillars/dotfiles/nvim/init.lua ~/.config/nvim/init.lua
+ln -sf ~/Pillars/dotfiles/.bashrc ~/.bashrc
+ln -sf ~/Pillars/dotfiles/.bash_aliases ~/.bash_aliases
+ln -sf ~/Pillars/dotfiles/.bash_exports ~/.bash_exports
+ln -sf ~/Pillars/dotfiles/.gitconfig ~/.gitconfig
+ln -sf ~/Pillars/dotfiles/.tmux.conf ~/.tmux.conf
 
 # Create secrets file from template
-if [[ -f ~/dotfiles/.bash_secrets.example && ! -f ~/.bash_secrets ]]; then
+if [[ -f ~/Pillars/dotfiles/.bash_secrets.example && ! -f ~/.bash_secrets ]]; then
     echo -e "${YELLOW}Creating secrets file from template...${NC}"
-    cp ~/dotfiles/.bash_secrets.example ~/.bash_secrets
+    cp ~/Pillars/dotfiles/.bash_secrets.example ~/.bash_secrets
     chmod 600 ~/.bash_secrets
     echo -e "${BLUE}Created ~/.bash_secrets from template. Edit it to add your secrets.${NC}"
 fi
@@ -110,9 +110,9 @@ if command -v pacman &>/dev/null; then
     echo -e "${YELLOW}Detected Arch Linux!${NC}"
     
     # Check if Arch Linux setup script exists
-    if [[ -f ~/dotfiles/arch-linux/setup.sh ]]; then
+    if [[ -f ~/Pillars/dotfiles/arch-linux/setup.sh ]]; then
         echo -e "${YELLOW}Running Arch Linux specific setup...${NC}"
-        bash ~/dotfiles/arch-linux/setup.sh
+        bash ~/Pillars/dotfiles/arch-linux/setup.sh
     else
         echo -e "${YELLOW}No Arch Linux setup script found. Skipping Arch-specific setup.${NC}"
     fi
@@ -123,9 +123,9 @@ if grep -q "Raspberry Pi" /proc/cpuinfo 2>/dev/null; then
     echo -e "${YELLOW}Detected Raspberry Pi hardware!${NC}"
     
     # Check if Raspberry Pi setup script exists
-    if [[ -f ~/dotfiles/raspberry-pi/setup.sh ]]; then
+    if [[ -f ~/Pillars/dotfiles/raspberry-pi/setup.sh ]]; then
         echo -e "${YELLOW}Running Raspberry Pi specific setup...${NC}"
-        bash ~/dotfiles/raspberry-pi/setup.sh
+        bash ~/Pillars/dotfiles/raspberry-pi/setup.sh
     else
         echo -e "${YELLOW}No Raspberry Pi setup script found. Skipping Pi-specific setup.${NC}"
     fi


### PR DESCRIPTION
This PR refactors the setup script to use a single DOT_DEN variable for all path references.

Benefits:
- Follows DRY (Don't Repeat Yourself) principle
- Makes it easy to change the dotfiles location by modifying just one variable
- Improves maintainability and reduces chance of errors
- Adds mkdir -p to ensure parent directories exist
- Uses a cute and cozy variable name that adds personality

To change the dotfiles location in the future, simply modify the DOT_DEN variable at the top of the script.