### PR TITLE
feat(security): update qsafe function with comprehensive untrusted tools list

### DIFF
--- a/.bash_aliases.d/clipboard.sh
+++ b/.bash_aliases.d/clipboard.sh
@@ -10,7 +10,15 @@ alias clip="xclip -selection clipboard"
 # Copy Amazon Q security recommendations to clipboard
 # Works with qtrust alias in q-cli.sh for a complete security workflow
 qsafe() {
-    # Format as a single command with all tools on one line
-    echo "/tools untrust fs_write execute_bash use_aws github___create_issue github___add_issue_comment github___push_files github___create_or_update_file github___create_repository gitlab___push_files gitlab___create_or_update_file git___git_commit git___git_add" | xclip -selection clipboard
+    # Format as a single command with all tools on one line that updates, creates, or deletes resources
+    echo "/tools untrust fs_write execute_bash use_aws git___git_commit git___git_reset \
+    github___create_issue github___add_issue_comment github___push_files github___create_or_update_file github___create_repository \
+    github___fork_repository github___create_branch github___create_pull_request github___merge_pull_request github___add_pull_request_review_comment \
+    gitlab___push_files gitlab___create_or_update_file gitlab___create_repository \
+    atlassian___jira_create_issue atlassian___jira_update_issue atlassian___jira_add_comment atlassian___jira_add_worklog \
+    atlassian___jira_create_issue_link atlassian___confluence_create_page atlassian___confluence_update_page \
+    atlassian___jira_transition_issue atlassian___jira_update_sprint atlassian___jira_delete_issue \
+    atlassian___confluence_delete_page atlassian___jira_remove_issue_link atlassian___confluence_add_label \
+    atlassian___jira_batch_create_issues atlassian___jira_create_sprint atlassian___jira_link_to_epic" | xclip -selection clipboard
 }
 


### PR DESCRIPTION
This PR enhances the security of Amazon Q CLI usage by updating the `qsafe` function with a comprehensive list of tools that should be untrusted.

## Changes
- Added all Atlassian tools that create, update, or delete resources to the untrust list
- Added GitHub tools: fork_repository, create_branch, create_pull_request, merge_pull_request, add_pull_request_review_comment
- Changed git___git_add to git___git_reset in the untrust list
- Improved organization and readability of the function
- Added a more descriptive comment explaining the purpose

## Testing
- Verified that the function correctly copies the command to clipboard
- Confirmed all specified tools are included in the untrust list

This change follows our dotfiles philosophy of making configuration changes reproducible and secure across machines.