### PR TITLE
Fix SSH login shell not sourcing .bashrc on Raspberry Pi

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -1,0 +1,4 @@
+# Source .bashrc for login shells (like SSH sessions)
+if [ -f ~/.bashrc ]; then
+    source ~/.bashrc
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -138,6 +138,7 @@ fi
 echo "Creating symlinks for config files..."
 ln -sf "$DOT_DEN/.bashrc" ~/.bashrc
 ln -sf "$DOT_DEN/.bash_aliases" ~/.bash_aliases
+ln -sf "$DOT_DEN/.bash_profile" ~/.bash_profile
 # Create directory for modular aliases if it doesn't exist
 mkdir -p ~/.bash_aliases.d
 # Copy the contents instead of creating a symlink to avoid recursive symlink issues


### PR DESCRIPTION
Fixes #288 by adding a .bash_profile file that sources .bashrc for login shells. This ensures that custom prompt and other configurations are applied automatically when connecting via SSH.