### PR TITLE
feat(aliases): add ppv alias for quick navigation to private P.P.V. repository

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -32,3 +32,6 @@ alias aq-merge='git checkout main && git pull && git merge docs/update-amazonq-g
 
 # Quick add AmazonQ.md with guidance template - creates a file with standardized guidance I ALWAYS WANT included
 alias aq-add='add-amazonq'
+
+# Quick navigation to private P.P.V. repository - personal pillars, pipelines, and vaults
+alias ppv='cd ~/Pillars/private-ppv'


### PR DESCRIPTION
This PR adds a new alias 'ppv' that provides quick navigation to the private P.P.V. repository located at ~/Pillars/private-ppv. This makes it easier to access personal pillars, pipelines, and vaults with a simple command.