### PR TITLE
Remove unused AWS Diagram and GitLab MCP servers

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -19,7 +19,7 @@ This standardized approach makes it easy to add more MCP servers in the future f
 
 | Integration | Description | Authentication Method | Installation Method | Documentation |
 |-------------|-------------|----------------------|---------------------|---------------|
-| AWS Labs | AWS documentation, diagrams, CDK | None required | PyPI packages via UVX | - |
+| AWS Labs | AWS documentation, CDK | None required | PyPI packages via UVX | - |
 | GitHub | GitHub API integration | Uses GitHub CLI token | Custom setup script | [Our Fork](https://github.com/atxtechbro/github-mcp-server?tab=readme-ov-file#github-mcp-server) |
 | Atlassian | Jira and Confluence integration | API tokens from `.bash_secrets` | Custom setup script | - |
 | Google Maps | Google Maps API integration | API key from `.bash_secrets` | Docker container | - |

--- a/mcp/mcp.json
+++ b/mcp/mcp.json
@@ -16,13 +16,7 @@
         "BEDROCK_KB_RERANKING_ENABLED": "false"
       }
     },
-    "awslabs.aws-diagram-mcp-server": {
-      "command": "uvx",
-      "args": ["awslabs.aws-diagram-mcp-server"],
-      "env": {
-        "FASTMCP_LOG_LEVEL": "ERROR"
-      }
-    },
+
     "awslabs.cdk-mcp-server": {
       "command": "uvx",
       "args": ["awslabs.cdk-mcp-server@latest"],
@@ -44,17 +38,7 @@
         "FASTMCP_LOG_LEVEL": "ERROR"
       }
     },
-    "gitlab": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@modelcontextprotocol/server-gitlab"
-      ],
-      "env": {
-        "GITLAB_PERSONAL_ACCESS_TOKEN": "<YOUR_TOKEN>",
-        "GITLAB_API_URL": "https://gitlab.com/api/v4"
-      }
-    },
+
     "github": {
       "command": "github-mcp-wrapper.sh",
       "args": [],


### PR DESCRIPTION
## Description
This PR removes the unused AWS Diagram and GitLab MCP servers from our configuration to streamline our setup and reduce maintenance overhead.

## Changes
- Removed AWS Diagram MCP server entry from `mcp.json`
- Removed GitLab MCP server entry from `mcp.json`
- Updated README.md to remove references to these servers in the documentation

## Testing
- Verified that the configuration file is still valid JSON
- Confirmed that no setup scripts for these servers existed that needed removal

## Related Issues
Closes #271
Closes #272