### PR TITLE
Fix #258: Enhance GitHub MCP setup script to always rebuild binary and improve logging

### DIFF
--- a/mcp/setup-github-mcp.sh
+++ b/mcp/setup-github-mcp.sh
@@ -26,19 +26,32 @@ fi
 # Build the GitHub MCP server
 echo "Building GitHub MCP server from source..."
 cd "$CURRENT_SCRIPT_DIRECTORY/servers/github-mcp-server/cmd/github-mcp-server"
+
+# Remove existing binary if it exists to ensure a fresh build
+if [ -f "$CURRENT_SCRIPT_DIRECTORY/servers/github" ]; then
+    echo "Removing existing binary for clean rebuild..."
+    rm "$CURRENT_SCRIPT_DIRECTORY/servers/github"
+fi
+
+# Build new binary
+echo "Compiling new binary..."
 go build -o "$CURRENT_SCRIPT_DIRECTORY/servers/github"
 
 # Check if build was successful
 if [ ! -f "$CURRENT_SCRIPT_DIRECTORY/servers/github" ]; then
     echo "Error: Failed to build GitHub MCP server"
     exit 1
+else
+    echo "Successfully built new GitHub MCP server binary"
 fi
 
 # Make the binary executable
 chmod +x "$CURRENT_SCRIPT_DIRECTORY/servers/github"
+echo "Made binary executable"
 
 # Make the wrapper script executable
 chmod +x "$CURRENT_SCRIPT_DIRECTORY/github-mcp-wrapper.sh"
+echo "Made wrapper script executable"
 
 echo "GitHub MCP server setup complete!"
 echo "The server will use your GitHub CLI authentication token."


### PR DESCRIPTION
## Description

This PR addresses issue #258 by enhancing the GitHub MCP server setup script to always rebuild the binary and provide clearer logging throughout the process.

## Changes Made

1. Added explicit removal of the existing binary before building a new one
2. Added more detailed logging at each step of the build process:
   - Clear indication when removing the existing binary
   - Message when compiling the new binary
   - Success message when the binary is successfully built
   - Confirmation when making files executable

3. Improved the overall flow of the script to make it clear what's happening at each step

## Testing Done

The script has been tested to ensure it:
- Properly removes existing binaries before rebuilding
- Successfully builds a new binary from source
- Provides clear logging throughout the process
- Maintains all existing functionality

## Screenshots

Before:
```
GitHub MCP server repository already exists, updating...
Already up to date.
Building GitHub MCP server from source...
GitHub MCP server setup complete!
The server will use your GitHub CLI authentication token.
Make sure you're logged in with 'gh auth login' before using the GitHub MCP server.
```

After:
```
GitHub MCP server repository already exists, updating...
Already up to date.
Building GitHub MCP server from source...
Removing existing binary for clean rebuild...
Compiling new binary...
Successfully built new GitHub MCP server binary
Made binary executable
Made wrapper script executable
GitHub MCP server setup complete!
The server will use your GitHub CLI authentication token.
Make sure you're logged in with 'gh auth login' before using the GitHub MCP server.
```

## Closes

Closes #258