### PR TITLE
feat(bash): add dotfiles alias for quick navigation

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -53,3 +53,6 @@ alias hue="$HOME/ppv/pipelines/hue_minimal/hue.sh"
 alias haiku='export ANTHROPIC_MODEL=claude-3-5-haiku-latest'
 alias sonnet='export ANTHROPIC_MODEL=claude-3-7-sonnet-latest'
 alias opus='export ANTHROPIC_MODEL=claude-3-opus-latest'
+
+# Quick navigation to dotfiles directory
+alias dotfiles='cd ~/ppv/pillars/dotfiles'


### PR DESCRIPTION
Added a simple 'dotfiles' alias to quickly navigate to the dotfiles directory from anywhere in the terminal.

This small quality-of-life improvement makes it easier to access and modify dotfiles configuration.