### PR TITLE
feat(git): improve prose diff handling for markdown and text files

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -136,9 +136,6 @@ parse_git_branch() {
   git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/ (\1)/'
 }
 
-# Set prompt to show current directory and git branch
-PS1='\W\[\033[32m\]$(parse_git_branch)\[\033[00m\] \$ '
-
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
@@ -193,4 +190,7 @@ tmux source-file ~/.tmux.conf >/dev/null 2>&1 || true
 [[ -f "${HOME}/.local/share/amazon-q/shell/bashrc.post.bash" ]] && builtin source "${HOME}/.local/share/amazon-q/shell/bashrc.post.bash"
 export PATH="$HOME/.local/bin:$PATH"
 export PATH="$HOME/.local/uv-tools/bin:$PATH"
+
+# Set prompt to show current directory and git branch (placed at the end to ensure it's not overridden)
+PS1='\W\[\033[32m\]$(parse_git_branch)\[\033[00m\] \$ '
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,25 @@
+# Global .gitattributes file
+# This file defines attributes for different file types
+
+# Default behavior for all text files
+*.txt diff=text
+
+# Markdown files
+*.md diff=markdown
+*.mdx diff=markdown
+*.markdown diff=markdown
+
+# JSON files
+*.json diff=json
+
+# Plain text files that should be treated as prose
+*.txt diff=astextplain
+README diff=astextplain
+LICENSE diff=astextplain
+CHANGELOG diff=astextplain
+CONTRIBUTING diff=astextplain
+
+# Configuration files that might contain prose
+*.yaml diff=astextplain
+*.yml diff=astextplain
+*.toml diff=astextplain

--- a/.gitconfig
+++ b/.gitconfig
@@ -33,7 +33,7 @@
 [diff "markdown"]
 		wordRegex = [^[:space:]]
 		xfuncname = "^#+.*$"
-		command = git diff --word-diff
+		command = git diff --word-diff --no-index -- \"$LOCAL\" \"$REMOTE\"
 [diff "json"]
 		wordRegex = [^[:space:],]
 [init]

--- a/.gitconfig
+++ b/.gitconfig
@@ -45,3 +45,4 @@
 		helper = !/usr/bin/gh auth git-credential
 [credential "https://gist.github.com"]
         helper = !/usr/bin/gh auth git-credential
+# Removed circular include

--- a/.gitconfig
+++ b/.gitconfig
@@ -33,6 +33,7 @@
 [diff "markdown"]
 		wordRegex = [^[:space:]]
 		xfuncname = "^#+.*$"
+		command = git diff --word-diff
 [diff "json"]
 		wordRegex = [^[:space:],]
 [init]

--- a/.gitconfig
+++ b/.gitconfig
@@ -4,6 +4,7 @@
 [core]
 		editor = nvim
 		pager = delta
+		attributesfile = ~/ppv/pillars/dotfiles/.gitattributes
 [interactive]
 		diffFilter = delta --color-only
 [delta]
@@ -14,6 +15,9 @@
 		syntax-theme = Monokai Extended
 		diff-so-fancy = true
 		max-line-length = 200  # prevent overly wide diffs
+		# Better handling of prose files
+		word-diff-regex = "\\w+|[^[:space:]]"
+		features = decorations
 [delta "interactive"]
 		keep-plus-minus-markers = false
 [merge]
@@ -21,6 +25,16 @@
 [diff]
 		colorMoved = default
 		algorithm = patience  # more intelligent diff algorithm
+		wordRegex = [^[:space:]]
+		submodule = log
+[diff "astextplain"]
+		textconv = cat
+		wordRegex = .
+[diff "markdown"]
+		wordRegex = [^[:space:]]
+		xfuncname = "^#+.*$"
+[diff "json"]
+		wordRegex = [^[:space:],]
 [init]
 		defaultBranch = main
 [push]

--- a/setup.sh
+++ b/setup.sh
@@ -112,9 +112,11 @@ ln -sf "$DOT_DEN/.tmux.conf" ~/.tmux.conf
 echo "Setting up Git configuration..."
 gitconfig_path="$HOME/.gitconfig"
 dotfiles_gitconfig="$DOT_DEN/.gitconfig"
+dotfiles_gitattributes="$DOT_DEN/.gitattributes"
 
+# Create or update ~/.gitconfig to include dotfiles config
 if [[ ! -f "$gitconfig_path" ]]; then
-  echo "Creating new ~/.gitconfig with dotfiles include..."
+  echo "Creating new ~/.gitconfig shim..."
   echo -e "[include]\n\tpath = $dotfiles_gitconfig" > "$gitconfig_path"
   echo -e "${GREEN}✓ Git configuration created${NC}"
 elif ! grep -q "$dotfiles_gitconfig" "$gitconfig_path" 2>/dev/null; then
@@ -124,6 +126,10 @@ elif ! grep -q "$dotfiles_gitconfig" "$gitconfig_path" 2>/dev/null; then
 else
   echo -e "${GREEN}✓ Git configuration already includes dotfiles .gitconfig${NC}"
 fi
+
+# Set core.attributesfile to point to dotfiles .gitattributes
+git config --global core.attributesfile "$dotfiles_gitattributes"
+echo -e "${GREEN}✓ Global gitattributes configured${NC}"
 
 # Create secrets file from template
 if [[ -f "$DOT_DEN/.bash_secrets.example" && ! -f ~/.bash_secrets ]]; then


### PR DESCRIPTION
This PR enhances Git's handling of prose files like Markdown and plain text.

Changes:
- Added global .gitattributes file to define file type associations
- Configured specialized diff drivers for markdown, json, and plain text
- Enhanced delta configuration for better word-level diffs
- Added core.attributesfile to reference the global attributes

These changes make Git show more meaningful diffs for prose files, showing only the specific words or characters that changed rather than highlighting entire lines when making small edits like punctuation changes.