### PR TITLE
Fix: Remap F11 debugger step-into key for WSL compatibility

### DIFF
--- a/nvim/debugging-cheatsheet.md
+++ b/nvim/debugging-cheatsheet.md
@@ -9,7 +9,8 @@ A comprehensive guide for debugging in Neovim with DAP (Debug Adapter Protocol) 
 | `<F5>` | Start/continue debugging |
 | `<F9>` | Toggle breakpoint (VS Code style) |
 | `<F10>` | Step over |
-| `<F11>` | Step into |
+| `<F11>` | Step into (may conflict with Windows fullscreen in WSL) |
+| `<leader>si` | Step into (WSL-compatible alternative) |
 | `<F12>` | Step out |
 | `<leader>bp` | Toggle breakpoint (alternative to F9) |
 | `<leader>du` | Toggle DAP UI (variables, stack, watches) |

--- a/nvim/lua/config/dap.lua
+++ b/nvim/lua/config/dap.lua
@@ -145,6 +145,10 @@ end)
 local opts = { noremap = true, silent = true }
 vim.api.nvim_set_keymap('n', '<F5>', "<cmd>lua require('dap').continue()<CR>", opts)
 vim.api.nvim_set_keymap('n', '<F10>', "<cmd>lua require('dap').step_over()<CR>", opts)
+-- Remap F11 (step into) to <Leader>si for WSL compatibility
+-- F11 conflicts with Windows fullscreen toggle in WSL environments
+vim.api.nvim_set_keymap('n', '<Leader>si', "<cmd>lua require('dap').step_into()<CR>", opts)
+-- Keep F11 mapping for non-WSL environments
 vim.api.nvim_set_keymap('n', '<F11>', "<cmd>lua require('dap').step_into()<CR>", opts)
 vim.api.nvim_set_keymap('n', '<F12>', "<cmd>lua require('dap').step_out()<CR>", opts)
 vim.api.nvim_set_keymap('n', '<F9>', "<cmd>lua require('dap').toggle_breakpoint()<CR>", opts)  -- VS Code style


### PR DESCRIPTION
## Description
This PR addresses issue #254 by adding a WSL-compatible alternative keybinding for the debugger step-into functionality.

### Changes
- Added `<Leader>si` as an alternative keybinding for step-into
- Kept the F11 binding for non-WSL environments
- Updated the debugging cheatsheet documentation with the new keybinding information

### Problem
In WSL environments, pressing F11 triggers Windows' fullscreen toggle (showing/hiding the taskbar) instead of executing the debugger step-into command.

### Solution
Added a WSL-compatible alternative keybinding (`<Leader>si`) that doesn't conflict with Windows system shortcuts while maintaining the original F11 binding for non-WSL environments.

Closes #254