### PR TITLE
feat(tmux): Add VS Code-inspired pane highlighting

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -42,5 +42,10 @@ set -g base-index 1
 # Don't rename windows automatically
 set-option -g allow-rename off
 
+# VS Code-inspired active pane highlighting
+set -g window-active-style 'bg=colour235'   # Subtle dark background for active pane
+set -g window-style 'bg=colour234'          # Slightly different for inactive panes
+set -g pane-border-style 'bg=colour233'     # Minimal border color
+
 # Set status bar color to blue (minimal)
 set -g status-style bg=blue

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -9,6 +9,7 @@ vim.opt.timeoutlen = 500      -- By default timeoutlen is 1000 ms
 vim.opt.clipboard = "unnamedplus" -- Use system clipboard
 vim.opt.mouse = "a"           -- Enable mouse support
 vim.opt.cursorline = true     -- Highlight the current line
+vim.api.nvim_set_hl(0, 'CursorLine', { bg = '#2C323C', blend = 20 }) -- Subtle VS Code-like highlight
 vim.opt.signcolumn = "yes"    -- Always show the signcolumn
 
 -- Set leader key to space


### PR DESCRIPTION
## Summary
- Add subtle background color variation for active and inactive tmux panes
- Enhance visual focus and reduce visual noise

## Motivation
Improve terminal multiplexer experience by adding visual differentiation between active and inactive panes, inspired by modern IDEs like VS Code.

## Implementation
- Use tmux style settings to create background color variations
- Active pane uses a slightly darker background
- Inactive panes have a uniform, muted background

## Test Plan
- Verify pane highlighting works as expected
- Ensure color variations are subtle and not distracting