### PR TITLE
fix: add symlink for .bash_aliases.d directory

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -114,6 +114,7 @@ fi
 echo "Creating symlinks for config files..."
 ln -sf "$DOT_DEN/.bashrc" ~/.bashrc
 ln -sf "$DOT_DEN/.bash_aliases" ~/.bash_aliases
+ln -sf "$DOT_DEN/.bash_aliases.d" ~/.bash_aliases.d
 ln -sf "$DOT_DEN/.bash_exports" ~/.bash_exports
 ln -sf "$DOT_DEN/.tmux.conf" ~/.tmux.conf
 


### PR DESCRIPTION
This PR fixes the issue where the 'dotfiles' alias (and other aliases defined in the modular .bash_aliases.d directory) were not working.

The problem was that while the main .bash_aliases file was being symlinked to the home directory, the .bash_aliases.d directory containing the actual alias modules was not.

This change adds a symlink for the .bash_aliases.d directory in the setup script, ensuring that all modular aliases are properly loaded.

Fixes the 'dotfiles: command not found' error.