### PR TITLE
fix: prevent tmux auto-start when using navigation aliases

### DIFF
--- a/.bash_aliases.d/nav.sh
+++ b/.bash_aliases.d/nav.sh
@@ -2,13 +2,13 @@
 # Include this file in your .bashrc or .bash_aliases
 
 # Quick navigation to dotfiles directory
-alias dotfiles="cd ~/ppv/pillars/dotfiles"
+alias dotfiles="NAVIGATION_ALIAS_RUNNING=true; cd ~/ppv/pillars/dotfiles"
 
 # Quick navigation to private P.P.V. repository
-alias ppv="cd ~/ppv"
+alias ppv="NAVIGATION_ALIAS_RUNNING=true; cd ~/ppv"
 
 # P.P.V. system navigation
-alias pillars="cd ~/ppv/pillars"
-alias vaults="cd ~/ppv/vaults"
-alias pipelines="cd ~/ppv/pipelines"
+alias pillars="NAVIGATION_ALIAS_RUNNING=true; cd ~/ppv/pillars"
+alias vaults="NAVIGATION_ALIAS_RUNNING=true; cd ~/ppv/vaults"
+alias pipelines="NAVIGATION_ALIAS_RUNNING=true; cd ~/ppv/pipelines"
 

--- a/.bashrc
+++ b/.bashrc
@@ -176,7 +176,8 @@ else
 
     # Auto-start tmux with a unique session name based on timestamp
     # Skip auto-start if we're running from the setup script
-    if [ -z "$TMUX" ] && [[ "$-" == *i* ]] && command -v tmux >/dev/null 2>&1 && [ -z "$SETUP_SCRIPT_RUNNING" ]; then
+    # Also skip if we're running a navigation alias (to prevent session termination)
+    if [ -z "$TMUX" ] && [[ "$-" == *i* ]] && command -v tmux >/dev/null 2>&1 && [ -z "$SETUP_SCRIPT_RUNNING" ] && [ -z "$NAVIGATION_ALIAS_RUNNING" ]; then
         # Create a new session with a unique name (terminal-TIMESTAMP)
         SESSION_NAME="terminal-$(date +%s)"
         exec tmux new-session -s "$SESSION_NAME"


### PR DESCRIPTION
This PR fixes an issue where using navigation aliases like 'dotfiles' would terminate the user's session.

## Problem
When using the 'dotfiles' alias (or other navigation aliases), the session would be terminated because:
1. The alias would change directories
2. Then the .bashrc would detect we're not in a tmux session and start a new one with 'exec tmux'
3. The 'exec' command replaces the current shell process, effectively terminating the session

## Solution
1. Added a NAVIGATION_ALIAS_RUNNING environment variable to all navigation aliases
2. Modified the tmux auto-start logic in .bashrc to check for this variable and skip auto-starting tmux when it's set

This allows users to use navigation aliases like 'dotfiles' without having their session terminated.