### PR TITLE
fix: remove Neovim auto-installation from setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -82,61 +82,26 @@ elif [[ -d "$DOT_DEN" ]]; then
 fi
 
 ### Set up Neovim
-echo -e "${YELLOW}Setting up Neovim...${NC}"
+echo -e "${YELLOW}Setting up Neovim configuration...${NC}"
 
 # Check if Neovim is installed
 if ! command -v nvim &> /dev/null; then
-    echo -e "${YELLOW}Neovim not found. Installing...${NC}"
-    
-    # Download latest Neovim release
-    NVIM_TMP_DIR=$(mktemp -d)
-    NVIM_RELEASE="https://github.com/neovim/neovim/releases/latest/download/nvim-linux-x86_64.tar.gz"
-    
-    echo -e "${BLUE}Downloading Neovim from: ${NVIM_RELEASE}${NC}"
-    curl -L -o "${NVIM_TMP_DIR}/nvim.tar.gz" "${NVIM_RELEASE}"
-    
-    # Install Neovim
-    echo -e "${BLUE}Installing Neovim to /opt...${NC}"
-    sudo rm -rf /opt/nvim
-    sudo tar -C /opt -xzf "${NVIM_TMP_DIR}/nvim.tar.gz"
-    
-    # Clean up
-    rm -rf "${NVIM_TMP_DIR}"
-    
-    # Add to PATH if not already there
-    if ! grep -q '/opt/nvim-linux-x86_64/bin' ~/.bashrc; then
-        echo -e "${BLUE}Adding Neovim to PATH in ~/.bashrc...${NC}"
-        echo 'export PATH="$PATH:/opt/nvim-linux-x86_64/bin"' >> ~/.bashrc
-        export PATH="$PATH:/opt/nvim-linux-x86_64/bin"
-    fi
-    
-    echo -e "${GREEN}Neovim installed successfully!${NC}"
+    echo -e "${YELLOW}Neovim not found.${NC}"
+    echo -e "${BLUE}Please install Neovim manually before running this script.${NC}"
+    echo -e "${BLUE}See README.md for installation instructions.${NC}"
 fi
 
-# Link Neovim configuration
-echo -e "${YELLOW}Linking Neovim configuration...${NC}"
-rm -rf ~/.config/nvim
-ln -sfn "$DOT_DEN/nvim" ~/.config/nvim
-
-# Install Neovim dependencies
-echo -e "${YELLOW}Installing Neovim dependencies...${NC}"
-
-# Run LSP install script
-if [ -f "$DOT_DEN/nvim/scripts/lsp-install.sh" ]; then
-    echo -e "${BLUE}Running LSP installation script...${NC}"
-    "$DOT_DEN/nvim/scripts/lsp-install.sh"
-elif [ -f "$DOT_DEN/nvim/lsp-install.sh" ]; then
-    echo -e "${BLUE}Running LSP installation script...${NC}"
-    "$DOT_DEN/nvim/lsp-install.sh"
-fi
-
-# Run Python debug install script
-if [ -f "$DOT_DEN/nvim/scripts/python-debug-install.sh" ]; then
-    echo -e "${BLUE}Running Python debugging tools installation script...${NC}"
-    "$DOT_DEN/nvim/scripts/python-debug-install.sh"
-elif [ -f "$DOT_DEN/nvim/python-debug-install.sh" ]; then
-    echo -e "${BLUE}Running Python debugging tools installation script...${NC}"
-    "$DOT_DEN/nvim/python-debug-install.sh"
+# Link Neovim configuration only if Neovim is available
+if command -v nvim &> /dev/null; then
+    echo -e "${YELLOW}Linking Neovim configuration...${NC}"
+    mkdir -p ~/.config
+    rm -rf ~/.config/nvim
+    ln -sfn "$DOT_DEN/nvim" ~/.config/nvim
+    
+    echo -e "${BLUE}Neovim configuration linked. LSP and debugging tools must be installed manually.${NC}"
+    echo -e "${BLUE}See $DOT_DEN/nvim/scripts/README.md for more information.${NC}"
+else
+    echo -e "${YELLOW}Skipping Neovim configuration as Neovim is not installed.${NC}"
 fi
 
 # Create symlinks for other configuration files


### PR DESCRIPTION
## Summary
- Simplifies the setup script by removing automatic Neovim installation
- Makes Neovim an assumed prerequisite that users must install manually
- Only links configuration files if Neovim is detected on the system

## Test plan
- Run setup.sh on a system without Neovim to verify it shows proper instructions
- Run setup.sh on a system with Neovim to verify it only links configuration

This change aligns with our Working Procedure: Subtraction Creates Value

🤖 Generated with [Claude Code](https://claude.ai/code)