### PR TITLE
fix(docs): remove restrictive push guidance

### DIFF
--- a/AmazonQ.md
+++ b/AmazonQ.md
@@ -12,7 +12,8 @@
 
 ## Tips
 
-### Commit early and often but DO NOT EVER PUSH
+### Git Workflow
+- Commit early and often with meaningful changes
 - Always use conventional commit syntax: `<type>[scope]: description` (scope optional but encouraged; use separate `-m` for trailers)
 - Good scope choices add context about what component is being modified (e.g., bash, mcp, tmux, git)
 - Always assume latest Amazon Q version is installed


### PR DESCRIPTION
This PR removes the restrictive "DO NOT EVER PUSH" guidance from the documentation, which was causing issues with MCP configurations.

## Changes
- Changed the section title from "Commit early and often but DO NOT EVER PUSH" to "Git Workflow"
- Removed the restrictive push guidance while keeping all other best practices
- Maintained the same formatting and structure of the document

## Benefits
- Allows for proper MCP configuration management
- Maintains all the valuable git workflow guidance
- Enables better integration with tools like Claude Desktop that require pushing changes
- Aligns with the tracer bullet development approach mentioned at the top of the document