### PR TITLE
feat(claude): add Claude Desktop MCP integration

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -127,6 +127,10 @@ ln -sf "$DOT_DEN/.tmux.conf" ~/.tmux.conf
 mkdir -p ~/.aws/amazonq
 ln -sf "$DOT_DEN"/mcp/mcp.json ~/.aws/amazonq/mcp.json
 
+# Claude Desktop MCP integration
+mkdir -p ~/.config/Claude
+ln -sf "$DOT_DEN"/mcp/mcp.json ~/.config/Claude/claude_desktop_config.json
+
 # Set up Git configuration
 echo "Setting up Git configuration..."
 gitconfig_path="$HOME/.gitconfig"


### PR DESCRIPTION
This PR adds Claude Desktop MCP integration to the setup script.

## Changes
- Added configuration to create the Claude Desktop config directory
- Added symlink from `~/.config/Claude/claude_desktop_config.json` to `$DOT_DEN/mcp/mcp.json`
- This allows Claude Desktop to use the same MCP configuration as Amazon Q

## Benefits
- Maintains the "spilled coffee" principle by making Claude Desktop configuration reproducible
- Follows dotfiles philosophy of using setup scripts for symlinks rather than manual commands
- Reuses existing MCP configuration to maintain consistency across AI tools