### PR TITLE
docs(amazonq): add critical warning about escape sequences

### DIFF
--- a/AmazonQ.md
+++ b/AmazonQ.md
@@ -24,6 +24,13 @@ This file contains guidance for Amazon Q when interacting with this repository.
 - Prefer concise issues with less context over verbose ones
 - Treat GitHub issues as discussion points and suggestions, not strict mandates
 
+## PR Comments Formatting
+- CRITICAL: Never use `\n\n` in PR comments as they will appear literally in the comment
+- For PR comments, always use actual line breaks by pressing Enter between lines
+- Example: `gh pr comment <number> -b "First line.` (press Enter) `Second line."` ✓
+- NOT: `gh pr comment <number> -b "First line.\n\nSecond line."` ✗
+- This prevents embarrassing escape sequences from appearing in comments
+
 ## Quick AmazonQ.md Updates
 - For quick updates to this file, use the standardized branch name: `docs/update-amazonq-guidance`
 - Command: `git checkout main && git pull && git checkout -b docs/update-amazonq-guidance`

--- a/AmazonQ.md
+++ b/AmazonQ.md
@@ -25,13 +25,6 @@ This file contains guidance for Amazon Q when interacting with this repository.
 - Prefer concise issues with less context over verbose ones
 - Treat GitHub issues as discussion points and suggestions, not strict mandates
 
-## PR Comments Formatting
-- CRITICAL: Never use `\n\n` in PR comments as they will appear literally in the comment
-- For PR comments, always use actual line breaks by pressing Enter between lines
-- Example: `gh pr comment <number> -b "First line.` (press Enter) `Second line."` ✓
-- NOT: `gh pr comment <number> -b "First line.\n\nSecond line."` ✗
-- This prevents embarrassing escape sequences from appearing in comments
-
 ## Quick AmazonQ.md Updates
 - For quick updates to this file, use the standardized branch name: `docs/update-amazonq-guidance`
 - Command: `git checkout main && git pull && git checkout -b docs/update-amazonq-guidance`

--- a/AmazonQ.md
+++ b/AmazonQ.md
@@ -9,6 +9,7 @@ This file contains guidance for Amazon Q when interacting with this repository.
 - Use branch naming pattern: `type/description` (e.g., `feature/add-tool`, `fix/typo`)
 - For GitHub CLI comments use: `gh pr comment <number> -b "text"` (not `---comment`)
 - Don't thank yourself when closing your own PRs
+- CRITICAL: Never use escape sequences like `\n\n` in any text submitted through interfaces (PR comments, descriptions, issues, etc.) as they will appear literally
 
 ## PR Description Formatting
 - IMPORTANT: When creating PR descriptions, use actual line breaks instead of `\n\n` escape sequences


### PR DESCRIPTION
Adds a critical warning to the Common Errors section about escape sequences appearing literally in text.

The new warning emphasizes:
- Never use escape sequences like \n\n in any text submitted through interfaces
- This applies to PR comments, descriptions, issues, and other text interfaces
- Prevents embarrassing escape sequences from appearing in submitted text

This is a minimal change that reinforces existing guidance and makes it more prominent.