### PR TITLE
Use cp instead of symlink for Claude Desktop config

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -129,7 +129,7 @@ ln -sf "$DOT_DEN"/mcp/mcp.json ~/.aws/amazonq/mcp.json
 
 # Claude Desktop MCP integration
 mkdir -p ~/.config/Claude
-ln -sf "$DOT_DEN"/mcp/mcp.json ~/.config/Claude/claude_desktop_config.json
+cp "$DOT_DEN"/mcp/mcp.json ~/.config/Claude/claude_desktop_config.json
 
 # Set up Git configuration
 echo "Setting up Git configuration..."


### PR DESCRIPTION
This PR changes the setup script to use `cp` instead of symlinks (`ln -sf`) for the Claude Desktop configuration file.

## Changes
- Modified setup.sh to use `cp` instead of `ln -sf` for copying the MCP configuration to Claude Desktop

## Rationale
Using a direct copy instead of a symlink ensures that Claude Desktop has its own independent configuration file. This prevents potential issues if the dotfiles repository is moved or if the user wants to make Claude-specific modifications without affecting the main MCP configuration.

This change follows the dotfiles philosophy of making the setup reproducible and robust across different environments.