### PR TITLE
Fix: Update DOTFILES_DIR path to use Pillars directory structure

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -156,7 +156,7 @@ if [ -f ~/.bash_secrets ]; then
     . ~/.bash_secrets
 fi
 
-DOTFILES_DIR="$HOME/dotfiles"
+DOTFILES_DIR="$HOME/Pillars/dotfiles"
 
 # Add your scripts directory to the PATH
 export PATH="$DOTFILES_DIR/bin:$PATH"


### PR DESCRIPTION
This PR fixes an inconsistency in the .bashrc file where DOTFILES_DIR was pointing to ~/dotfiles instead of ~/Pillars/dotfiles. This ensures that the path is consistent with the PPV system structure and the setup.sh script.