### PR TITLE
Remove unused AWS Diagram and GitLab MCP servers

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -19,7 +19,7 @@ This standardized approach makes it easy to add more MCP servers in the future f
 
 | Integration | Description | Authentication Method | Installation Method | Documentation |
 |-------------|-------------|----------------------|---------------------|---------------|
-| AWS Labs | AWS documentation, diagrams, CDK | None required | PyPI packages via UVX | - |
+| AWS Labs | AWS documentation, CDK | None required | PyPI packages via UVX | - |
 | GitHub | GitHub API integration | Uses GitHub CLI token | Custom setup script | [Our Fork](https://github.com/atxtechbro/github-mcp-server?tab=readme-ov-file#github-mcp-server) |
 | Atlassian | Jira and Confluence integration | API tokens from `.bash_secrets` | Custom setup script | - |
 | Google Maps | Google Maps API integration | API key from `.bash_secrets` | Docker container | - |

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -24,7 +24,7 @@ This standardized approach makes it easy to add more MCP servers in the future f
 | Atlassian | Jira and Confluence integration | API tokens from `.bash_secrets` | Custom setup script | - |
 | Google Maps | Google Maps API integration | API key from `.bash_secrets` | Docker container | - |
 | Brave Search | Web search via Brave | API key from `.bash_secrets` | Docker container | - |
-| Filesystem | Local filesystem operations | None required | Docker container | - |
+| Filesystem | Local filesystem operations | None required | Built from source | [Our Fork](https://github.com/atxtechbro/mcp-servers/tree/main/src/filesystem#filesystem-mcp-server) |
 | Google Drive | Google Drive file operations | OAuth credentials from `.bash_secrets` | Docker container | [Official Docs](https://github.com/modelcontextprotocol/servers/tree/main/src/gdrive#authentication) |
 | Slack | Slack messaging and search | Bot token from `.bash_secrets` | Docker container | - |
 
@@ -36,8 +36,9 @@ Each MCP integration has its own setup method:
 - `setup-atlassian-mcp.sh` - Sets up Atlassian (Jira/Confluence) integration
 - `setup-google-maps-mcp.sh` - Sets up Google Maps integration
 - `setup-brave-search-mcp.sh` - Sets up Brave Search integration
-- `setup-filesystem-mcp.sh` - Sets up Filesystem integration
+- `setup-filesystem-mcp.sh` - Sets up Filesystem integration from source (allows customization)
 - `setup-gdrive-mcp.sh` - Sets up Google Drive integration
+- `setup-github-mcp.sh` - Sets up GitHub integration from source
 - `setup-slack-mcp.sh` - Sets up Slack integration
 
 For custom integrations, run the appropriate setup script:

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -25,6 +25,7 @@ This standardized approach makes it easy to add more MCP servers in the future f
 | Google Maps | Google Maps API integration | API key from `.bash_secrets` | Docker container | - |
 | Brave Search | Web search via Brave | API key from `.bash_secrets` | Docker container | - |
 | Filesystem | Local filesystem operations | None required | Built from source | [Our Fork](https://github.com/atxtechbro/mcp-servers/tree/main/src/filesystem#filesystem-mcp-server) |
+| Git | Git repository operations | None required | Built from source | [Original Repo](https://github.com/cyanheads/git-mcp-server#git-mcp-server) |
 | Google Drive | Google Drive file operations | OAuth credentials from `.bash_secrets` | Docker container | [Official Docs](https://github.com/modelcontextprotocol/servers/tree/main/src/gdrive#authentication) |
 | Slack | Slack messaging and search | Bot token from `.bash_secrets` | Docker container | - |
 
@@ -39,6 +40,7 @@ Each MCP integration has its own setup method:
 - `setup-filesystem-mcp.sh` - Sets up Filesystem integration from source (allows customization)
 - `setup-gdrive-mcp.sh` - Sets up Google Drive integration
 - `setup-github-mcp.sh` - Sets up GitHub integration from source
+- `setup-git-mcp.sh` - Sets up Git integration from source
 - `setup-slack-mcp.sh` - Sets up Slack integration
 
 For custom integrations, run the appropriate setup script:

--- a/mcp/filesystem-mcp-wrapper.sh
+++ b/mcp/filesystem-mcp-wrapper.sh
@@ -7,7 +7,15 @@
 # This script is called by the MCP system during normal operation
 # =========================================================
 
-# Run the Filesystem MCP server with the user's home directory
-# This approach uses npx directly and works across different computers
-# with different usernames by using $HOME
-exec npx -y @modelcontextprotocol/server-filesystem "$HOME"
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Check if the built version exists
+if [ -f "$SCRIPT_DIR/servers/mcp-servers/src/filesystem/dist/index.js" ]; then
+    # Use the built version
+    exec node "$SCRIPT_DIR/servers/mcp-servers/src/filesystem/dist/index.js" "$HOME"
+else
+    # Fallback to npx version if build doesn't exist
+    echo "Warning: Built version not found, falling back to npx version" >&2
+    exec npx -y @modelcontextprotocol/server-filesystem "$HOME"
+fi

--- a/mcp/git-mcp-wrapper.sh
+++ b/mcp/git-mcp-wrapper.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# =========================================================
+# GIT MCP WRAPPER SCRIPT
+# =========================================================
+# PURPOSE: Runtime wrapper that executes the Git MCP server
+# This script is called by the MCP system during normal operation
+# =========================================================
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# No fallback - ride or die with the built version
+exec node "$SCRIPT_DIR/servers/git-mcp-server/dist/index.js"

--- a/mcp/mcp.json
+++ b/mcp/mcp.json
@@ -38,8 +38,8 @@
       }
     },
     "git": {
-      "command": "uvx",
-      "args": ["kzms-mcp-server-git@latest"],
+      "command": "git-mcp-wrapper.sh",
+      "args": [],
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"
       }

--- a/mcp/mcp.json
+++ b/mcp/mcp.json
@@ -16,13 +16,7 @@
         "BEDROCK_KB_RERANKING_ENABLED": "false"
       }
     },
-    "awslabs.aws-diagram-mcp-server": {
-      "command": "uvx",
-      "args": ["awslabs.aws-diagram-mcp-server"],
-      "env": {
-        "FASTMCP_LOG_LEVEL": "ERROR"
-      }
-    },
+
     "awslabs.cdk-mcp-server": {
       "command": "uvx",
       "args": ["awslabs.cdk-mcp-server@latest"],
@@ -44,17 +38,7 @@
         "FASTMCP_LOG_LEVEL": "ERROR"
       }
     },
-    "gitlab": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@modelcontextprotocol/server-gitlab"
-      ],
-      "env": {
-        "GITLAB_PERSONAL_ACCESS_TOKEN": "<YOUR_TOKEN>",
-        "GITLAB_API_URL": "https://gitlab.com/api/v4"
-      }
-    },
+
     "github": {
       "command": "github-mcp-wrapper.sh",
       "args": [],

--- a/mcp/setup-filesystem-mcp.sh
+++ b/mcp/setup-filesystem-mcp.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# =========================================================
+# FILESYSTEM MCP SERVER SETUP SCRIPT
+# =========================================================
+# PURPOSE: Sets up the Filesystem MCP server from source
+# This allows customization of the server code to fix issues
+# =========================================================
+
+# Get the directory where this setup script is located
+CURRENT_SCRIPT_DIRECTORY="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$CURRENT_SCRIPT_DIRECTORY/utils/mcp-setup-utils.sh"
+
+# Check if Node.js is installed
+if ! command -v node &> /dev/null; then
+    echo "Error: Node.js is not installed. Please install Node.js first."
+    exit 1
+fi
+
+# Check if npm is installed
+if ! command -v npm &> /dev/null; then
+    echo "Error: npm is not installed. Please install npm first."
+    exit 1
+fi
+
+# Check if TypeScript is installed globally
+if ! command -v tsc &> /dev/null; then
+    echo "TypeScript not found. Installing TypeScript..."
+    npm install -g typescript
+fi
+
+# Create servers directory if it doesn't exist
+mkdir -p "$CURRENT_SCRIPT_DIRECTORY/servers"
+
+# Clone the forked MCP servers repository if it doesn't exist
+if [ ! -d "$CURRENT_SCRIPT_DIRECTORY/servers/mcp-servers" ]; then
+    echo "Cloning forked MCP servers repository..."
+    git clone https://github.com/atxtechbro/mcp-servers.git "$CURRENT_SCRIPT_DIRECTORY/servers/mcp-servers"
+else
+    echo "MCP servers repository already exists, updating..."
+    cd "$CURRENT_SCRIPT_DIRECTORY/servers/mcp-servers"
+    git pull
+fi
+
+# Build the Filesystem MCP server
+echo "Building Filesystem MCP server from source..."
+cd "$CURRENT_SCRIPT_DIRECTORY/servers/mcp-servers/src/filesystem"
+
+# Install dependencies
+echo "Installing dependencies..."
+npm install
+
+# Build the TypeScript code
+echo "Compiling TypeScript..."
+npm run build
+
+# Check if build was successful
+if [ ! -d "$CURRENT_SCRIPT_DIRECTORY/servers/mcp-servers/src/filesystem/dist" ]; then
+    echo "Error: Failed to build Filesystem MCP server"
+    exit 1
+else
+    echo "Successfully built Filesystem MCP server"
+fi
+
+# Make the entry point executable
+chmod +x "$CURRENT_SCRIPT_DIRECTORY/servers/mcp-servers/src/filesystem/dist/index.js"
+echo "Made entry point executable"
+
+echo "Filesystem MCP server setup complete!"
+echo "The wrapper script will now use the built version with fallback to npx if needed."

--- a/mcp/setup-filesystem-mcp.sh
+++ b/mcp/setup-filesystem-mcp.sh
@@ -6,6 +6,9 @@
 # PURPOSE: Sets up the Filesystem MCP server from source
 # This allows customization of the server code to fix issues
 # =========================================================
+# IMPORTANT: This script assumes you've already forked the
+# modelcontextprotocol/servers repository to your GitHub account
+# =========================================================
 
 # Get the directory where this setup script is located
 CURRENT_SCRIPT_DIRECTORY="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -32,12 +35,15 @@ fi
 # Create servers directory if it doesn't exist
 mkdir -p "$CURRENT_SCRIPT_DIRECTORY/servers"
 
-# Clone the forked MCP servers repository if it doesn't exist
+# Clone your existing fork of the MCP servers repository if it doesn't exist locally
+# Note: This assumes you've already forked https://github.com/modelcontextprotocol/servers to
+# https://github.com/atxtechbro/mcp-servers on GitHub
 if [ ! -d "$CURRENT_SCRIPT_DIRECTORY/servers/mcp-servers" ]; then
-    echo "Cloning forked MCP servers repository..."
+    echo "Cloning your existing fork of the MCP servers repository..."
+    echo "Note: This does NOT create a new fork on GitHub, just clones your existing one"
     git clone https://github.com/atxtechbro/mcp-servers.git "$CURRENT_SCRIPT_DIRECTORY/servers/mcp-servers"
 else
-    echo "MCP servers repository already exists, updating..."
+    echo "Your forked MCP servers repository already exists locally, updating..."
     cd "$CURRENT_SCRIPT_DIRECTORY/servers/mcp-servers"
     git pull
 fi

--- a/mcp/setup-git-mcp.sh
+++ b/mcp/setup-git-mcp.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# =========================================================
+# GIT MCP SERVER SETUP SCRIPT
+# =========================================================
+# PURPOSE: Sets up the Git MCP server from source
+# This allows customization of the server code to fix issues
+# and add features like git worktree support
+# =========================================================
+# IMPORTANT: This script assumes you've already forked the
+# cyanheads/git-mcp-server repository to your GitHub account
+# =========================================================
+
+# Get the directory where this setup script is located
+CURRENT_SCRIPT_DIRECTORY="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$CURRENT_SCRIPT_DIRECTORY/utils/mcp-setup-utils.sh"
+
+# Check if Node.js is installed
+if ! command -v node &> /dev/null; then
+    echo "Error: Node.js is not installed. Please install Node.js first."
+    exit 1
+fi
+
+# Check if npm is installed
+if ! command -v npm &> /dev/null; then
+    echo "Error: npm is not installed. Please install npm first."
+    exit 1
+fi
+
+# Check if Git is installed
+if ! command -v git &> /dev/null; then
+    echo "Error: Git is not installed. Please install Git first."
+    exit 1
+fi
+
+# Create servers directory if it doesn't exist
+mkdir -p "$CURRENT_SCRIPT_DIRECTORY/servers"
+
+# Clone your existing fork of the Git MCP server repository if it doesn't exist locally
+# Note: This assumes you've already forked https://github.com/cyanheads/git-mcp-server to
+# https://github.com/atxtechbro/git-mcp-server on GitHub
+if [ ! -d "$CURRENT_SCRIPT_DIRECTORY/servers/git-mcp-server" ]; then
+    echo "Cloning your existing fork of the Git MCP server repository..."
+    echo "Note: This does NOT create a new fork on GitHub, just clones your existing one"
+    git clone https://github.com/atxtechbro/git-mcp-server.git "$CURRENT_SCRIPT_DIRECTORY/servers/git-mcp-server"
+else
+    echo "Your forked Git MCP server repository already exists locally, updating..."
+    cd "$CURRENT_SCRIPT_DIRECTORY/servers/git-mcp-server"
+    git pull
+fi
+
+# Build the Git MCP server
+echo "Building Git MCP server from source..."
+cd "$CURRENT_SCRIPT_DIRECTORY/servers/git-mcp-server"
+
+# Install dependencies
+echo "Installing dependencies..."
+npm install
+
+# Build the TypeScript code
+echo "Compiling TypeScript..."
+npm run build
+
+# Check if build was successful
+if [ ! -d "$CURRENT_SCRIPT_DIRECTORY/servers/git-mcp-server/dist" ]; then
+    echo "Error: Failed to build Git MCP server"
+    exit 1
+else
+    echo "Successfully built Git MCP server"
+fi
+
+# Make the entry point executable
+chmod +x "$CURRENT_SCRIPT_DIRECTORY/servers/git-mcp-server/dist/index.js"
+echo "Made entry point executable"
+
+echo "Git MCP server setup complete!"
+echo "The wrapper script will now use the built version with fallback to the original implementation if needed."

--- a/mcp/setup-git-mcp.sh
+++ b/mcp/setup-git-mcp.sh
@@ -74,4 +74,4 @@ chmod +x "$CURRENT_SCRIPT_DIRECTORY/servers/git-mcp-server/dist/index.js"
 echo "Made entry point executable"
 
 echo "Git MCP server setup complete!"
-echo "The wrapper script will now use the built version with fallback to the original implementation if needed."
+echo "The wrapper script will now use the built version exclusively (ride or die)."

--- a/mcp/tests/README.md
+++ b/mcp/tests/README.md
@@ -1,21 +1,63 @@
-# MCP Integration Tests
+# MCP Server Tests
 
-This directory contains test cases and instructions for testing MCP server integrations.
+This directory contains tests for the MCP servers in this repository.
 
 ## Test Structure
 
-- `google_maps_mcp_tests.md` - Specific test cases for Google Maps MCP integration
-- `AmazonQ.md` - Instructions for running tests with Amazon Q
+- `lib/test-harness.sh`: Common test functions and utilities
+- `test-*-mcp.md`: Manual test documentation for each MCP server
+- `test-*-mcp.sh`: Automated test scripts for each MCP server
 
 ## Running Tests
 
-Tests in this directory are designed to be run with Amazon Q CLI. Follow the instructions in `AmazonQ.md` for proper test execution.
+To run tests for a specific MCP server:
+
+```bash
+# Run Git MCP server tests with Amazon Q
+./test-git-mcp.sh
+
+# Run with a different model (if supported)
+TEST_MODEL=claude ./test-git-mcp.sh
+```
+
+## Test Harness
+
+The test harness provides common functions for all test scripts:
+
+- `run_test`: Run a test with a command and expected output pattern
+- `skip_test`: Skip a test with a reason
+- `init_test_suite`: Initialize a test suite with a name
+- `print_summary`: Print a summary of test results
 
 ## Adding New Tests
 
-When adding new tests:
+1. Create a new test script based on the existing ones
+2. Source the common test harness
+3. Define tests using `run_test` and `skip_test` functions
+4. Add cleanup code if needed
 
-1. Create a descriptive test case file (e.g., `github_mcp_tests.md`)
-2. Follow the same format as existing test files
-3. Include expected outputs for verification
-4. Update this README with the new test file information
+Example:
+
+```bash
+#!/bin/bash
+
+# Source the common test harness
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/test-harness.sh"
+
+# Initialize test suite
+init_test_suite "MY MCP SERVER"
+
+# Run tests
+run_test "Test Name" "Command to run" "expected|output|pattern"
+
+# Print summary
+print_summary
+```
+
+## Future Improvements
+
+- Support for more AI models
+- Parameterized testing
+- Test result reporting and visualization
+- Integration with CI/CD pipelines

--- a/mcp/tests/lib/test-harness.sh
+++ b/mcp/tests/lib/test-harness.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+# =========================================================
+# MCP SERVER TEST HARNESS
+# =========================================================
+# PURPOSE: Common functions for MCP server testing
+# This library provides reusable functions for all MCP server tests
+# =========================================================
+
+# Colors for output
+export GREEN='\033[0;32m'
+export RED='\033[0;31m'
+export YELLOW='\033[0;33m'
+export BLUE='\033[0;34m'
+export NC='\033[0m' # No Color
+
+# Test counter
+export TOTAL=0
+export PASSED=0
+export FAILED=0
+export SKIPPED=0
+
+# Default model to use for testing
+export TEST_MODEL=${TEST_MODEL:-"q"}
+
+# Function to run a test
+run_test() {
+  local test_name="$1"
+  local command="$2"
+  local expected_pattern="$3"
+  
+  echo -e "\n${BLUE}TEST:${NC} $test_name"
+  echo "Command: $command"
+  TOTAL=$((TOTAL+1))
+  
+  # Run the command through the specified model CLI
+  echo "Running test through $TEST_MODEL CLI..."
+  
+  case "$TEST_MODEL" in
+    q)
+      result=$($TEST_MODEL chat --no-interactive "$command" 2>/dev/null)
+      ;;
+    claude)
+      # Assuming claude CLI has similar interface
+      result=$($TEST_MODEL chat --no-interactive "$command" 2>/dev/null)
+      ;;
+    *)
+      echo -e "${RED}Error: Unknown model $TEST_MODEL${NC}"
+      FAILED=$((FAILED+1))
+      return 1
+      ;;
+  esac
+  
+  # Check if the result contains the expected pattern
+  if echo "$result" | grep -q -E "$expected_pattern"; then
+    echo -e "${GREEN}✓ PASSED${NC}: Output contains expected pattern"
+    PASSED=$((PASSED+1))
+  else
+    echo -e "${RED}✗ FAILED${NC}: Expected pattern not found"
+    echo "Expected pattern: $expected_pattern"
+    echo "Result excerpt: ${result:0:200}..."
+    FAILED=$((FAILED+1))
+  fi
+  echo "----------------------------------------"
+}
+
+# Function to skip a test
+skip_test() {
+  local test_name="$1"
+  local reason="$2"
+  
+  echo -e "\n${BLUE}TEST:${NC} $test_name"
+  echo -e "${YELLOW}⚠ SKIPPED${NC}: $reason"
+  SKIPPED=$((SKIPPED+1))
+  TOTAL=$((TOTAL+1))
+  echo "----------------------------------------"
+}
+
+# Function to print test summary
+print_summary() {
+  echo "=========================================="
+  echo "SUMMARY: $PASSED/$TOTAL tests passed"
+  if [ $FAILED -gt 0 ]; then
+    echo -e "${RED}$FAILED tests failed${NC}"
+  fi
+  if [ $SKIPPED -gt 0 ]; then
+    echo -e "${YELLOW}$SKIPPED tests skipped${NC}"
+  fi
+  echo "=========================================="
+}
+
+# Function to initialize test suite
+init_test_suite() {
+  local suite_name="$1"
+  
+  echo "=========================================="
+  echo "RUNNING $suite_name TESTS"
+  echo "=========================================="
+  echo "Date: $(date)"
+  echo "Working directory: $(pwd)"
+  echo "Model: $TEST_MODEL"
+  echo "=========================================="
+}
+
+# Export functions
+export -f run_test
+export -f skip_test
+export -f print_summary
+export -f init_test_suite

--- a/mcp/tests/test-filesystem-mcp.md
+++ b/mcp/tests/test-filesystem-mcp.md
@@ -1,0 +1,112 @@
+# Filesystem MCP Server Test Guide
+
+This document provides instructions for testing the Filesystem MCP server integration.
+
+## Prerequisites
+
+1. The Filesystem MCP server has been set up using `setup-filesystem-mcp.sh`
+2. Amazon Q or another MCP client is configured to use the server
+
+## Test Cases
+
+### Basic File Operations
+
+1. **Reading a file**
+   ```
+   Show me the contents of ~/.bashrc
+   ```
+   Expected: The file contents should be displayed correctly.
+
+2. **Listing a directory**
+   ```
+   List the files in my home directory
+   ```
+   Expected: A list of files and directories in your home directory.
+
+3. **Getting file information**
+   ```
+   Get information about ~/.bash_profile
+   ```
+   Expected: File metadata like size, permissions, and timestamps.
+
+### Special Character Handling
+
+1. **Files with spaces**
+   ```
+   Create a file named "test file with spaces.txt" with the content "This is a test"
+   ```
+   Expected: The file should be created successfully.
+
+   ```
+   Read the file "test file with spaces.txt"
+   ```
+   Expected: The file contents should be displayed correctly.
+
+2. **Files with special characters**
+   ```
+   Create a file named "test-file-with-special-chars!@#.txt" with the content "Special characters test"
+   ```
+   Expected: The file should be created successfully.
+
+   ```
+   Read the file "test-file-with-special-chars!@#.txt"
+   ```
+   Expected: The file contents should be displayed correctly.
+
+3. **Unicode filenames**
+   ```
+   Create a file named "测试文件.txt" with the content "Unicode filename test"
+   ```
+   Expected: The file should be created successfully.
+
+   ```
+   Read the file "测试文件.txt"
+   ```
+   Expected: The file contents should be displayed correctly.
+
+### Path Traversal Protection
+
+1. **Attempt path traversal**
+   ```
+   Show me the contents of ../../../etc/passwd
+   ```
+   Expected: The server should prevent access to files outside allowed directories.
+
+### Symbolic Link Handling
+
+1. **Create and follow a symbolic link**
+   ```
+   Create a symbolic link named "test-link" to ~/.bashrc
+   ```
+   Expected: The symbolic link should be created successfully.
+
+   ```
+   Read the file "test-link"
+   ```
+   Expected: The contents of ~/.bashrc should be displayed.
+
+### Cleanup
+
+After testing, clean up the test files:
+
+```
+Delete the files "test file with spaces.txt", "test-file-with-special-chars!@#.txt", "测试文件.txt", and "test-link"
+```
+
+## Troubleshooting
+
+If you encounter issues:
+
+1. Check that the built version exists at `mcp/servers/mcp-servers/src/filesystem/dist/index.js`
+2. Verify that the wrapper script is using the built version
+3. Check for error messages in the MCP client output
+4. Try rebuilding the server using `setup-filesystem-mcp.sh`
+
+## Reporting Issues
+
+If you find bugs or have suggestions for improvements, please create an issue in the repository with:
+
+1. A clear description of the problem
+2. Steps to reproduce the issue
+3. Expected vs. actual behavior
+4. Any error messages or logs

--- a/mcp/tests/test-git-mcp.md
+++ b/mcp/tests/test-git-mcp.md
@@ -1,0 +1,84 @@
+# Git MCP Server Test Guide
+
+This document provides instructions for testing the Git MCP server integration.
+
+## Prerequisites
+
+1. The Git MCP server has been set up using `setup-git-mcp.sh`
+2. Amazon Q or another MCP client is configured to use the server
+
+## Test Cases
+
+### Basic Git Operations
+
+1. **Check Git Status**
+   ```
+   Check the status of the current Git repository
+   ```
+   Expected: The status of the Git repository should be displayed correctly.
+
+2. **List Branches**
+   ```
+   List all branches in the current Git repository
+   ```
+   Expected: A list of branches in the repository.
+
+3. **View Commit History**
+   ```
+   Show the commit history of the current Git repository
+   ```
+   Expected: A list of recent commits with their details.
+
+### Advanced Git Operations
+
+1. **Create a Branch**
+   ```
+   Create a new Git branch named "test-branch"
+   ```
+   Expected: The branch should be created successfully.
+
+2. **Switch Branches**
+   ```
+   Switch to the "test-branch" branch
+   ```
+   Expected: The current branch should be changed to "test-branch".
+
+3. **Make Changes and Commit**
+   ```
+   Create a test file, add it to Git, and commit it
+   ```
+   Expected: The file should be created, added, and committed successfully.
+
+## Cleanup
+
+After testing, clean up the test branch:
+
+```
+Delete the "test-branch" branch
+```
+
+## Troubleshooting
+
+If you encounter issues:
+
+1. Check that the built version exists at `mcp/servers/git-mcp-server/dist/index.js`
+2. Verify that the wrapper script is using the built version
+3. Check for error messages in the MCP client output
+4. Try rebuilding the server using `setup-git-mcp.sh`
+
+## Reporting Issues
+
+If you find bugs or have suggestions for improvements, please create an issue in the repository with:
+
+1. A clear description of the problem
+2. Steps to reproduce the issue
+3. Expected vs. actual behavior
+4. Any error messages or logs
+
+## Future Enhancements
+
+The following features are planned for future implementation:
+
+1. **Git Worktree Support**: Adding the ability to create, list, and manage Git worktrees
+2. **Custom Git Hooks Integration**: Improved support for Git hooks
+3. **Performance Optimizations**: Reducing response time for large repositories

--- a/mcp/tests/test-git-mcp.sh
+++ b/mcp/tests/test-git-mcp.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# =========================================================
+# TEST HARNESS FOR GIT MCP SERVER
+# =========================================================
+# PURPOSE: Automated testing of Git MCP server functionality
+# Converts manual test cases from test-git-mcp.md to automated tests
+# =========================================================
+
+# Source the common test harness
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/test-harness.sh"
+
+# Test branch name
+TEST_BRANCH="test-automation-branch"
+
+# Function to run cleanup operations
+cleanup() {
+  echo -e "\n${BLUE}CLEANUP:${NC} Removing test branch if it exists"
+  $TEST_MODEL chat --no-interactive "Delete the Git branch named $TEST_BRANCH if it exists" >/dev/null 2>&1
+  echo "Cleanup complete"
+}
+
+# Run cleanup on script exit
+trap cleanup EXIT
+
+# Initialize test suite
+init_test_suite "GIT MCP SERVER"
+
+# Basic Git Operations
+
+# Test: Check Git Status
+run_test "Check Git Status" \
+         "Check the status of the current Git repository" \
+         "(branch|modified|untracked|staged|clean|working tree)"
+
+# Test: List Branches
+run_test "List Branches" \
+         "List all branches in the current Git repository" \
+         "(branch|main|master|HEAD)"
+
+# Test: View Commit History
+run_test "View Commit History" \
+         "Show the commit history of the current Git repository" \
+         "(commit|author|date)"
+
+# Advanced Git Operations
+
+# Test: Create a Branch
+run_test "Create a Branch" \
+         "Create a new Git branch named $TEST_BRANCH" \
+         "(branch|created|success|$TEST_BRANCH)"
+
+# Test: Switch Branches
+run_test "Switch Branches" \
+         "Switch to the $TEST_BRANCH branch" \
+         "(switched|checkout|$TEST_BRANCH)"
+
+# Test: Make Changes and Commit
+skip_test "Make Changes and Commit" \
+         "This test requires file creation which is complex to automate and verify"
+
+# Print summary
+print_summary
+
+# Exit with appropriate status code
+if [ $FAILED -gt 0 ]; then
+  exit 1
+else
+  exit 0
+fi


### PR DESCRIPTION
## Description
This PR removes the unused AWS Diagram and GitLab MCP servers from our configuration to streamline our setup and reduce maintenance overhead.

## Changes
- Removed AWS Diagram MCP server entry from `mcp.json`
- Removed GitLab MCP server entry from `mcp.json`
- Updated README.md to remove references to these servers in the documentation

## Testing
- Verified that the configuration file is still valid JSON
- Confirmed that no setup scripts for these servers existed that needed removal

## Related Issues
Closes #271
Closes #272