### PR TITLE
refactor(q-cli): reorder aliases for logical workflow

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -54,6 +54,9 @@ alias haiku='export ANTHROPIC_MODEL=claude-3-5-haiku-latest'
 alias sonnet='export ANTHROPIC_MODEL=claude-3-7-sonnet-latest'
 alias opus='export ANTHROPIC_MODEL=claude-3-opus-latest'
 
+# Quick navigation to dotfiles directory
+alias dotfiles='cd ~/ppv/pillars/dotfiles'
+
 # Source Amazon Q CLI development aliases
 if [ -f "$HOME/ppv/pillars/dotfiles/.bash_aliases.q-cli" ]; then
     source "$HOME/ppv/pillars/dotfiles/.bash_aliases.q-cli"

--- a/.bash_aliases
+++ b/.bash_aliases
@@ -53,3 +53,8 @@ alias hue="$HOME/ppv/pipelines/hue_minimal/hue.sh"
 alias haiku='export ANTHROPIC_MODEL=claude-3-5-haiku-latest'
 alias sonnet='export ANTHROPIC_MODEL=claude-3-7-sonnet-latest'
 alias opus='export ANTHROPIC_MODEL=claude-3-opus-latest'
+
+# Source Amazon Q CLI development aliases
+if [ -f "$HOME/ppv/pillars/dotfiles/.bash_aliases.q-cli" ]; then
+    source "$HOME/ppv/pillars/dotfiles/.bash_aliases.q-cli"
+fi

--- a/.bash_aliases.q-cli
+++ b/.bash_aliases.q-cli
@@ -1,14 +1,12 @@
 # Amazon Q CLI - Development aliases
 # Include this file in your .bashrc or .bash_aliases
 
-# Run Amazon Q chat directly from source code
-alias q-run="cd $HOME/ppv/pillars/q-cli && cargo run --bin q_cli -- chat"
-
-# Use the compiled release version
-alias q-dev="$HOME/ppv/pillars/q-cli/target/release/q"
-
-# Run Amazon Q chat with the compiled release version
-alias q-dev-chat="$HOME/ppv/pillars/q-cli/target/release/q chat"
-
 # Build Amazon Q CLI from source
-alias q-dev-build="cd $HOME/ppv/pillars/q-cli && cargo build --release"
+alias q-build="cd $HOME/ppv/pillars/q-cli && cargo build --release"
+
+# Run the compiled release version
+alias q-run="$HOME/ppv/pillars/q-cli/target/release/q"
+
+# Quick development testing (build and run in one step)
+alias q-dev="cd $HOME/ppv/pillars/q-cli && cargo run --bin q_cli -- chat"
+

--- a/.bash_aliases.q-cli
+++ b/.bash_aliases.q-cli
@@ -1,0 +1,8 @@
+# Amazon Q CLI - Development aliases
+# Include this file in your .bashrc or .bash_aliases
+
+# Run Amazon Q chat directly from source code
+alias q-run="cd $HOME/ppv/pillars/q-cli && cargo run --bin q_cli -- chat"
+
+# Use the compiled release version
+alias q-dev="$HOME/ppv/pillars/q-cli/target/release/q"

--- a/.bash_aliases.q-cli
+++ b/.bash_aliases.q-cli
@@ -6,3 +6,9 @@ alias q-run="cd $HOME/ppv/pillars/q-cli && cargo run --bin q_cli -- chat"
 
 # Use the compiled release version
 alias q-dev="$HOME/ppv/pillars/q-cli/target/release/q"
+
+# Run Amazon Q chat with the compiled release version
+alias q-dev-chat="$HOME/ppv/pillars/q-cli/target/release/q chat"
+
+# Build Amazon Q CLI from source
+alias q-dev-build="cd $HOME/ppv/pillars/q-cli && cargo build --release"

--- a/README.md
+++ b/README.md
@@ -249,22 +249,32 @@ For SSO, the URL typically follows this format:
 https://d-XXXXXXXXXX.awsapps.com/start/#/console?account_id=XXXXXXXXXXXX&role_name=YOUR_ROLE_NAME
 ```
 
-#### Development Version
+### Modular Shell Configuration
+
+This repository uses a modular approach to shell configuration, organizing aliases and functions into specialized, self-contained files:
+
+```bash
+# Source modular alias files
+for alias_file in ~/ppv/pillars/dotfiles/.bash_aliases.*; do
+  [ -f "$alias_file" ] && source "$alias_file"
+done
+```
+
+#### Amazon Q CLI Development
+
+For Amazon Q CLI development, source the specialized module:
+
+```bash
+source ~/ppv/pillars/dotfiles/.bash_aliases.q-cli
+```
+
+See the module file directly for detailed documentation of available aliases.
 
 For development work with Amazon Q CLI:
 
 ```bash
 # Source the development aliases
 source ~/ppv/pillars/dotfiles/.bash_aliases.q-cli
-
-# Build the release version
-q-build
-
-# Run the compiled release version
-q-run chat
-
-# Quick development testing (build and run in one step)
-q-dev chat
 ```
 
 See `.bash_aliases.q-cli` for more details on working with the source code version.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,24 @@
 
 A collection of configuration files for a consistent development environment across different machines.
 
+## Modular Shell Configuration
+
+This repository uses a modular approach to shell configuration:
+
+```bash
+# Source modular alias files
+for alias_file in ~/ppv/pillars/dotfiles/.bash_aliases.*; do
+  [ -f "$alias_file" ] && source "$alias_file"
+done
+```
+
+This pattern provides:
+- **Separation of concerns** – Each file focuses on a specific tool
+- **Lazy loading** – Files sourced only when they exist
+- **Namespace hygiene** – Avoids cluttering global namespace
+
+Modules follow the naming convention `.bash_aliases.<tool-name>` and are automatically loaded when present.
+
 ## P.P.V System: Pillars, Pipelines, and Vaults
 
 This repository is part of the P.P.V system, a holistic approach to organizing knowledge work and digital assets:

--- a/README.md
+++ b/README.md
@@ -249,6 +249,23 @@ For SSO, the URL typically follows this format:
 https://d-XXXXXXXXXX.awsapps.com/start/#/console?account_id=XXXXXXXXXXXX&role_name=YOUR_ROLE_NAME
 ```
 
+#### Development Version
+
+For development work with Amazon Q CLI:
+
+```bash
+# Source the development aliases
+source ~/ppv/pillars/dotfiles/.bash_aliases.q-cli
+
+# Run directly from source code
+q-run
+
+# Use compiled release version
+q-dev chat
+```
+
+See `.bash_aliases.q-cli` for more details on working with the source code version.
+
 ### Tmux Config Comparison
 
 To compare different tmux configurations (like at an optometrist):

--- a/README.md
+++ b/README.md
@@ -267,31 +267,11 @@ For SSO, the URL typically follows this format:
 https://d-XXXXXXXXXX.awsapps.com/start/#/console?account_id=XXXXXXXXXXXX&role_name=YOUR_ROLE_NAME
 ```
 
-### Modular Shell Configuration
-
-This repository uses a modular approach to shell configuration, organizing aliases and functions into specialized, self-contained files:
-
-```bash
-# Source modular alias files
-for alias_file in ~/ppv/pillars/dotfiles/.bash_aliases.*; do
-  [ -f "$alias_file" ] && source "$alias_file"
-done
-```
-
 #### Amazon Q CLI Development
 
 For Amazon Q CLI development, source the specialized module:
 
 ```bash
-source ~/ppv/pillars/dotfiles/.bash_aliases.q-cli
-```
-
-See the module file directly for detailed documentation of available aliases.
-
-For development work with Amazon Q CLI:
-
-```bash
-# Source the development aliases
 source ~/ppv/pillars/dotfiles/.bash_aliases.q-cli
 ```
 

--- a/README.md
+++ b/README.md
@@ -257,10 +257,13 @@ For development work with Amazon Q CLI:
 # Source the development aliases
 source ~/ppv/pillars/dotfiles/.bash_aliases.q-cli
 
-# Run directly from source code
-q-run
+# Build the release version
+q-build
 
-# Use compiled release version
+# Run the compiled release version
+q-run chat
+
+# Quick development testing (build and run in one step)
 q-dev chat
 ```
 

--- a/README.md
+++ b/README.md
@@ -267,16 +267,6 @@ For SSO, the URL typically follows this format:
 https://d-XXXXXXXXXX.awsapps.com/start/#/console?account_id=XXXXXXXXXXXX&role_name=YOUR_ROLE_NAME
 ```
 
-#### Amazon Q CLI Development
-
-For Amazon Q CLI development, source the specialized module:
-
-```bash
-source ~/ppv/pillars/dotfiles/.bash_aliases.q-cli
-```
-
-See `.bash_aliases.q-cli` for more details on working with the source code version.
-
 ### Tmux Config Comparison
 
 To compare different tmux configurations (like at an optometrist):


### PR DESCRIPTION
This PR reorganizes the Amazon Q CLI aliases to follow a more intuitive workflow:

1. q-build - For building the release version
2. q-run - For running the compiled release version  
3. q-dev - For quick development testing

This naming convention follows a clear progression from building to running to development testing, making it more intuitive for anyone working on the Amazon Q CLI project.

The aliases support local development of Amazon Q CLI, allowing developers to build, test, and make changes to the codebase.