### PR TITLE
feat(q): add simple scripts to toggle Amazon Q logging

### DIFF
--- a/bin/q-log-off
+++ b/bin/q-log-off
@@ -1,0 +1,2 @@
+#!/bin/bash
+unset Q_LOG_LEVEL && unset TMPDIR && echo "Amazon Q logging disabled."

--- a/bin/q-log-on
+++ b/bin/q-log-on
@@ -1,0 +1,2 @@
+#!/bin/bash
+export Q_LOG_LEVEL=trace && export TMPDIR="/tmp/q-logs" && mkdir -p "$TMPDIR" && echo "Amazon Q logging enabled. Logs at: $TMPDIR/qlog"


### PR DESCRIPTION
Adds two simple scripts to easily toggle Amazon Q logging on and off for debugging purposes:\n\n- bin/q-log-on: Enables trace logging and sets the log directory\n- bin/q-log-off: Disables trace logging\n\nThis will help with debugging MCP server issues and other Amazon Q CLI problems.