### PR TITLE
Fix #260: Remove redundant wrapper script executable code from setup-github-mcp.sh

### DIFF
--- a/mcp/setup-github-mcp.sh
+++ b/mcp/setup-github-mcp.sh
@@ -49,10 +49,6 @@ fi
 chmod +x "$CURRENT_SCRIPT_DIRECTORY/servers/github"
 echo "Made binary executable"
 
-# Make the wrapper script executable
-chmod +x "$CURRENT_SCRIPT_DIRECTORY/github-mcp-wrapper.sh"
-echo "Made wrapper script executable"
-
 echo "GitHub MCP server setup complete!"
 echo "The server will use your GitHub CLI authentication token."
 echo "Make sure you're logged in with 'gh auth login' before using the GitHub MCP server."


### PR DESCRIPTION
## Description

This PR addresses issue #260 by removing the redundant code that makes the wrapper script executable from the GitHub MCP server setup script.

## Changes Made

Removed lines 52-54 from `mcp/setup-github-mcp.sh`:
```bash
# Make the wrapper script executable
chmod +x "$CURRENT_SCRIPT_DIRECTORY/github-mcp-wrapper.sh"
echo "Made wrapper script executable"
```

## Rationale

Since `github-mcp-wrapper.sh` is deliberately checked into the repository with executable permissions already set, these lines are redundant and unnecessary. They don't provide any value and could potentially cause confusion about whether the wrapper script needs to have its permissions modified.

## Benefits

- Cleaner, more focused setup script
- Removes unnecessary operations
- Avoids potential confusion about the wrapper script's permissions
- Follows the principle that the script should only do what's necessary

## Testing Done

Verified that the script still functions correctly without these lines, as the wrapper script already has executable permissions in the repository.

## Closes

Closes #260