### PR TITLE
fix(shellcheck): add -x flag to follow sourced files

### DIFF
--- a/.github/workflows/test-general-dotfiles-setup.yml
+++ b/.github/workflows/test-general-dotfiles-setup.yml
@@ -17,8 +17,8 @@ jobs:
       - name: Install shellcheck
         run: sudo apt-get install -y shellcheck
       
-      - name: Lint setup script
-        run: shellcheck setup.sh
+      - name: Run shellcheck setup.sh
+        run: shellcheck -x setup.sh
 
   test-ubuntu:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR fixes the shellcheck issue by adding the -x flag to the shellcheck command in the CI workflow.

The -x flag tells shellcheck to follow sourced files, which resolves the SC1091 errors when sourcing platform-specific setup scripts.

Fixes #114