### PR TITLE
Standardize dotfiles directory variable to DOT_DEN

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -156,10 +156,10 @@ if [ -f ~/.bash_secrets ]; then
     . ~/.bash_secrets
 fi
 
-DOTFILES_DIR="$HOME/Pillars/dotfiles"
+DOT_DEN="$HOME/Pillars/dotfiles"
 
 # Add your scripts directory to the PATH
-export PATH="$DOTFILES_DIR/bin:$PATH"
+export PATH="$DOT_DEN/bin:$PATH"
 
 # Skip auto-tmux and directory change for SSH connections
 if [[ -n "$SSH_CONNECTION" ]]; then
@@ -169,7 +169,7 @@ if [[ -n "$SSH_CONNECTION" ]]; then
 else
     # Only change to dotfiles directory when NOT in a tmux session
     if [ -z "$TMUX" ]; then
-        cd "$DOTFILES_DIR"
+        cd "$DOT_DEN"
     fi
 
     # Source Amazon Q environment if installed


### PR DESCRIPTION
This PR standardizes the variable used to reference the dotfiles directory. Previously, setup.sh used DOT_DEN while .bashrc used DOTFILES_DIR. This inconsistency could cause issues when sourcing files or running scripts.\n\nChanges:\n- Changed DOTFILES_DIR to DOT_DEN in .bashrc\n- Updated all references to use the same variable name\n\nThis ensures consistency across all scripts and configuration files.