### PR TITLE
Fix SSH login shell not sourcing .bashrc on Raspberry Pi (follow-up)

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -1,0 +1,4 @@
+# Source .bashrc for login shells (like SSH sessions)
+if [ -f ~/.bashrc ]; then
+    source ~/.bashrc
+fi

--- a/.profile
+++ b/.profile
@@ -1,0 +1,7 @@
+# ~/.profile: executed by the command interpreter for login shells.
+# This file is not read by bash(1), if ~/.bash_profile or ~/.bash_login exists.
+
+# Source .bashrc for login shells (like SSH sessions)
+if [ -n "$BASH_VERSION" ] && [ -f "$HOME/.bashrc" ]; then
+    source "$HOME/.bashrc"
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -138,6 +138,8 @@ fi
 echo "Creating symlinks for config files..."
 ln -sf "$DOT_DEN/.bashrc" ~/.bashrc
 ln -sf "$DOT_DEN/.bash_aliases" ~/.bash_aliases
+ln -sf "$DOT_DEN/.bash_profile" ~/.bash_profile
+ln -sf "$DOT_DEN/.profile" ~/.profile
 # Create directory for modular aliases if it doesn't exist
 mkdir -p ~/.bash_aliases.d
 # Copy the contents instead of creating a symlink to avoid recursive symlink issues


### PR DESCRIPTION
This PR addresses issue #291, which is a follow-up to the previous fix in PR #289 that didn't fully resolve the SSH login shell issue on Raspberry Pi.

## Changes
- Add `.profile` file for systems that prefer it over `.bash_profile`
- Update `setup.sh` to create symlinks for both `.bash_profile` and `.profile`
- Ensure both files properly source `.bashrc` for login shells

## Why Two Files?
Different systems have different preferences for login shell initialization:
- Some systems prefer `.bash_profile` (like macOS)
- Others prefer `.profile` (like some Linux distributions)
- By providing both, we ensure compatibility across systems

## Testing
This has been tested on Raspberry Pi to ensure that:
1. SSH login properly sources `.bashrc`
2. Custom prompt and other configurations are applied automatically
3. No manual sourcing is required after login

Fixes #291