### PR TITLE
feat(nvim): Add VS Code-inspired cursor line highlight

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -481,7 +481,7 @@ end)
 vim.cmd([[
   augroup CursorLineHighlight
     autocmd!
-    autocmd VimEnter,ColorScheme * highlight CursorLine guibg=#FF00FF blend=0
+    autocmd VimEnter,ColorScheme * highlight CursorLine guibg=#87FFD7 blend=0
   augroup END
 ]])
 

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -9,7 +9,6 @@ vim.opt.timeoutlen = 500      -- By default timeoutlen is 1000 ms
 vim.opt.clipboard = "unnamedplus" -- Use system clipboard
 vim.opt.mouse = "a"           -- Enable mouse support
 vim.opt.cursorline = true     -- Highlight the current line
-vim.api.nvim_set_hl(0, 'CursorLine', { bg = '#2C323C', blend = 20 }) -- Subtle VS Code-like highlight
 vim.opt.signcolumn = "yes"    -- Always show the signcolumn
 
 -- Set leader key to space
@@ -477,6 +476,14 @@ pcall(function()
   require('config.terminal')
   print("ToggleTerm terminal integration loaded from 'config.terminal'")
 end)
+
+-- Ensure cursor line is enabled
+vim.cmd([[
+  augroup CursorLineHighlight
+    autocmd!
+    autocmd VimEnter,ColorScheme * highlight CursorLine guibg=#FF00FF blend=0
+  augroup END
+]])
 
 print("Neovim configuration loaded")
 

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -481,7 +481,7 @@ end)
 vim.cmd([[
   augroup CursorLineHighlight
     autocmd!
-    autocmd VimEnter,ColorScheme * highlight CursorLine guibg=#87FFD7 blend=0
+    autocmd VimEnter,ColorScheme * highlight CursorLine guibg=#1A7A5A blend=40
   augroup END
 ]])
 

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -9,6 +9,7 @@ vim.opt.timeoutlen = 500      -- By default timeoutlen is 1000 ms
 vim.opt.clipboard = "unnamedplus" -- Use system clipboard
 vim.opt.mouse = "a"           -- Enable mouse support
 vim.opt.cursorline = true     -- Highlight the current line
+vim.api.nvim_set_hl(0, 'CursorLine', { bg = '#2C323C', blend = 20 }) -- Subtle VS Code-like highlight
 vim.opt.signcolumn = "yes"    -- Always show the signcolumn
 
 -- Set leader key to space


### PR DESCRIPTION
## Summary
- Add a subtle, VS Code-like cursor line highlight
- Enhance visual focus with slight background color and transparency

## Motivation
Improve coding experience by adding a more visually appealing cursor line highlight that mimics modern IDEs.

## Implementation
- Used Neovim's highlight API to set a custom background color
- Added slight transparency for a modern look

## Test Plan
- Verify cursor line highlight appears in Neovim
- Ensure readability and aesthetic appeal