### PR TITLE
Fix Packer plugin installation failures

### DIFF
--- a/nvim/lua/plugins/init.lua
+++ b/nvim/lua/plugins/init.lua
@@ -1,0 +1,45 @@
+-- Plugin definitions
+return {
+  -- LSP and completion
+  'neovim/nvim-lspconfig',          -- LSP configuration
+  'williamboman/mason.nvim',        -- Package manager for LSP servers
+  'williamboman/mason-lspconfig.nvim', -- Integration with lspconfig
+  
+  -- Autocompletion
+  'hrsh7th/nvim-cmp',               -- Completion engine
+  'hrsh7th/cmp-nvim-lsp',           -- LSP source for nvim-cmp
+  'hrsh7th/cmp-buffer',             -- Buffer source for nvim-cmp
+  'hrsh7th/cmp-path',               -- Path source for nvim-cmp
+  'hrsh7th/cmp-cmdline',            -- Command line source for nvim-cmp
+  'saadparwaiz1/cmp_luasnip',       -- Snippets source for nvim-cmp
+  
+  -- Snippets
+  'L3MON4D3/LuaSnip',               -- Snippet engine
+  'rafamadriz/friendly-snippets',    -- Snippet collection
+  
+  -- LSP enhancements
+  'ray-x/lsp_signature.nvim',       -- Show function signature when typing
+  'folke/lsp-colors.nvim',          -- Better LSP colors
+  
+  -- TreeSitter
+  {'nvim-treesitter/nvim-treesitter', run = ':TSUpdate'},
+  
+  -- Telescope fuzzy finder
+  {'nvim-telescope/telescope.nvim', requires = {'nvim-lua/plenary.nvim'}},
+  
+  -- Git integration with blame support
+  {'lewis6991/gitsigns.nvim', requires = {'nvim-lua/plenary.nvim'}},
+  
+  -- Debugging with full UI
+  'mfussenegger/nvim-dap',
+  'nvim-neotest/nvim-nio',  -- Required dependency for nvim-dap-ui
+  {'rcarriga/nvim-dap-ui', requires = {'mfussenegger/nvim-dap', 'nvim-neotest/nvim-nio'}},
+  'theHamsta/nvim-dap-virtual-text',
+  'nvim-telescope/telescope-dap.nvim',
+  
+  -- Terminal
+  'akinsho/toggleterm.nvim',
+  
+  -- GitHub Copilot
+  'github/copilot.vim',
+}


### PR DESCRIPTION
Closes #203

## Summary
This PR fixes the Packer plugin installation failures that were preventing proper setup of Neovim plugins, including the new Copilot integration.

## Changes
- Created a dedicated `nvim/lua/plugins/init.lua` file with correct plugin specifications
- Fixed the incorrect repository URL for `ray-x/lsp_signature.help` to `ray-x/lsp_signature.nvim`
- Added Copilot to the plugin list for automatic installation

## How to Test
1. Pull this branch
2. Run Neovim
3. Execute `:PackerSync`
4. Verify that all plugins install correctly without errors

## Related Issues
This fixes the plugin installation failures that were preventing the Copilot integration from working properly.