### PR TITLE
feat(amazonq): Add qtrust alias for quick tool trust management

### DIFF
--- a/.bash_aliases.amazonq
+++ b/.bash_aliases.amazonq
@@ -1,29 +1,10 @@
 #!/bin/bash
 # Amazon Q aliases and functions
 
-# Function to run Amazon Q with trust permissions setup
-function q() {
-  # Only run setup if this is an interactive chat session
-  if [[ "$1" == "chat" && "$2" != "--no-interactive" ]]; then
-    # Create a temporary script file with commands to run at startup
-    STARTUP_SCRIPT=$(mktemp)
-    cat > "$STARTUP_SCRIPT" << EOF
-/tools trustall
-/tools untrust execute_bash use_aws fs_write
-EOF
-    
-    # Launch Amazon Q with the startup script
-    echo "Launching Amazon Q with trust setup..."
-    command q chat --startup-commands-file "$STARTUP_SCRIPT"
-    
-    # Clean up
-    rm "$STARTUP_SCRIPT"
-    return
-  fi
-  
-  # For all other commands, just pass through
-  command q "$@"
-}
-
-# Export the function
-export -f q
+# Quick alias to trust all tools and then suggest which ones to untrust
+alias qtrust='q chat "/tools trustall" && echo -e "\n\033[1;33mSecurity Tip:\033[0m Consider untrusting tools that modify resources:"
+echo -e "  \033[1;36m/tools untrust fs_write execute_bash use_aws\033[0m"
+echo -e "  \033[1;36m/tools untrust github___create_issue github___add_issue_comment github___push_files\033[0m"
+echo -e "  \033[1;36m/tools untrust github___create_or_update_file github___create_repository\033[0m"
+echo -e "  \033[1;36m/tools untrust gitlab___push_files gitlab___create_or_update_file\033[0m"
+echo -e "  \033[1;36m/tools untrust git___git_commit git___git_add\033[0m"'


### PR DESCRIPTION
## Description
This PR adds a streamlined `qtrust` alias that:
- Runs `q chat "/tools trustall"` to trust all tools
- Provides helpful suggestions about which tools to untrust for security
- Focuses on tools that modify resources (create, update, delete)

## Implementation
- Created a simple alias in `.bash_aliases.amazonq`
- Removed the previous `q()` function implementation
- Added color-coded suggestions for which tools to untrust

## Security Considerations
- The alias provides clear guidance on which tools should be untrusted for security
- Focuses on tools that can modify resources like:
  - File system tools (fs_write)
  - Command execution (execute_bash, use_aws)
  - GitHub/GitLab resource creation and modification tools
  - Git commit/add tools

## Testing
- Verified the alias works correctly
- Confirmed the suggestions are displayed properly with color coding

## Related Issues
Part of the Amazon Q trust setup feature