### PR TITLE
feat(aliases): add mdserve alias for mdbook with port cleanup

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -35,3 +35,7 @@ alias aq-add='add-amazonq'
 
 # Quick navigation to private P.P.V. repository - personal pillars, pipelines, and vaults
 alias ppv='cd ~/Pillars/private-ppv'
+
+# mdbook build and serve with automatic port cleanup
+# Kills any process using port 3000 before starting mdbook serve
+alias mdserve='fuser -k 3000/tcp 2>/dev/null; mdbook build && mdbook serve'


### PR DESCRIPTION
This PR adds a new alias 'mdserve' that:

1. Kills any existing process using port 3000 (the default mdbook port)
2. Builds the mdbook project
3. Serves the mdbook project

This makes it easier to work with mdbook documentation by ensuring a clean port before starting the server, preventing the common 'address already in use' error.