### PR TITLE
feat(nvim): add DAP call stack navigation and frame highlighting

### DIFF
--- a/nvim/nvim-cheatsheet.md
+++ b/nvim/nvim-cheatsheet.md
@@ -57,6 +57,8 @@ A quick reference guide for the Neovim configuration in this dotfiles repository
 | `<F11>` | Step into |
 | `<F12>` | Step out |
 | `<leader>du` | Toggle DAP UI (variables, stack, watches) |
+| `<leader>dj` | Move down the call stack (older frames) |
+| `<leader>dk` | Move up the call stack (newer frames) |
 
 ## LSP Features
 


### PR DESCRIPTION
## Summary
- Add call stack navigation with `<leader>dj` and `<leader>dk` keymaps
- Implement visual highlighting of selected call stack frame
- Auto-jump to file+line of current frame when it changes
- Update nvim-cheatsheet with new keybindings

## Test plan
- Debug a Python program with multiple function calls
- Set breakpoints and start debugging with `<F5>`
- Navigate through call stack with `<leader>dj` and `<leader>dk`
- Verify frame highlighting and auto-jump to frame location works
- Check that new keybindings are documented in cheatsheet

🤖 Generated with [Claude Code](https://claude.ai/code)