### PR TITLE
Implement environment-specific MCP configuration

### DIFF
--- a/.bash_aliases.mcp
+++ b/.bash_aliases.mcp
@@ -1,0 +1,8 @@
+#!/bin/bash
+# ~/ppv/pillars/dotfiles/.bash_aliases.mcp
+# Aliases for MCP configuration management
+
+# Easy MCP environment switching
+alias mcp-work='~/ppv/pillars/dotfiles/utils/mcp-select.sh work'
+alias mcp-personal='~/ppv/pillars/dotfiles/utils/mcp-select.sh personal'
+alias mcp-status='~/ppv/pillars/dotfiles/utils/mcp-select.sh'

--- a/README.md
+++ b/README.md
@@ -150,6 +150,24 @@ brew install git gh jq tmux curl wget
 ```
 </details>
 
+## MCP Configuration
+
+This repository uses a modular approach to MCP (Model Context Protocol) configuration:
+
+```bash
+# Switch between work and personal MCP configurations
+mcp-work    # Use work configuration with all MCP servers
+mcp-personal # Use personal configuration (no Atlassian server)
+mcp-status  # Check current configuration
+```
+
+This pattern provides:
+- **Environment-specific configurations** – Different MCP servers for work and personal use
+- **Easy switching** – Simple commands to switch between configurations
+- **Automatic setup** – Configurations created and managed by setup scripts
+
+The MCP configuration system follows the "spilled coffee principle" - everything is reproducible and automated.
+
 ## Applications
 
 ### Google Chrome

--- a/mcp-configs/README.md
+++ b/mcp-configs/README.md
@@ -1,1 +1,16 @@
 # MCP Environment Configuration
+
+This directory contains environment-specific MCP configurations:
+
+- `mcp.work.json` - Work configuration with all MCP servers
+- `mcp.personal.json` - Personal configuration (no Atlassian server)
+
+These configurations are managed by the `mcp-setup.sh` script and can be switched using:
+
+```bash
+mcp-work     # Switch to work configuration
+mcp-personal # Switch to personal configuration
+mcp-status   # Check current configuration
+```
+
+The setup script automatically creates these configurations from the base MCP configuration and removes the Atlassian server from the personal configuration.

--- a/mcp-configs/README.md
+++ b/mcp-configs/README.md
@@ -1,0 +1,1 @@
+# MCP Environment Configuration

--- a/setup.sh
+++ b/setup.sh
@@ -145,10 +145,14 @@ mkdir -p ~/.bash_aliases.d
 cp -r "$DOT_DEN/.bash_aliases.d/"* ~/.bash_aliases.d/ 2>/dev/null || true
 ln -sf "$DOT_DEN/.bash_exports" ~/.bash_exports
 ln -sf "$DOT_DEN/.tmux.conf" ~/.tmux.conf
-# Global Configuration: ~/.aws/amazonq/mcp.json - Applies to all workspaces
-# (as opposed to Workspace Configuration: .amazonq/mcp.json - Specific to the current workspace)
+
+# Set up MCP configurations
+echo "Setting up MCP configurations..."
 mkdir -p ~/.aws/amazonq
-ln -sf "$DOT_DEN"/mcp/mcp.json ~/.aws/amazonq/mcp.json
+# Set up environment-specific MCP configurations
+"$DOT_DEN/utils/mcp-setup.sh"
+# Default to personal configuration
+"$DOT_DEN/utils/mcp-select.sh" personal
 
 # Claude Desktop MCP integration
 mkdir -p ~/.config/Claude
@@ -342,7 +346,7 @@ if ! command -v uv >/dev/null 2>&1; then
   echo "Installing uv package manager..."
   curl -Ls https://astral.sh/uv/install.sh | sh >/dev/null 2>&1
   # Check if PATH already contains the .local/bin entry before adding
-  if ! grep -q "export PATH=\"\\$HOME/.local/bin:\\$PATH\"" "$HOME/.bashrc"; then
+  if ! grep -q "export PATH=\"\$HOME/.local/bin:\$PATH\"" "$HOME/.bashrc"; then
     echo "export PATH=\"$HOME/.local/bin:\$PATH\"" >> "$HOME/.bashrc"
   fi
   # Make uv available in the current shell

--- a/setup.sh
+++ b/setup.sh
@@ -148,7 +148,9 @@ ln -sf "$DOT_DEN/.tmux.conf" ~/.tmux.conf
 
 # Set up MCP configurations
 echo "Setting up MCP configurations..."
-mkdir -p ~/.aws/amazonq
+mkdir -p ~/.aws/amazonq # Global Configuration: ~/.aws/amazonq/mcp.json - Applies to all workspaces
+# (as opposed to Workspace Configuration: .amazonq/mcp.json - Specific to the current workspace)
+
 # Set up environment-specific MCP configurations
 "$DOT_DEN/utils/mcp-setup.sh"
 # Default to personal configuration

--- a/utils/mcp-select.sh
+++ b/utils/mcp-select.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# ~/ppv/pillars/dotfiles/utils/mcp-select.sh
+# Script to switch between different MCP configurations
+
+ENV_TYPE="$1"
+MCP_DIR="${HOME}/ppv/pillars/dotfiles/mcp-configs"
+MCP_DEST="${HOME}/.mcp.json"
+
+if [ "$ENV_TYPE" != "work" ] && [ "$ENV_TYPE" != "personal" ]; then
+  echo "Usage: mcp-select.sh [work|personal]"
+  echo "Current configuration:"
+  if [ -f "$MCP_DEST" ]; then
+    if [ -L "$MCP_DEST" ]; then
+      echo "$(readlink -f "$MCP_DEST")"
+    else
+      echo "Custom configuration (not managed by mcp-select)"
+    fi
+  else
+    echo "No configuration set"
+  fi
+  exit 1
+fi
+
+# Check if the target config exists
+if [ ! -f "${MCP_DIR}/mcp.${ENV_TYPE}.json" ]; then
+  echo "Error: ${MCP_DIR}/mcp.${ENV_TYPE}.json does not exist"
+  echo "Please run setup.sh first to create the configuration files"
+  exit 1
+fi
+
+# Create symlink to the selected config
+ln -sf "${MCP_DIR}/mcp.${ENV_TYPE}.json" "$MCP_DEST"
+echo "MCP configuration set to ${ENV_TYPE}"
+echo "Restart Amazon Q CLI for changes to take effect"

--- a/utils/mcp-setup.sh
+++ b/utils/mcp-setup.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# ~/ppv/pillars/dotfiles/utils/mcp-setup.sh
+# Script to set up MCP environment-specific configurations
+
+MCP_DIR="${HOME}/ppv/pillars/dotfiles/mcp-configs"
+MCP_SOURCE="${HOME}/ppv/pillars/dotfiles/mcp/mcp.json"
+
+# Create mcp-configs directory if it doesn't exist
+mkdir -p "$MCP_DIR"
+
+# Create work and personal configs if they don't exist
+if [ ! -f "${MCP_DIR}/mcp.work.json" ]; then
+  echo "Creating work MCP configuration..."
+  cp "$MCP_SOURCE" "${MCP_DIR}/mcp.work.json"
+  echo "Work MCP configuration created at ${MCP_DIR}/mcp.work.json"
+fi
+
+if [ ! -f "${MCP_DIR}/mcp.personal.json" ]; then
+  echo "Creating personal MCP configuration..."
+  cp "$MCP_SOURCE" "${MCP_DIR}/mcp.personal.json"
+  
+  # Remove Atlassian from personal config
+  if command -v jq &> /dev/null; then
+    echo "Removing Atlassian server from personal configuration..."
+    jq '.servers = [.servers[] | select(.name != "atlassian")]' \
+      "${MCP_DIR}/mcp.personal.json" > "${MCP_DIR}/temp.json" && \
+      mv "${MCP_DIR}/temp.json" "${MCP_DIR}/mcp.personal.json"
+    echo "Atlassian server removed from personal configuration"
+  else
+    echo "jq not found. Please install jq to automatically remove Atlassian server."
+    echo "You can manually edit ${MCP_DIR}/mcp.personal.json to remove the Atlassian server."
+  fi
+  
+  echo "Personal MCP configuration created at ${MCP_DIR}/mcp.personal.json"
+fi
+
+# Make mcp-select.sh executable
+chmod +x "${HOME}/ppv/pillars/dotfiles/utils/mcp-select.sh"
+
+echo "MCP environment configurations set up successfully."
+echo "Use 'mcp-work' or 'mcp-personal' to switch between configurations."


### PR DESCRIPTION
## Description
This PR implements a simple environment-specific MCP configuration system that allows users to easily switch between work and personal MCP configurations. This addresses the issue where the Atlassian MCP server causes timeouts on personal computers while being essential for work environments.

## Changes
- Create `mcp-configs` directory for storing environment-specific configurations
- Add `mcp-select.sh` utility script for switching between configurations
- Add bash aliases (`mcp-work`, `mcp-personal`, `mcp-status`) for easy switching
- Update setup script to handle the new configuration approach
- Document the new approach in README.md

## Testing
- The setup script creates both work and personal configurations
- The personal configuration automatically removes the Atlassian server
- Users can easily switch between configurations using the provided aliases
- The configuration is automatically applied during setup

Closes #297