### PR TITLE
fix(bash): update setup script to require sourcing

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -194,6 +194,3 @@ export PATH="$HOME/.local/uv-tools/bin:$PATH"
 # Set prompt to show current directory and git branch (placed at the end to ensure it's not overridden)
 PS1='\W\[\033[32m\]$(parse_git_branch)\[\033[00m\] \$ '
 
-# Re-apply Bash config on demand
-# Usage: source ~/.bashrc
-

--- a/.bashrc
+++ b/.bashrc
@@ -4,10 +4,6 @@
 # see /usr/share/doc/bash/examples/startup-files (in the package bash-doc)
 # for examples
 
-# Source bashrc quickly with a short alias
-# Defined directly in .bashrc to ensure it's always available
-alias src="source ~/.bashrc"
-
 # # .bashrc or .zshrc
 # alias linusfiles='function _linusfiles() {
 #     echo "Listing files tracked by git and copying contents to clipboard, approved by Linus Torvalds himself!";
@@ -197,4 +193,7 @@ export PATH="$HOME/.local/uv-tools/bin:$PATH"
 
 # Set prompt to show current directory and git branch (placed at the end to ensure it's not overridden)
 PS1='\W\[\033[32m\]$(parse_git_branch)\[\033[00m\] \$ '
+
+# Re-apply Bash config on demand
+# Usage: source ~/.bashrc
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,13 +1,25 @@
 #!/bin/bash
 # Dotfiles Automated Setup Script
 # Universal configuration for all environments
+#
+# USAGE: source setup.sh
+# NOTE: This script must be sourced, not executed, to affect your current shell
 
 set -e  # Exit on error
 
 GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
 RED='\033[0;31m'
+BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 DIVIDER="----------------------------------------"
+
+# Check if the script is being sourced
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    echo -e "${RED}Error: This script must be sourced, not executed.${NC}"
+    echo -e "Please run: ${GREEN}source setup.sh${NC}"
+    exit 1
+fi
 
 DOT_DEN="$HOME/ppv/pillars/dotfiles"
 
@@ -41,7 +53,7 @@ done
 
 if [[ "$missing_commands" == true ]]; then
     echo -e "${RED}Please install the missing commands and run this script again.${NC}"
-    exit 1
+    return 1
 fi
 
 # Determine OS type
@@ -147,7 +159,7 @@ if command -v pacman &>/dev/null; then
     # Check if Arch Linux setup script exists
     if [[ -f "$DOT_DEN/arch-linux/setup.sh" ]]; then
         echo "Running Arch Linux specific setup..."
-        bash "$DOT_DEN/arch-linux/setup.sh"
+        source "$DOT_DEN/arch-linux/setup.sh"
     else
         echo "No Arch Linux setup script found. Skipping Arch-specific setup."
     fi
@@ -160,7 +172,7 @@ if grep -q "Raspberry Pi" /proc/cpuinfo 2>/dev/null; then
     # Check if Raspberry Pi setup script exists
     if [[ -f "$DOT_DEN/raspberry-pi/setup.sh" ]]; then
         echo "Running Raspberry Pi specific setup..."
-        bash "$DOT_DEN/raspberry-pi/setup.sh"
+        source "$DOT_DEN/raspberry-pi/setup.sh"
     else
         echo "No Raspberry Pi setup script found. Skipping Pi-specific setup."
     fi
@@ -250,6 +262,5 @@ fi
 echo -e "${DIVIDER}"
 echo -e "${GREEN}✅ Dotfiles setup complete!${NC}"
 echo "Your development environment is now configured and ready to use."
-echo -e "${YELLOW}NOTE: Run 'src' or 'source ~/.bashrc' to load the new configuration in your current shell.${NC}"
 echo -e "${DIVIDER}"
 

--- a/setup.sh
+++ b/setup.sh
@@ -7,7 +7,9 @@
 set -e  # Exit on error
 
 GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
 RED='\033[0;31m'
+BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 DIVIDER="----------------------------------------"
 
@@ -100,14 +102,14 @@ if command -v nvim &> /dev/null; then
     rm -rf ~/.config/nvim
     ln -sfn "$DOT_DEN/nvim" ~/.config/nvim
     
-    echo -e "${GREEN}Neovim configuration linked.${NC}"
-    echo -e "Note: LSP and debugging tools must be installed manually."
-    echo -e "See $DOT_DEN/nvim/scripts/README.md for more information."
+    echo -e "${BLUE}Neovim configuration linked.${NC}"
+    echo -e "${BLUE}Note: LSP and debugging tools must be installed manually.${NC}"
+    echo -e "${BLUE}See $DOT_DEN/nvim/scripts/README.md for more information.${NC}"
 else
-    echo -e "Neovim not installed. Skipping Neovim configuration."
-    echo -e "To use Neovim configuration:"
-    echo -e "1. Install Neovim"
-    echo -e "2. Run: ln -sfn $DOT_DEN/nvim ~/.config/nvim"
+    echo -e "${YELLOW}Neovim not installed. Skipping Neovim configuration.${NC}"
+    echo -e "${BLUE}To use Neovim configuration:${NC}"
+    echo -e "${BLUE}1. Install Neovim${NC}"
+    echo -e "${BLUE}2. Run: ln -sfn $DOT_DEN/nvim ~/.config/nvim${NC}"
 fi
 
 # Create symlinks for other configuration files
@@ -260,4 +262,3 @@ echo -e "${DIVIDER}"
 echo -e "${GREEN}✅ Dotfiles setup complete!${NC}"
 echo "Your development environment is now configured and ready to use."
 echo -e "${DIVIDER}"
-

--- a/setup.sh
+++ b/setup.sh
@@ -7,9 +7,7 @@
 set -e  # Exit on error
 
 GREEN='\033[0;32m'
-YELLOW='\033[0;33m'
 RED='\033[0;31m'
-BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 DIVIDER="----------------------------------------"
 

--- a/setup.sh
+++ b/setup.sh
@@ -3,14 +3,11 @@
 # Universal configuration for all environments
 #
 # USAGE: source setup.sh
-# NOTE: This script must be sourced, not executed, to affect your current shell
 
 set -e  # Exit on error
 
 GREEN='\033[0;32m'
-YELLOW='\033[0;33m'
 RED='\033[0;31m'
-BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 DIVIDER="----------------------------------------"
 
@@ -103,14 +100,14 @@ if command -v nvim &> /dev/null; then
     rm -rf ~/.config/nvim
     ln -sfn "$DOT_DEN/nvim" ~/.config/nvim
     
-    echo -e "${BLUE}Neovim configuration linked.${NC}"
-    echo -e "${BLUE}Note: LSP and debugging tools must be installed manually.${NC}"
-    echo -e "${BLUE}See $DOT_DEN/nvim/scripts/README.md for more information.${NC}"
+    echo -e "${GREEN}Neovim configuration linked.${NC}"
+    echo -e "Note: LSP and debugging tools must be installed manually."
+    echo -e "See $DOT_DEN/nvim/scripts/README.md for more information."
 else
-    echo -e "${YELLOW}Neovim not installed. Skipping Neovim configuration.${NC}"
-    echo -e "${BLUE}To use Neovim configuration:${NC}"
-    echo -e "${BLUE}1. Install Neovim${NC}"
-    echo -e "${BLUE}2. Run: ln -sfn $DOT_DEN/nvim ~/.config/nvim${NC}"
+    echo -e "Neovim not installed. Skipping Neovim configuration."
+    echo -e "To use Neovim configuration:"
+    echo -e "1. Install Neovim"
+    echo -e "2. Run: ln -sfn $DOT_DEN/nvim ~/.config/nvim"
 fi
 
 # Create symlinks for other configuration files


### PR DESCRIPTION
This PR updates the setup script to require sourcing instead of executing, which ensures that environment changes take effect in the current shell.

Key changes:
- Added check to verify the script is being sourced
- Changed exit commands to return for proper sourcing behavior
- Updated sub-script calls to use source instead of bash
- Improved error messages and documentation
- Removed redundant src alias in favor of explicit sourcing instructions