### PR TITLE
fix(bash): prevent tmux auto-start during setup script execution

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -175,7 +175,8 @@ else
     fi
 
     # Auto-start tmux with a unique session name based on timestamp
-    if [ -z "$TMUX" ] && [[ "$-" == *i* ]] && command -v tmux >/dev/null 2>&1; then
+    # Skip auto-start if we're running from the setup script
+    if [ -z "$TMUX" ] && [[ "$-" == *i* ]] && command -v tmux >/dev/null 2>&1 && [ -z "$SETUP_SCRIPT_RUNNING" ]; then
         # Create a new session with a unique name (terminal-TIMESTAMP)
         SESSION_NAME="terminal-$(date +%s)"
         exec tmux new-session -s "$SESSION_NAME"


### PR DESCRIPTION
This PR fixes an issue where running the setup script from within tmux would cause the current tmux session to terminate.

The problem was that the .bashrc file would auto-start a new tmux session when sourced, which happens during setup. This change adds a check for the SETUP_SCRIPT_RUNNING environment variable (which is set by setup.sh) to prevent tmux from auto-starting during setup.

This allows users to safely run 'source setup.sh' from within a tmux session without disrupting their current session.