### PR TITLE
feat(nav): add PPV system navigation aliases

### DIFF
--- a/.bash_aliases.d/nav.sh
+++ b/.bash_aliases.d/nav.sh
@@ -7,3 +7,8 @@ alias dotfiles="cd ~/ppv/pillars/dotfiles"
 # Quick navigation to private P.P.V. repository
 alias ppv="cd ~/ppv"
 
+# P.P.V. system navigation
+alias pillars="cd ~/ppv/pillars"
+alias vaults="cd ~/ppv/vaults"
+alias pipelines="cd ~/ppv/pipelines"
+


### PR DESCRIPTION
This PR adds navigation aliases for the P.P.V. system directories:

- `pillars` - Navigate to ~/ppv/pillars
- `vaults` - Navigate to ~/ppv/vaults
- `pipelines` - Navigate to ~/ppv/pipelines

These aliases provide a quality of life enhancement for quickly navigating between the core components of the P.P.V. system.