### PR TITLE
Add GitHub Copilot integration for Neovim

### DIFF
--- a/nvim/lua/plugins/copilot.lua
+++ b/nvim/lua/plugins/copilot.lua
@@ -1,0 +1,19 @@
+-- GitHub Copilot Configuration
+-- Simple integration with existing Packer setup
+
+return {
+  "github/copilot.vim",
+  config = function()
+    -- Basic settings
+    vim.g.copilot_no_tab_map = true
+    
+    -- Key mappings
+    vim.api.nvim_set_keymap('i', '<C-J>', 'copilot#Accept()', {expr = true, silent = true})
+    vim.api.nvim_set_keymap('i', '<C-]>', '<Plug>(copilot-next)', {silent = true})
+    vim.api.nvim_set_keymap('i', '<C-[>', '<Plug>(copilot-previous)', {silent = true})
+    vim.api.nvim_set_keymap('i', '<C-\\>', '<Plug>(copilot-dismiss)', {silent = true})
+    
+    -- Toggle command
+    vim.api.nvim_set_keymap('n', '<leader>tc', ':Copilot toggle<CR>', {noremap = true, silent = true})
+  end
+}


### PR DESCRIPTION
Closes #201

## Summary
This PR adds a minimal, focused configuration for GitHub Copilot that integrates with our existing Neovim Packer setup.

## Implementation
- Created a single Lua configuration file in `nvim/lua/plugins/copilot.lua`
- Configured intuitive key mappings:
  - `<C-J>` to accept suggestions
  - `<C-]>` for next suggestion
  - `<C-[>` for previous suggestion
  - `<C-\>` to dismiss suggestions
- Added toggle functionality with `<leader>tc`

## User Instructions
After merging this PR:
1. Run `:PackerSync` to install Copilot
2. Run `:Copilot setup` once to authenticate with GitHub
3. Start using Copilot with the configured key bindings

## Follows Dotfiles Philosophy
- Modular approach to configuration
- Clean, focused implementation
- Integrates with existing plugin management system