### PR TITLE
Fix: setup.sh switches directory when sourced from git worktree

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -114,7 +114,7 @@ if [[ ! -d "$DOT_DEN" && "$IS_WSL" == false ]]; then
     echo -e "${GREEN}✓ Repository cloned successfully${NC}"
 elif [[ -d "$DOT_DEN" ]]; then
     echo "Dotfiles repository already exists at $DOT_DEN"
-    cd "$DOT_DEN" 2>/dev/null
+    # Removed cd command to prevent changing user's directory when sourced
 fi
 
 # Neovim configuration setup


### PR DESCRIPTION
## Problem
When running `source setup.sh` from a git worktree branch, the script changes the current directory to the main repository path (`~/ppv/pillars/dotfiles`), effectively switching the user back to the main branch unexpectedly.

## Solution
This PR removes the `cd "$DOT_DEN"` command that was causing the issue. This is the simplest approach to fix the problem without introducing additional complexity.

The removed line was not necessary for the script's functionality, as all operations in the script use absolute paths with the `$DOT_DEN` variable.

## Testing
Tested by:
1. Creating a git worktree
2. Navigating to the worktree directory
3. Running `source setup.sh`
4. Verifying that the current directory remains in the worktree

Fixes #284