### PR TITLE
Add External System MCP Integrations (Atlassian and MSSQL)

### DIFF
--- a/.bash_secrets.example
+++ b/.bash_secrets.example
@@ -41,6 +41,16 @@
 # export ATLASSIAN_JIRA_USERNAME="your.email@domain.com"
 # export ATLASSIAN_JIRA_API_TOKEN="your_api_token"
 
+# ==== MSSQL CREDENTIALS ====
+# For secure database access with MSSQL MCP server
+# export MSSQL_DRIVER="your_mssql_driver"
+# export MSSQL_HOST="localhost"
+# export MSSQL_USER="your_username"
+# export MSSQL_PASSWORD="your_password"
+# export MSSQL_DATABASE="your_database"
+# export MSSQL_TRUST_SERVER_CERT="yes"  # Optional
+# export MSSQL_TRUSTED_CONNECTION="no"  # Optional
+
 # ==== COMPANY-SPECIFIC SECRETS ====
 # Add your company-specific secrets here
 # Consider maintaining a separate company-specific dotfiles repo

--- a/.bash_secrets.example
+++ b/.bash_secrets.example
@@ -32,6 +32,15 @@
 # export DEV_DB_CONNECTION="postgresql://user:password@localhost:5432/dbname"
 # export TEST_DB_CONNECTION="postgresql://user:password@localhost:5432/test_dbname"
 
+# ==== ATLASSIAN CREDENTIALS ====
+# Get API tokens from: https://id.atlassian.com/manage-profile/security/api-tokens
+# export ATLASSIAN_CONFLUENCE_URL="https://your-domain.atlassian.net/wiki"
+# export ATLASSIAN_CONFLUENCE_USERNAME="your.email@domain.com"
+# export ATLASSIAN_CONFLUENCE_API_TOKEN="your_api_token"
+# export ATLASSIAN_JIRA_URL="https://your-domain.atlassian.net"
+# export ATLASSIAN_JIRA_USERNAME="your.email@domain.com"
+# export ATLASSIAN_JIRA_API_TOKEN="your_api_token"
+
 # ==== COMPANY-SPECIFIC SECRETS ====
 # Add your company-specific secrets here
 # Consider maintaining a separate company-specific dotfiles repo

--- a/mcp/mcp.json
+++ b/mcp/mcp.json
@@ -66,6 +66,13 @@
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"
       }
+    },
+    "mssql": {
+      "command": "servers/mssql-mcp-wrapper.sh",
+      "args": [],
+      "env": {
+        "FASTMCP_LOG_LEVEL": "ERROR"
+      }
     }
   }
 }

--- a/mcp/mcp.json
+++ b/mcp/mcp.json
@@ -5,8 +5,7 @@
       "args": ["awslabs.core-mcp-server@latest"],
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"
-      },
-      "disabled": false
+      }
     },
     "awslabs.bedrock-kb-retrieval-mcp-server": {
       "command": "uvx",
@@ -15,40 +14,35 @@
         "FASTMCP_LOG_LEVEL": "ERROR",
         "AWS_REGION": "us-east-1",
         "BEDROCK_KB_RERANKING_ENABLED": "false"
-      },
-      "disabled": false
+      }
     },
     "awslabs.aws-diagram-mcp-server": {
       "command": "uvx",
       "args": ["awslabs.aws-diagram-mcp-server"],
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"
-      },
-      "disabled": false
+      }
     },
     "awslabs.cdk-mcp-server": {
       "command": "uvx",
       "args": ["awslabs.cdk-mcp-server@latest"],
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"
-      },
-      "disabled": false
+      }
     },
     "awslabs.aws-documentation-mcp-server": {
       "command": "uvx",
       "args": ["awslabs.aws-documentation-mcp-server@latest"],
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"
-      },
-      "disabled": false
+      }
     },
     "git": {
       "command": "uvx",
       "args": ["kzms-mcp-server-git@latest"],
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"
-      },
-      "disabled": false
+      }
     },
     "gitlab": {
       "command": "npx",
@@ -65,6 +59,13 @@
       "command": "github-mcp-wrapper.sh",
       "args": [],
       "env": {}
+    },
+    "atlassian": {
+      "command": "servers/atlassian-mcp-wrapper.sh",
+      "args": [],
+      "env": {
+        "FASTMCP_LOG_LEVEL": "ERROR"
+      }
     }
   }
 }

--- a/mcp/servers/atlassian-mcp-wrapper.sh
+++ b/mcp/servers/atlassian-mcp-wrapper.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# =========================================================
+# ATLASSIAN MCP WRAPPER SCRIPT
+# =========================================================
+# PURPOSE: Runtime wrapper that executes the MCP Atlassian server
+# This script is called by the MCP system during normal operation
+# It loads credentials from ~/.bash_secrets and passes them to the server
+# 
+# RELATIONSHIP: This is the runtime component that gets executed by the
+# MCP system. The setup-atlassian-mcp.sh script is the one-time setup
+# script that prepares your environment for using this wrapper.
+# =========================================================
+
+# Source secrets file if it exists
+if [ -f ~/.bash_secrets ]; then
+  source ~/.bash_secrets
+else
+  echo "Error: ~/.bash_secrets file not found. Please create it using the template." >&2
+  exit 1
+fi
+
+# Check if required environment variables are set
+if [ -z "$ATLASSIAN_CONFLUENCE_URL" ] || [ -z "$ATLASSIAN_CONFLUENCE_USERNAME" ] || [ -z "$ATLASSIAN_CONFLUENCE_API_TOKEN" ] || \
+   [ -z "$ATLASSIAN_JIRA_URL" ] || [ -z "$ATLASSIAN_JIRA_USERNAME" ] || [ -z "$ATLASSIAN_JIRA_API_TOKEN" ]; then
+  echo "Error: Missing required Atlassian credentials in ~/.bash_secrets" >&2
+  echo "Please add the following variables to your ~/.bash_secrets file:" >&2
+  echo "  export ATLASSIAN_CONFLUENCE_URL=\"https://your-domain.atlassian.net/wiki\"" >&2
+  echo "  export ATLASSIAN_CONFLUENCE_USERNAME=\"your.email@domain.com\"" >&2
+  echo "  export ATLASSIAN_CONFLUENCE_API_TOKEN=\"your_api_token\"" >&2
+  echo "  export ATLASSIAN_JIRA_URL=\"https://your-domain.atlassian.net\"" >&2
+  echo "  export ATLASSIAN_JIRA_USERNAME=\"your.email@domain.com\"" >&2
+  echo "  export ATLASSIAN_JIRA_API_TOKEN=\"your_api_token\"" >&2
+  exit 1
+fi
+
+# Run the MCP Atlassian server with credentials from environment variables
+exec uvx mcp-atlassian \
+  --confluence-url="$ATLASSIAN_CONFLUENCE_URL" \
+  --confluence-username="$ATLASSIAN_CONFLUENCE_USERNAME" \
+  --confluence-token="$ATLASSIAN_CONFLUENCE_API_TOKEN" \
+  --jira-url="$ATLASSIAN_JIRA_URL" \
+  --jira-username="$ATLASSIAN_JIRA_USERNAME" \
+  --jira-token="$ATLASSIAN_JIRA_API_TOKEN"

--- a/mcp/servers/mssql-mcp-wrapper.sh
+++ b/mcp/servers/mssql-mcp-wrapper.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# =========================================================
+# MSSQL MCP WRAPPER SCRIPT
+# =========================================================
+# PURPOSE: Runtime wrapper that executes the MCP MSSQL server
+# This script is called by the MCP system during normal operation
+# It loads credentials from ~/.bash_secrets and passes them to the server
+# 
+# RELATIONSHIP: This is the runtime component that gets executed by the
+# MCP system. The setup-mssql-mcp.sh script is the one-time setup
+# script that prepares your environment for using this wrapper.
+# =========================================================
+
+# Source secrets file if it exists
+if [ -f ~/.bash_secrets ]; then
+  source ~/.bash_secrets
+else
+  echo "Error: ~/.bash_secrets file not found. Please create it using the template." >&2
+  exit 1
+fi
+
+# Check if required environment variables are set
+if [ -z "$MSSQL_DRIVER" ] || [ -z "$MSSQL_HOST" ] || [ -z "$MSSQL_USER" ] || \
+   [ -z "$MSSQL_PASSWORD" ] || [ -z "$MSSQL_DATABASE" ]; then
+  echo "Error: Missing required MSSQL credentials in ~/.bash_secrets" >&2
+  echo "Please add the following variables to your ~/.bash_secrets file:" >&2
+  echo "  export MSSQL_DRIVER=\"your_mssql_driver\"" >&2
+  echo "  export MSSQL_HOST=\"localhost\"" >&2
+  echo "  export MSSQL_USER=\"your_username\"" >&2
+  echo "  export MSSQL_PASSWORD=\"your_password\"" >&2
+  echo "  export MSSQL_DATABASE=\"your_database\"" >&2
+  echo "  export MSSQL_TRUST_SERVER_CERT=\"yes\"  # Optional" >&2
+  echo "  export MSSQL_TRUSTED_CONNECTION=\"no\"  # Optional" >&2
+  exit 1
+fi
+
+# Run the MCP MSSQL server with credentials from environment variables
+exec uvx mssql-mcp-server \
+  --driver="$MSSQL_DRIVER" \
+  --host="$MSSQL_HOST" \
+  --user="$MSSQL_USER" \
+  --password="$MSSQL_PASSWORD" \
+  --database="$MSSQL_DATABASE" \
+  ${MSSQL_TRUST_SERVER_CERT:+--trust-server-cert="$MSSQL_TRUST_SERVER_CERT"} \
+  ${MSSQL_TRUSTED_CONNECTION:+--trusted-connection="$MSSQL_TRUSTED_CONNECTION"}

--- a/mcp/setup-atlassian-mcp.sh
+++ b/mcp/setup-atlassian-mcp.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# =========================================================
+# ATLASSIAN MCP SETUP SCRIPT
+# =========================================================
+# PURPOSE: One-time setup script that prepares your environment
+# This script installs dependencies, creates directories, and
+# guides you through setting up your Atlassian credentials
+# 
+# RELATIONSHIP: This is the one-time setup script that you run
+# manually. It prepares your environment for the atlassian-mcp-wrapper.sh
+# script, which is the runtime component that gets executed by the
+# MCP system during normal operation.
+# =========================================================
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SECRETS_TEMPLATE="${SCRIPT_DIR}/../.bash_secrets.example"
+USER_SECRETS="${HOME}/.bash_secrets"
+
+# Install mcp-atlassian if not already installed
+echo "Checking for mcp-atlassian..."
+if ! command -v uvx &> /dev/null; then
+  echo "Installing uv package manager..."
+  curl -fsSL https://astral.sh/uv/install.sh | sh
+fi
+
+echo "Installing mcp-atlassian..."
+uvx install mcp-atlassian
+
+# Create directories if they don't exist
+mkdir -p "${SCRIPT_DIR}/servers"
+
+# Check if secrets file exists and contains Atlassian credentials
+if [ -f "$USER_SECRETS" ]; then
+  echo "Checking for Atlassian credentials in ~/.bash_secrets..."
+  
+  # Source the secrets file to check for variables
+  source "$USER_SECRETS"
+  
+  # Check if all required variables are set
+  if [ -z "$ATLASSIAN_CONFLUENCE_URL" ] || [ -z "$ATLASSIAN_CONFLUENCE_USERNAME" ] || [ -z "$ATLASSIAN_CONFLUENCE_API_TOKEN" ] || \
+     [ -z "$ATLASSIAN_JIRA_URL" ] || [ -z "$ATLASSIAN_JIRA_USERNAME" ] || [ -z "$ATLASSIAN_JIRA_API_TOKEN" ]; then
+    echo "Atlassian credentials not found in ~/.bash_secrets"
+    echo "Please add the following variables to your ~/.bash_secrets file:"
+    echo "  export ATLASSIAN_CONFLUENCE_URL=\"https://your-domain.atlassian.net/wiki\""
+    echo "  export ATLASSIAN_CONFLUENCE_USERNAME=\"your.email@domain.com\""
+    echo "  export ATLASSIAN_CONFLUENCE_API_TOKEN=\"your_api_token\""
+    echo "  export ATLASSIAN_JIRA_URL=\"https://your-domain.atlassian.net\""
+    echo "  export ATLASSIAN_JIRA_USERNAME=\"your.email@domain.com\""
+    echo "  export ATLASSIAN_JIRA_API_TOKEN=\"your_api_token\""
+    echo ""
+    echo "You can get API tokens from: https://id.atlassian.com/manage-profile/security/api-tokens"
+  else
+    echo "Atlassian credentials found in ~/.bash_secrets"
+  fi
+else
+  echo "~/.bash_secrets file not found"
+  echo "Creating ~/.bash_secrets from template..."
+  cp "$SECRETS_TEMPLATE" "$USER_SECRETS"
+  chmod 600 "$USER_SECRETS"
+  echo "Please edit ~/.bash_secrets to add your Atlassian credentials"
+fi
+
+# Make wrapper script executable
+chmod +x "${SCRIPT_DIR}/servers/atlassian-mcp-wrapper.sh"
+
+echo "Setup complete!"
+echo "To use the Atlassian MCP integration:"
+echo "1. Make sure your credentials are in ~/.bash_secrets"
+echo "2. Restart Amazon Q CLI or Claude Desktop"
+echo ""
+echo "You can test the integration with: uvx @modelcontextprotocol/inspector ${SCRIPT_DIR}/servers/atlassian-mcp-wrapper.sh"

--- a/mcp/setup-mssql-mcp.sh
+++ b/mcp/setup-mssql-mcp.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# =========================================================
+# MSSQL MCP SETUP SCRIPT
+# =========================================================
+# PURPOSE: One-time setup script that prepares your environment
+# This script installs dependencies, creates directories, and
+# guides you through setting up your MSSQL credentials
+# 
+# RELATIONSHIP: This is the one-time setup script that you run
+# manually. It prepares your environment for the mssql-mcp-wrapper.sh
+# script, which is the runtime component that gets executed by the
+# MCP system during normal operation.
+# =========================================================
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SECRETS_TEMPLATE="${SCRIPT_DIR}/../.bash_secrets.example"
+USER_SECRETS="${HOME}/.bash_secrets"
+
+# Install mssql-mcp-server if not already installed
+echo "Checking for mssql-mcp-server..."
+if ! command -v uvx &> /dev/null; then
+  echo "Installing uv package manager..."
+  curl -fsSL https://astral.sh/uv/install.sh | sh
+fi
+
+echo "Installing mssql-mcp-server..."
+uvx install mssql-mcp-server
+
+# Create directories if they don't exist
+mkdir -p "${SCRIPT_DIR}/servers"
+
+# Check if secrets file exists and contains MSSQL credentials
+if [ -f "$USER_SECRETS" ]; then
+  echo "Checking for MSSQL credentials in ~/.bash_secrets..."
+  
+  # Source the secrets file to check for variables
+  source "$USER_SECRETS"
+  
+  # Check if all required variables are set
+  if [ -z "$MSSQL_DRIVER" ] || [ -z "$MSSQL_HOST" ] || [ -z "$MSSQL_USER" ] || \
+     [ -z "$MSSQL_PASSWORD" ] || [ -z "$MSSQL_DATABASE" ]; then
+    echo "MSSQL credentials not found in ~/.bash_secrets"
+    echo "Please add the following variables to your ~/.bash_secrets file:"
+    echo "  export MSSQL_DRIVER=\"your_mssql_driver\"" 
+    echo "  export MSSQL_HOST=\"localhost\""
+    echo "  export MSSQL_USER=\"your_username\""
+    echo "  export MSSQL_PASSWORD=\"your_password\""
+    echo "  export MSSQL_DATABASE=\"your_database\""
+    echo "  export MSSQL_TRUST_SERVER_CERT=\"yes\"  # Optional"
+    echo "  export MSSQL_TRUSTED_CONNECTION=\"no\"  # Optional"
+    echo ""
+    echo "For security best practices:"
+    echo "- Use a dedicated MSSQL user with minimal privileges"
+    echo "- Never use root credentials or full administrative accounts"
+    echo "- Restrict database access to only necessary operations"
+  else
+    echo "MSSQL credentials found in ~/.bash_secrets"
+  fi
+else
+  echo "~/.bash_secrets file not found"
+  echo "Creating ~/.bash_secrets from template..."
+  cp "$SECRETS_TEMPLATE" "$USER_SECRETS"
+  chmod 600 "$USER_SECRETS"
+  echo "Please edit ~/.bash_secrets to add your MSSQL credentials"
+fi
+
+# Make wrapper script executable
+chmod +x "${SCRIPT_DIR}/servers/mssql-mcp-wrapper.sh"
+
+echo "Setup complete!"
+echo "To use the MSSQL MCP integration:"
+echo "1. Make sure your credentials are in ~/.bash_secrets"
+echo "2. Restart Amazon Q CLI or Claude Desktop"
+echo ""
+echo "You can test the integration with: uvx @modelcontextprotocol/inspector ${SCRIPT_DIR}/servers/mssql-mcp-wrapper.sh"


### PR DESCRIPTION
## Description
This PR adds support for two MCP integrations that connect to external systems:
1. **Atlassian MCP Integration** - For interacting with Jira and Confluence
2. **MSSQL MCP Integration** - For secure database access to Microsoft SQL Server

Both implementations follow our dotfiles philosophy:
- **Spilled coffee principle**: Configuration is reproducible across machines
- **Secret management**: Sensitive credentials stored in `~/.bash_secrets`
- **Automation mindset**: Setup scripts for easy installation

## Key Components

### Shared Implementation Pattern
Both integrations follow the same secure pattern:
- Wrapper scripts that load credentials from `~/.bash_secrets` at runtime
- Setup scripts that automate installation and configuration
- Clear documentation and security best practices

### Atlassian Integration
- Added Atlassian MCP server configuration to mcp.json
- Created wrapper script for secure credential handling
- Updated secrets template with Atlassian credential examples

### MSSQL Integration
- Added MSSQL MCP server configuration to mcp.json
- Created wrapper script for secure database credential handling
- Updated secrets template with MSSQL credential examples
- Added security best practices for database access

## Usage

### Atlassian Integration
1. Run the setup script:
   ```bash
   cd ~/ppv/pillars/dotfiles
   ./mcp/setup-atlassian-mcp.sh
   ```
2. Add your Atlassian credentials to `~/.bash_secrets`
3. Restart Amazon Q CLI or Claude Desktop

### MSSQL Integration
1. Run the setup script:
   ```bash
   cd ~/ppv/pillars/dotfiles
   ./mcp/setup-mssql-mcp.sh
   ```
2. Add your MSSQL credentials to `~/.bash_secrets`
3. Restart Amazon Q CLI or Claude Desktop

## Testing
- Tested with the MCP inspector for both integrations
- Verified that credentials are properly loaded from `~/.bash_secrets`
- Confirmed secure handling of sensitive information

## Related Issues
N/A