### PR TITLE
feat(nvim): Add Material theme with deep ocean style

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -42,5 +42,10 @@ set -g base-index 1
 # Don't rename windows automatically
 set-option -g allow-rename off
 
+# VS Code-inspired active pane highlighting
+set -g window-active-style 'bg=colour235'   # Subtle dark background for active pane
+set -g window-style 'bg=colour234'          # Slightly different for inactive panes
+set -g pane-border-style 'bg=colour233'     # Minimal border color
+
 # Set status bar color to blue (minimal)
 set -g status-style bg=blue

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -43,6 +43,9 @@ require('packer').startup(function(use)
   -- Packer can manage itself
   use 'wbthomason/packer.nvim'
 
+  -- Themes
+  use 'marko-cerovac/material.nvim'
+
   -- LSP and completion
   use 'neovim/nvim-lspconfig'           -- LSP configuration
   use 'williamboman/mason.nvim'         -- Package manager for LSP servers
@@ -445,6 +448,47 @@ local setup_language_servers = function()
 end
 
 pcall(setup_language_servers)
+
+-- Material Theme Configuration
+vim.g.material_style = "deep ocean"  -- Options: "darker", "lighter", "oceanic", "deep ocean", "palenight"
+require('material').setup({
+  contrast = {
+    terminal = false,        -- Enable contrast for the built-in terminal
+    sidebars = false,        -- Enable contrast for sidebar-like windows
+    floating_windows = true, -- Enable contrast for floating windows
+    cursor_line = true,      -- Enable darker background for the cursor line
+    non_current_windows = false, -- Enable darker background for non-current windows
+    filetypes = {},          -- Specify filetypes to enable contrast for
+  },
+  styles = {
+    comments = { italic = true },
+    keywords = { italic = true },
+    functions = { bold = true },
+    strings = {},
+    variables = {},
+  },
+  plugins = {
+    -- Enable plugin integrations
+    "dap",
+    "dashboard",
+    "gitsigns",
+    "hop",
+    "indent-blankline",
+    "lspsaga",
+    "mini",
+    "neogit",
+    "neorg",
+    "nvim-cmp",
+    "nvim-navic",
+    "nvim-tree",
+    "telescope",
+    "trouble",
+    "which-key",
+  },
+})
+
+-- Set the colorscheme
+vim.cmd 'colorscheme material'
 
 -- Quick clear file content keybinding
 vim.keymap.set('n', '<leader>da', ':%d<CR>', { noremap = true, silent = true, desc = "Delete all content" })

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -9,6 +9,7 @@ vim.opt.timeoutlen = 500      -- By default timeoutlen is 1000 ms
 vim.opt.clipboard = "unnamedplus" -- Use system clipboard
 vim.opt.mouse = "a"           -- Enable mouse support
 vim.opt.cursorline = true     -- Highlight the current line
+vim.api.nvim_set_hl(0, 'CursorLine', { bg = '#2C323C', blend = 20 }) -- Subtle VS Code-like highlight
 vim.opt.signcolumn = "yes"    -- Always show the signcolumn
 
 -- Set leader key to space


### PR DESCRIPTION
## Summary
- Install Material theme for Neovim
- Configure deep ocean color variant
- Add custom theme styling options

## Motivation
Enhance coding experience with a modern, aesthetically pleasing theme that's easy on the eyes

## Implementation
- Added Material theme plugin
- Configured deep ocean color style
- Set up theme with custom contrast and style settings

## Variants to Try
Included theme variants:
- deep ocean (default)
- darker
- lighter
- oceanic
- palenight

## Test Plan
- Verify theme installation
- Check color rendering in various file types
- Confirm plugin integrations work correctly