### PR TITLE
Add setup script for building filesystem MCP server from source

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -24,7 +24,7 @@ This standardized approach makes it easy to add more MCP servers in the future f
 | Atlassian | Jira and Confluence integration | API tokens from `.bash_secrets` | Custom setup script | - |
 | Google Maps | Google Maps API integration | API key from `.bash_secrets` | Docker container | - |
 | Brave Search | Web search via Brave | API key from `.bash_secrets` | Docker container | - |
-| Filesystem | Local filesystem operations | None required | Docker container | - |
+| Filesystem | Local filesystem operations | None required | Built from source | [Our Fork](https://github.com/atxtechbro/mcp-servers/tree/main/src/filesystem#filesystem-mcp-server) |
 | Google Drive | Google Drive file operations | OAuth credentials from `.bash_secrets` | Docker container | [Official Docs](https://github.com/modelcontextprotocol/servers/tree/main/src/gdrive#authentication) |
 | Slack | Slack messaging and search | Bot token from `.bash_secrets` | Docker container | - |
 
@@ -36,8 +36,9 @@ Each MCP integration has its own setup method:
 - `setup-atlassian-mcp.sh` - Sets up Atlassian (Jira/Confluence) integration
 - `setup-google-maps-mcp.sh` - Sets up Google Maps integration
 - `setup-brave-search-mcp.sh` - Sets up Brave Search integration
-- `setup-filesystem-mcp.sh` - Sets up Filesystem integration
+- `setup-filesystem-mcp.sh` - Sets up Filesystem integration from source (allows customization)
 - `setup-gdrive-mcp.sh` - Sets up Google Drive integration
+- `setup-github-mcp.sh` - Sets up GitHub integration from source
 - `setup-slack-mcp.sh` - Sets up Slack integration
 
 For custom integrations, run the appropriate setup script:

--- a/mcp/filesystem-mcp-wrapper.sh
+++ b/mcp/filesystem-mcp-wrapper.sh
@@ -7,7 +7,15 @@
 # This script is called by the MCP system during normal operation
 # =========================================================
 
-# Run the Filesystem MCP server with the user's home directory
-# This approach uses npx directly and works across different computers
-# with different usernames by using $HOME
-exec npx -y @modelcontextprotocol/server-filesystem "$HOME"
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Check if the built version exists
+if [ -f "$SCRIPT_DIR/servers/mcp-servers/src/filesystem/dist/index.js" ]; then
+    # Use the built version
+    exec node "$SCRIPT_DIR/servers/mcp-servers/src/filesystem/dist/index.js" "$HOME"
+else
+    # Fallback to npx version if build doesn't exist
+    echo "Warning: Built version not found, falling back to npx version" >&2
+    exec npx -y @modelcontextprotocol/server-filesystem "$HOME"
+fi

--- a/mcp/setup-filesystem-mcp.sh
+++ b/mcp/setup-filesystem-mcp.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# =========================================================
+# FILESYSTEM MCP SERVER SETUP SCRIPT
+# =========================================================
+# PURPOSE: Sets up the Filesystem MCP server from source
+# This allows customization of the server code to fix issues
+# =========================================================
+
+# Get the directory where this setup script is located
+CURRENT_SCRIPT_DIRECTORY="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$CURRENT_SCRIPT_DIRECTORY/utils/mcp-setup-utils.sh"
+
+# Check if Node.js is installed
+if ! command -v node &> /dev/null; then
+    echo "Error: Node.js is not installed. Please install Node.js first."
+    exit 1
+fi
+
+# Check if npm is installed
+if ! command -v npm &> /dev/null; then
+    echo "Error: npm is not installed. Please install npm first."
+    exit 1
+fi
+
+# Check if TypeScript is installed globally
+if ! command -v tsc &> /dev/null; then
+    echo "TypeScript not found. Installing TypeScript..."
+    npm install -g typescript
+fi
+
+# Create servers directory if it doesn't exist
+mkdir -p "$CURRENT_SCRIPT_DIRECTORY/servers"
+
+# Clone the forked MCP servers repository if it doesn't exist
+if [ ! -d "$CURRENT_SCRIPT_DIRECTORY/servers/mcp-servers" ]; then
+    echo "Cloning forked MCP servers repository..."
+    git clone https://github.com/atxtechbro/mcp-servers.git "$CURRENT_SCRIPT_DIRECTORY/servers/mcp-servers"
+else
+    echo "MCP servers repository already exists, updating..."
+    cd "$CURRENT_SCRIPT_DIRECTORY/servers/mcp-servers"
+    git pull
+fi
+
+# Build the Filesystem MCP server
+echo "Building Filesystem MCP server from source..."
+cd "$CURRENT_SCRIPT_DIRECTORY/servers/mcp-servers/src/filesystem"
+
+# Install dependencies
+echo "Installing dependencies..."
+npm install
+
+# Build the TypeScript code
+echo "Compiling TypeScript..."
+npm run build
+
+# Check if build was successful
+if [ ! -d "$CURRENT_SCRIPT_DIRECTORY/servers/mcp-servers/src/filesystem/dist" ]; then
+    echo "Error: Failed to build Filesystem MCP server"
+    exit 1
+else
+    echo "Successfully built Filesystem MCP server"
+fi
+
+# Make the entry point executable
+chmod +x "$CURRENT_SCRIPT_DIRECTORY/servers/mcp-servers/src/filesystem/dist/index.js"
+echo "Made entry point executable"
+
+echo "Filesystem MCP server setup complete!"
+echo "The wrapper script will now use the built version with fallback to npx if needed."

--- a/mcp/setup-filesystem-mcp.sh
+++ b/mcp/setup-filesystem-mcp.sh
@@ -6,6 +6,9 @@
 # PURPOSE: Sets up the Filesystem MCP server from source
 # This allows customization of the server code to fix issues
 # =========================================================
+# IMPORTANT: This script assumes you've already forked the
+# modelcontextprotocol/servers repository to your GitHub account
+# =========================================================
 
 # Get the directory where this setup script is located
 CURRENT_SCRIPT_DIRECTORY="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -32,12 +35,15 @@ fi
 # Create servers directory if it doesn't exist
 mkdir -p "$CURRENT_SCRIPT_DIRECTORY/servers"
 
-# Clone the forked MCP servers repository if it doesn't exist
+# Clone your existing fork of the MCP servers repository if it doesn't exist locally
+# Note: This assumes you've already forked https://github.com/modelcontextprotocol/servers to
+# https://github.com/atxtechbro/mcp-servers on GitHub
 if [ ! -d "$CURRENT_SCRIPT_DIRECTORY/servers/mcp-servers" ]; then
-    echo "Cloning forked MCP servers repository..."
+    echo "Cloning your existing fork of the MCP servers repository..."
+    echo "Note: This does NOT create a new fork on GitHub, just clones your existing one"
     git clone https://github.com/atxtechbro/mcp-servers.git "$CURRENT_SCRIPT_DIRECTORY/servers/mcp-servers"
 else
-    echo "MCP servers repository already exists, updating..."
+    echo "Your forked MCP servers repository already exists locally, updating..."
     cd "$CURRENT_SCRIPT_DIRECTORY/servers/mcp-servers"
     git pull
 fi

--- a/mcp/tests/test-filesystem-mcp.md
+++ b/mcp/tests/test-filesystem-mcp.md
@@ -1,0 +1,112 @@
+# Filesystem MCP Server Test Guide
+
+This document provides instructions for testing the Filesystem MCP server integration.
+
+## Prerequisites
+
+1. The Filesystem MCP server has been set up using `setup-filesystem-mcp.sh`
+2. Amazon Q or another MCP client is configured to use the server
+
+## Test Cases
+
+### Basic File Operations
+
+1. **Reading a file**
+   ```
+   Show me the contents of ~/.bashrc
+   ```
+   Expected: The file contents should be displayed correctly.
+
+2. **Listing a directory**
+   ```
+   List the files in my home directory
+   ```
+   Expected: A list of files and directories in your home directory.
+
+3. **Getting file information**
+   ```
+   Get information about ~/.bash_profile
+   ```
+   Expected: File metadata like size, permissions, and timestamps.
+
+### Special Character Handling
+
+1. **Files with spaces**
+   ```
+   Create a file named "test file with spaces.txt" with the content "This is a test"
+   ```
+   Expected: The file should be created successfully.
+
+   ```
+   Read the file "test file with spaces.txt"
+   ```
+   Expected: The file contents should be displayed correctly.
+
+2. **Files with special characters**
+   ```
+   Create a file named "test-file-with-special-chars!@#.txt" with the content "Special characters test"
+   ```
+   Expected: The file should be created successfully.
+
+   ```
+   Read the file "test-file-with-special-chars!@#.txt"
+   ```
+   Expected: The file contents should be displayed correctly.
+
+3. **Unicode filenames**
+   ```
+   Create a file named "测试文件.txt" with the content "Unicode filename test"
+   ```
+   Expected: The file should be created successfully.
+
+   ```
+   Read the file "测试文件.txt"
+   ```
+   Expected: The file contents should be displayed correctly.
+
+### Path Traversal Protection
+
+1. **Attempt path traversal**
+   ```
+   Show me the contents of ../../../etc/passwd
+   ```
+   Expected: The server should prevent access to files outside allowed directories.
+
+### Symbolic Link Handling
+
+1. **Create and follow a symbolic link**
+   ```
+   Create a symbolic link named "test-link" to ~/.bashrc
+   ```
+   Expected: The symbolic link should be created successfully.
+
+   ```
+   Read the file "test-link"
+   ```
+   Expected: The contents of ~/.bashrc should be displayed.
+
+### Cleanup
+
+After testing, clean up the test files:
+
+```
+Delete the files "test file with spaces.txt", "test-file-with-special-chars!@#.txt", "测试文件.txt", and "test-link"
+```
+
+## Troubleshooting
+
+If you encounter issues:
+
+1. Check that the built version exists at `mcp/servers/mcp-servers/src/filesystem/dist/index.js`
+2. Verify that the wrapper script is using the built version
+3. Check for error messages in the MCP client output
+4. Try rebuilding the server using `setup-filesystem-mcp.sh`
+
+## Reporting Issues
+
+If you find bugs or have suggestions for improvements, please create an issue in the repository with:
+
+1. A clear description of the problem
+2. Steps to reproduce the issue
+3. Expected vs. actual behavior
+4. Any error messages or logs


### PR DESCRIPTION
## Overview

This PR implements the solution for issue #263 by adding a setup script to build the filesystem MCP server from source, similar to how we implemented the GitHub MCP server build process.

## Changes

- Created `setup-filesystem-mcp.sh` that:
  - Clones our fork of the mcp-servers repository
  - Installs dependencies
  - Builds the TypeScript code
  - Makes the built script executable
- Updated `filesystem-mcp-wrapper.sh` to use the built version with fallback to npx
- Updated `README.md` to reflect the new build-from-source approach
- Added test documentation in `tests/test-filesystem-mcp.md`

## Implementation Details

The setup script follows the same pattern as our GitHub MCP server setup:
1. Checks for required dependencies (Node.js, npm, TypeScript)
2. Clones our fork of the mcp-servers repository
3. Builds the TypeScript code
4. Makes the entry point executable

The wrapper script now checks if the built version exists and uses it, with a fallback to the npx version if the build is not available. This ensures resilience and follows our "spilled coffee" principle.

## Testing

The implementation has been tested with:
- Basic file operations
- Files with special characters in their names
- Path traversal protection
- Symbolic link handling

## Related Issues

Fixes #263