### PR TITLE
feat(tmux): improve clipboard integration and auto-reload config

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -185,5 +185,9 @@ else
     fi
 fi
 
+# Reload tmux configuration whenever bashrc is sourced
+# This ensures tmux always has the latest config when started
+tmux source-file ~/.tmux.conf >/dev/null 2>&1 || true
+
 # Amazon Q post block. Keep at the bottom of this file.
 [[ -f "${HOME}/.local/share/amazon-q/shell/bashrc.post.bash" ]] && builtin source "${HOME}/.local/share/amazon-q/shell/bashrc.post.bash"

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -24,8 +24,8 @@ setw -g mode-keys vi
 
 # Setup 'v' to begin selection as in Vim
 bind-key -T copy-mode-vi v send-keys -X begin-selection
-# Setup 'y' to copy selection and exit copy mode (like Vim's yank)
-bind-key -T copy-mode-vi y send-keys -X copy-selection-and-cancel
+# Setup 'y' to copy selection to system clipboard and exit copy mode
+bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "xclip -selection clipboard"
 
 # Enter copy mode with Ctrl+a v (then press v again to start selection)
 bind v copy-mode


### PR DESCRIPTION
This PR improves tmux functionality in two key ways:

1. Adds system clipboard integration by configuring tmux to use xclip when copying text
   - Now when selecting text in tmux copy mode and pressing 'y', it copies to system clipboard
   - This allows seamless pasting into external applications like Slack

2. Automatically reloads tmux configuration whenever .bashrc is sourced
   - Ensures tmux always has the latest configuration without manual reloading
   - Works regardless of whether currently in a tmux session

These changes make the terminal experience more seamless and eliminate friction when copying text between terminal and other applications.