### PR TITLE
docs(chrome): update Chrome repository setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,18 +156,19 @@ brew install git gh jq tmux curl wget
 Install Google Chrome with automatic updates via the official Google repository:
 
 ```bash
-# Add Google Chrome repository key
-wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+# Modern method (recommended)
+# Download Google's signing key
+wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg
 
-# Add the Google Chrome repository
-sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list'
+# Add the Google Chrome repository with signed-by option
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list
 
 # Update package lists and install Chrome
 sudo apt update
 sudo apt install -y google-chrome-stable
 ```
 
-Chrome will automatically update when you run `sudo apt update` and `sudo apt upgrade` as part of your regular system maintenance.
+Chrome will automatically update when you run both `sudo apt update` AND `sudo apt upgrade` as part of your regular system maintenance. Remember that `apt update` only refreshes package information, while `apt upgrade` actually installs the updates.
 
 ## Secret Management
 


### PR DESCRIPTION
## Issue
The Chrome installation instructions in the README were using the deprecated apt-key method, which can cause auto-updates to fail silently.

## Changes
- Replace deprecated apt-key method with modern GPG keyring approach
- Clarify that both apt update AND apt upgrade are needed for Chrome updates
- Ensure Chrome auto-updates work correctly with modern Debian/Ubuntu systems

This addresses a user-reported issue where Chrome wasn't auto-updating despite following the README instructions.