### PR TITLE
feat(principles): break down principles into individual files

### DIFF
--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -8,51 +8,21 @@ This document contains guiding principles for personal and professional developm
 > 
 > I aim to live with humility, working quietly and deliberately, seeking discernment from the Holy Spirit for tasks, workflows, and partnerships that matter. My focus is on planting seeds, trusting God to grow them, and delighting in the process of tilling the soil each day.
 
-## Working Procedures
+## Core Principles
 
-### Systems Thinking
-Treat work and life as interconnected systems. Optimize and balance nodes in the system while expecting adjustments to maintain harmony.
-
-### System Review
-System reviews are the heartbeat of growth – personally and professionally. Block time weekly to reflect candidly: what worked, what didn't, and what wins stacked up? In teams, lean into the "touchy-feely"; it's where gold hides. Honesty trumps saving face, whether in sprint retrospectives or personal reviews. Stay disciplined: keep sessions focused, regular, and never just go through the motions. This is deep learning time – embrace it, and watch how fun progress becomes when you truly engage.
-
-### Subtraction Creates Value
-The idea that strategically removing items, commitments, or complexity often creates more value than adding new things.
-
-### Standardization
-Don't make everything a one-off work of art. Refer to artifacts and reuse patterns in a leveraged way!
-
-### Silent Strength: The David Principle
-True power lies not in broadcasting achievements, but in the quiet humility and self-sacrifice of mastering your craft. Like King David, who danced before the Lord with pure joy rather than for spectacle, we find our greatest fulfillment in the internal state of flow and focused creation rather than external validation.
-
-This principle celebrates the profound dignity of humble excellence - choosing to delight in the work itself rather than its social media echoes. It's about cultivating an internal compass that finds honor in mastery, regardless of who's watching.
-
-### Respect And Growth
-I lead through unshakable humility and steadfast integrity. I reject workplace politics and refuse to treat colleagues as stepping stones—true success comes from empowering others, not exploiting them. My commitment to trust-building and ethical conduct is non-negotiable, as I believe lasting impact stems from principled actions, not self-serving agendas.
-
-### Reflect
-Stack every win by writing it down, no win is too small and we believe they all add up into a compounding feedback loop. We celebrate a culture of documenting every win in writing. Additionally, record every true disappointment (non-trivial, the bigger moments) in order to see trends and improve, not punish ourselves.
-
-### Living Documentation
-Documentation is a living, breathing asset that demands active cultivation. We ruthlessly review, update, or delete docs every quarter. Stale docs are worse than no docs - they erode trust and waste time. If you write it, you own it. If you read it, you improve it.
-
-### Heart Of Service
-My greatest technical joy comes from building team-enabling systems – like implementing automated test frameworks in CI/CD pipelines that roll forward trust through event-based architectures. These collaborative foundations create compounding confidence: engineers ship fearlessly, failures become learning moments, and shared momentum unlocks fulfillment no solo effort can match. True systems thinking means designing workflows where individual growth requires collective success.
-
-### Grind And Climb
-True progress comes from deliberate pacing, not reckless speed. Like the Spanish proverb, "I dress slowly because I'm in a hurry," we automate mechanical tasks to free mental bandwidth while preserving the learning challenges that build mastery. Speed emerges from intentionality, not haste – the tortoise beats the hare because sustainable growth compounds over time.
-
-### Focus And Clarity
-A systematic approach to maintaining peak performance through health optimization, environment design, and adaptive productivity systems. This includes prioritizing physical and mental wellbeing through proper sleep and diet, creating distraction-free spaces for deep work, and developing self-aware systems that evolve with changing needs.
-
-### Feedback Loops
-Feedback loops shape outcomes – design them to work for you, not against you. For example: working remotely → earning more → better health → improved performance → career growth → higher earnings. Reinforcing loops like this compound gains, while balancing loops (e.g., overwork → burnout → reduced output) keep systems sustainable. Invest in tools and habits that amplify positive loops, ensuring momentum flows in your favor.
-
-### Continuous Learning
-Embrace perpetual growth through deliberate learning practices. Balance structured study with exploratory discovery, while leveraging technology and systems to maximize knowledge retention and application. Treat every experience as a learning opportunity, whether in technical skills, emotional intelligence, or life wisdom.
-
-### BIFF Communication
-BIFF: [Brief][Informative][Friendly][Firm] - A structured communication framework designed for clear message exchange with defined parameters for length, content quality, tone, and boundary maintenance.
-
-### 95 Percent Rule
-Do things well, but not perfectly. Aim for 95% completion over chasing perfection unless foundational.
+- [95 Percent Rule](./principles/95-percent-rule.md)
+- [BIFF Communication](./principles/biff-communication.md)
+- [Continuous Learning](./principles/continuous-learning.md)
+- [Feedback Loops](./principles/feedback-loops.md)
+- [Focus And Clarity](./principles/focus-and-clarity.md)
+- [Grind And Climb](./principles/grind-and-climb.md)
+- [Heart Of Service](./principles/heart-of-service.md)
+- [Living Documentation](./principles/living-documentation.md)
+- [Reflect](./principles/reflect.md)
+- [Respect And Growth](./principles/respect-and-growth.md)
+- [Silent Strength](./principles/silent-strength.md)
+- [Stack Wins](./principles/stack-wins.md)
+- [Standardization](./principles/standardization.md)
+- [Subtraction Creates Value](./principles/subtraction-creates-value.md)
+- [System Review](./principles/system-review.md)
+- [Systems Thinking](./principles/systems-thinking.md)

--- a/principles/95-percent-rule.md
+++ b/principles/95-percent-rule.md
@@ -1,0 +1,3 @@
+# 95 Percent Rule
+
+Do things well, but not perfectly. Aim for 95% completion over chasing perfection unless foundational.

--- a/principles/biff-communication.md
+++ b/principles/biff-communication.md
@@ -1,0 +1,3 @@
+# BIFF Communication
+
+BIFF: [Brief][Informative][Friendly][Firm] - A structured communication framework designed for clear message exchange with defined parameters for length, content quality, tone, and boundary maintenance.

--- a/principles/continuous-learning.md
+++ b/principles/continuous-learning.md
@@ -1,0 +1,3 @@
+# Continuous Learning
+
+Embrace perpetual growth through deliberate learning practices. Balance structured study with exploratory discovery, while leveraging technology and systems to maximize knowledge retention and application. Treat every experience as a learning opportunity, whether in technical skills, emotional intelligence, or life wisdom.

--- a/principles/feedback-loops.md
+++ b/principles/feedback-loops.md
@@ -1,0 +1,3 @@
+# Feedback Loops
+
+Feedback loops shape outcomes – design them to work for you, not against you. For example: working remotely → earning more → better health → improved performance → career growth → higher earnings. Reinforcing loops like this compound gains, while balancing loops (e.g., overwork → burnout → reduced output) keep systems sustainable. Invest in tools and habits that amplify positive loops, ensuring momentum flows in your favor.

--- a/principles/focus-and-clarity.md
+++ b/principles/focus-and-clarity.md
@@ -1,0 +1,3 @@
+# Focus And Clarity
+
+A systematic approach to maintaining peak performance through health optimization, environment design, and adaptive productivity systems. This includes prioritizing physical and mental wellbeing through proper sleep and diet, creating distraction-free spaces for deep work, and developing self-aware systems that evolve with changing needs.

--- a/principles/grind-and-climb.md
+++ b/principles/grind-and-climb.md
@@ -1,0 +1,3 @@
+# Grind And Climb
+
+True progress comes from deliberate pacing, not reckless speed. Like the Spanish proverb, "I dress slowly because I'm in a hurry," we automate mechanical tasks to free mental bandwidth while preserving the learning challenges that build mastery. Speed emerges from intentionality, not haste – the tortoise beats the hare because sustainable growth compounds over time.

--- a/principles/heart-of-service.md
+++ b/principles/heart-of-service.md
@@ -1,0 +1,3 @@
+# Heart Of Service
+
+My greatest technical joy comes from building team-enabling systems – like implementing automated test frameworks in CI/CD pipelines that roll forward trust through event-based architectures. These collaborative foundations create compounding confidence: engineers ship fearlessly, failures become learning moments, and shared momentum unlocks fulfillment no solo effort can match. True systems thinking means designing workflows where individual growth requires collective success.

--- a/principles/living-documentation.md
+++ b/principles/living-documentation.md
@@ -1,0 +1,3 @@
+# Living Documentation
+
+Documentation is a living, breathing asset that demands active cultivation. We ruthlessly review, update, or delete docs every quarter. Stale docs are worse than no docs - they erode trust and waste time. If you write it, you own it. If you read it, you improve it.

--- a/principles/reflect.md
+++ b/principles/reflect.md
@@ -1,0 +1,3 @@
+# Reflect
+
+Stack every win by writing it down, no win is too small and we believe they all add up into a compounding feedback loop. We celebrate a culture of documenting every win in writing. Additionally, record every true disappointment (non-trivial, the bigger moments) in order to see trends and improve, not punish ourselves.

--- a/principles/respect-and-growth.md
+++ b/principles/respect-and-growth.md
@@ -1,0 +1,3 @@
+# Respect And Growth
+
+I lead through unshakable humility and steadfast integrity. I reject workplace politics and refuse to treat colleagues as stepping stones—true success comes from empowering others, not exploiting them. My commitment to trust-building and ethical conduct is non-negotiable, as I believe lasting impact stems from principled actions, not self-serving agendas.

--- a/principles/silent-strength.md
+++ b/principles/silent-strength.md
@@ -1,0 +1,5 @@
+# Silent Strength: The David Principle
+
+True power lies not in broadcasting achievements, but in the quiet humility and self-sacrifice of mastering your craft. Like King David, who danced before the Lord with pure joy rather than for spectacle, we find our greatest fulfillment in the internal state of flow and focused creation rather than external validation.
+
+This principle celebrates the profound dignity of humble excellence - choosing to delight in the work itself rather than its social media echoes. It's about cultivating an internal compass that finds honor in mastery, regardless of who's watching.

--- a/principles/stack-wins.md
+++ b/principles/stack-wins.md
@@ -1,0 +1,5 @@
+# Stack Wins or It Didn't Happen
+
+In the game of continuous improvement, an undocumented win is a missed opportunity. Every victory, from tiny habits to major breakthroughs, must be stacked and logged to build unstoppable momentum.
+
+Stack Wins is a systematic approach to documenting and categorizing all achievements, no matter how small, to build momentum and maintain motivation through visible proof of progress.

--- a/principles/standardization.md
+++ b/principles/standardization.md
@@ -1,0 +1,3 @@
+# Standardization
+
+Don't make everything a one-off work of art. Refer to artifacts and reuse patterns in a leveraged way!

--- a/principles/subtraction-creates-value.md
+++ b/principles/subtraction-creates-value.md
@@ -1,0 +1,3 @@
+# Subtraction Creates Value
+
+The idea that strategically removing items, commitments, or complexity often creates more value than adding new things.

--- a/principles/system-review.md
+++ b/principles/system-review.md
@@ -1,0 +1,3 @@
+# System Review
+
+System reviews are the heartbeat of growth – personally and professionally. Block time weekly to reflect candidly: what worked, what didn't, and what wins stacked up? In teams, lean into the "touchy-feely"; it's where gold hides. Honesty trumps saving face, whether in sprint retrospectives or personal reviews. Stay disciplined: keep sessions focused, regular, and never just go through the motions. This is deep learning time – embrace it, and watch how fun progress becomes when you truly engage.

--- a/principles/systems-thinking.md
+++ b/principles/systems-thinking.md
@@ -1,0 +1,3 @@
+# Systems Thinking
+
+Treat work and life as interconnected systems. Optimize and balance nodes in the system while expecting adjustments to maintain harmony.


### PR DESCRIPTION
This PR breaks down the PRINCIPLES.md file into individual files for each principle, creating a modular structure that:

- Maintains a single source of truth for each principle
- Enables easier maintenance and updates
- Supports linking to individual principles
- Facilitates integration with mdBook through symlinks

The main PRINCIPLES.md file now serves as an index with links to all individual principles.

This approach separates content from presentation, allowing the principles to be referenced from multiple places while being maintained in a single location.