### PR TITLE
Fix MCP server path configuration

### DIFF
--- a/mcp/mcp.json
+++ b/mcp/mcp.json
@@ -61,7 +61,7 @@
       "env": {}
     },
     "atlassian": {
-      "command": "servers/atlassian-mcp-wrapper.sh",
+      "command": "atlassian-mcp-wrapper.sh",
       "args": [],
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"

--- a/setup.sh
+++ b/setup.sh
@@ -24,6 +24,8 @@ export DOT_DEN
 
 # Add MCP directory to PATH for easier access to MCP scripts
 export PATH="$DOT_DEN/mcp:$PATH"
+# Add MCP servers directory to PATH
+export PATH="$DOT_DEN/mcp/servers:$PATH"
 
 # Export flag to tell subscripts we're running from the main setup
 export SETUP_SCRIPT_RUNNING=true


### PR DESCRIPTION
This PR addresses two related issues with MCP server configuration:

1. Adds the `mcp/servers` directory to PATH in setup.sh for easier access to MCP server scripts
2. Updates the atlassian MCP server command in mcp.json to use the direct script name instead of a relative path

These changes make the MCP server configuration more robust and easier to maintain, as scripts in the servers directory can now be called directly without specifying the full path.

## Changes
- Added `export PATH="$DOT_DEN/mcp/servers:$PATH"` to setup.sh
- Changed `"command": "servers/atlassian-mcp-wrapper.sh"` to `"command": "atlassian-mcp-wrapper.sh"` in mcp.json