### PR TITLE
feat(bash): Add Claude model switch aliases

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -27,7 +27,6 @@ alias venv='[ -d .venv ] || uv venv .venv && source .venv/bin/activate'
 # Set library path for llama.cpp
 alias set-llama-env='export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:~/ppv/pipelines/llama.cpp/build/bin'
 
-
 # Quick AmazonQ.md update workflow - merge, push, and return to main
 alias aq-merge='git checkout main && git pull && git merge --squash docs/update-amazonq-guidance && git commit -m "docs(amazonq): update guidance" && git push origin main && echo "✅ AmazonQ.md changes merged and pushed to main"'
 # AmazonQ.md update workflow - preserves commit messages from feature branch
@@ -50,3 +49,7 @@ alias lpipe='llama-run -p "$(cat -)"'
 # Philips Hue control system alias
 alias hue="$HOME/ppv/pipelines/hue_minimal/hue.sh"
 
+# Claude model switch aliases
+alias haiku='export ANTHROPIC_MODEL=claude-3-haiku-20241022'
+alias sonnet='export ANTHROPIC_MODEL=claude-3-sonnet-20240229'
+alias opus='export ANTHROPIC_MODEL=claude-3-opus-20240229'

--- a/.bash_aliases
+++ b/.bash_aliases
@@ -51,5 +51,5 @@ alias hue="$HOME/ppv/pipelines/hue_minimal/hue.sh"
 
 # Claude model switch aliases
 alias haiku='export ANTHROPIC_MODEL=claude-3-haiku-20241022'
-alias sonnet='export ANTHROPIC_MODEL=claude-3-sonnet-20240229'
+alias sonnet='export ANTHROPIC_MODEL=claude-3-7-sonnet-latest'
 alias opus='export ANTHROPIC_MODEL=claude-3-opus-20240229'

--- a/.bash_aliases
+++ b/.bash_aliases
@@ -50,6 +50,6 @@ alias lpipe='llama-run -p "$(cat -)"'
 alias hue="$HOME/ppv/pipelines/hue_minimal/hue.sh"
 
 # Claude model switch aliases
-alias haiku='export ANTHROPIC_MODEL=claude-3-haiku-20241022'
+alias haiku='export ANTHROPIC_MODEL=claude-3-5-haiku-latest'
 alias sonnet='export ANTHROPIC_MODEL=claude-3-7-sonnet-latest'
-alias opus='export ANTHROPIC_MODEL=claude-3-opus-20240229'
+alias opus='export ANTHROPIC_MODEL=claude-3-opus-latest'


### PR DESCRIPTION
## Summary
- Added convenient aliases to quickly switch between Claude AI models
- New aliases: 'haiku', 'sonnet', 'opus'
- Using latest versions of each model

## Usage
Simply type the model name in the terminal to switch:
```bash
haiku   # Switch to latest Claude 3.5 Haiku
sonnet  # Switch to latest Claude 3.7 Sonnet
opus    # Switch to latest Claude Opus
```

## Test Plan
- Verify aliases are added to .bash_aliases
- Test switching between models by running each alias