### PR TITLE
feat(github): add standardized issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,42 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+title: 'bug(scope): brief description'
+labels: bug
+assignees: ''
+---
+
+<!-- 
+IMPORTANT: 
+- Minimum length: 31 lines
+- Maximum length: 55 lines
+- Title format: bug(scope): brief description
+  - scope: component affected (e.g., bash, tmux, git)
+  - description: concise summary of the issue
+- Please provide complete information following the template below
+-->
+
+## Bug Description
+<!-- A clear and concise description of the bug -->
+
+## Steps to Reproduce
+1. <!-- First step -->
+2. <!-- Second step -->
+3. <!-- And so on... -->
+
+## Expected Behavior
+<!-- What you expected to happen -->
+
+## Actual Behavior
+<!-- What actually happened -->
+
+## Environment
+- OS: <!-- e.g. Ubuntu 22.04, macOS 13.0, Windows 11 -->
+- Shell: <!-- e.g. Bash 5.1.16, Zsh 5.8 -->
+- Relevant tool versions: <!-- e.g. Git 2.39.0, Tmux 3.3a -->
+
+## Additional Context
+<!-- Add any other context about the problem here, such as screenshots or error messages -->
+
+## Possible Solution
+<!-- Optional: If you have suggestions on how to fix the bug -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation Issue
+    url: https://github.com/atxtechbro/dotfiles/issues/new?labels=documentation&template=bug_report.md&title=docs%28scope%29%3A+brief+description
+    about: Report issues with documentation
+  - name: Question
+    url: https://github.com/atxtechbro/dotfiles/issues/new?labels=question&template=feature_request.md&title=question%28scope%29%3A+brief+description
+    about: Ask a question about this project

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,31 @@
+---
+name: Feature Request
+about: Suggest an idea or enhancement
+title: 'feat(scope): brief description'
+labels: enhancement
+assignees: ''
+---
+
+<!-- 
+IMPORTANT: 
+- Minimum length: 1 line (body optional)
+- If including body, must be either 3 or 5 lines exactly
+- Title format: feat(scope): brief description
+  - scope: component affected (e.g., bash, tmux, git)
+  - description: concise summary of the feature
+-->
+
+## Feature Description
+<!-- A clear and concise description of the feature you'd like to see implemented -->
+
+## Use Case
+<!-- Describe the specific use case or problem this feature would solve -->
+
+## Proposed Solution
+<!-- Optional: Describe how you envision this feature working -->
+
+## Alternatives Considered
+<!-- Optional: Any alternative solutions or features you've considered -->
+
+## Additional Context
+<!-- Optional: Any other context, screenshots, or examples about the feature request -->

--- a/.github/ISSUE_TEMPLATE/refactor_request.md
+++ b/.github/ISSUE_TEMPLATE/refactor_request.md
@@ -1,0 +1,31 @@
+---
+name: Refactor Request
+about: Suggest code restructuring without changing functionality
+title: 'refactor(scope): brief description'
+labels: refactor
+assignees: ''
+---
+
+<!-- 
+IMPORTANT: 
+- Minimum length: 1 line (body optional)
+- If including body, must be either 3 or 5 lines exactly
+- Title format: refactor(scope): brief description
+  - scope: component affected (e.g., bash, tmux, git)
+  - description: concise summary of the refactoring needed
+-->
+
+## Current Implementation
+<!-- Describe the current implementation and its limitations -->
+
+## Proposed Refactoring
+<!-- Describe how the code should be restructured -->
+
+## Benefits
+<!-- Explain the benefits of this refactoring (e.g., maintainability, performance) -->
+
+## Scope of Changes
+<!-- Which files/components will be affected by this refactoring -->
+
+## Additional Context
+<!-- Any other relevant information about the refactoring request -->


### PR DESCRIPTION
This PR adds standardized GitHub issue templates following the "tracer bullet" development approach and automation mindset from our dotfiles philosophy.

## Changes
- Added bug report template with 31-55 line requirement
- Added feature request template with 1/3/5 line options
- Added refactor request template with 1/3/5 line options
- Created config.yml to disable blank issues and add specialized links
- Implemented conventional commit-style title taxonomy for all templates

## Benefits
- Standardizes issue reporting across the repository
- Enforces consistent formatting and information requirements
- Follows the automation mindset by templating common workflows
- Makes issues more searchable and categorizable

All templates follow the "spilled coffee" principle by ensuring reproducible configuration across machines through standardized templates.