### PR TITLE
Switch GitHub MCP server from Docker to Go build from source

### DIFF
--- a/mcp/github-mcp-wrapper.sh
+++ b/mcp/github-mcp-wrapper.sh
@@ -10,10 +10,17 @@ if [ -z "$TOKEN" ]; then
 fi
 
 # Export the token as an environment variable
-export GITHUB_TOKEN="$TOKEN"
+export GITHUB_PERSONAL_ACCESS_TOKEN="$TOKEN"
+
+# Path to the GitHub MCP server binary
+GITHUB_BINARY_PATH="$(dirname "$0")/servers/github"
+
+# Check if the binary exists and is executable
+if [ ! -x "$GITHUB_BINARY_PATH" ]; then
+  echo "Error: GitHub MCP server binary not found or not executable at $GITHUB_BINARY_PATH" >&2
+  echo "Please run setup-github-mcp.sh first to build the binary" >&2
+  exit 1
+fi
 
 # Run the GitHub MCP server with the token
-exec docker run -i --rm \
-  -e GITHUB_PERSONAL_ACCESS_TOKEN="$GITHUB_TOKEN" \
-  --network=host \
-  ghcr.io/github/github-mcp-server
+exec "$GITHUB_BINARY_PATH" stdio

--- a/mcp/setup-github-mcp.sh
+++ b/mcp/setup-github-mcp.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Get the directory where this setup script is located
+CURRENT_SCRIPT_DIRECTORY="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$CURRENT_SCRIPT_DIRECTORY/utils/mcp-setup-utils.sh"
+
+# Check if Go is installed
+if ! command -v go &> /dev/null; then
+    echo "Error: Go is not installed. Please install Go first."
+    exit 1
+fi
+
+# Create servers directory if it doesn't exist
+mkdir -p "$CURRENT_SCRIPT_DIRECTORY/servers"
+
+# Clone the forked GitHub MCP server repository if it doesn't exist
+if [ ! -d "$CURRENT_SCRIPT_DIRECTORY/servers/github-mcp-server" ]; then
+    echo "Cloning forked GitHub MCP server repository..."
+    git clone https://github.com/atxtechbro/github-mcp-server.git "$CURRENT_SCRIPT_DIRECTORY/servers/github-mcp-server"
+else
+    echo "GitHub MCP server repository already exists, updating..."
+    cd "$CURRENT_SCRIPT_DIRECTORY/servers/github-mcp-server"
+    git pull
+fi
+
+# Build the GitHub MCP server
+echo "Building GitHub MCP server from source..."
+cd "$CURRENT_SCRIPT_DIRECTORY/servers/github-mcp-server"
+go build -o "$CURRENT_SCRIPT_DIRECTORY/servers/github"
+
+# Check if build was successful
+if [ ! -f "$CURRENT_SCRIPT_DIRECTORY/servers/github" ]; then
+    echo "Error: Failed to build GitHub MCP server"
+    exit 1
+fi
+
+# Make the binary executable
+chmod +x "$CURRENT_SCRIPT_DIRECTORY/servers/github"
+
+# Make the wrapper script executable
+chmod +x "$CURRENT_SCRIPT_DIRECTORY/github-mcp-wrapper.sh"
+
+echo "GitHub MCP server setup complete!"
+echo "The server will use your GitHub CLI authentication token."
+echo "Make sure you're logged in with 'gh auth login' before using the GitHub MCP server."

--- a/mcp/utils/mcp-setup-utils.sh
+++ b/mcp/utils/mcp-setup-utils.sh
@@ -36,7 +36,7 @@ get_repo_root() {
 
 # Clone or update the MCP servers repository
 setup_mcp_servers_repo() {
-  local repo_url="${1:-https://github.com/modelcontextprotocol/servers.git}"
+  local repo_url="${1:-https://github.com/atxtechbro/mcp-servers.git}"
   local repo_dir="${2:-/tmp/mcp-servers}"
   
   if [ ! -d "$repo_dir" ]; then


### PR DESCRIPTION
## Changes

This PR switches the GitHub MCP server implementation from using Docker to building from source with Go:

- Created `setup-github-mcp.sh` to build the GitHub MCP server from source
- Updated `github-mcp-wrapper.sh` to use the locally built binary instead of Docker
- Uses our forked repository at https://github.com/atxtechbro/github-mcp-server
- Improves maintainability and allows for customization of the GitHub MCP server

## Benefits

- No Docker dependency for this MCP server
- Faster startup time since it doesn't need to pull or start a container
- Easier to debug and customize
- We can modify the source code in our fork and rebuild as needed

## Usage

To set up the GitHub MCP server:
```bash
./mcp/setup-github-mcp.sh
```

The wrapper script will automatically use the locally built binary.