### PR TITLE
feat(mcp): implement modular MCP server configuration system

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -9,6 +9,7 @@ The MCP Server Configuration system allows you to:
 - Switch between implementations seamlessly
 - Isolate dependencies using virtual environments
 - Preserve a consistent interface regardless of the underlying implementation
+- Detect and use locally built implementations
 
 ## Directory Structure
 
@@ -19,9 +20,12 @@ mcp/
 │   ├── git-kzms.json       # Configuration for kzms Git MCP server
 │   └── git-wrapper.json    # Configuration using the wrapper script
 ├── scripts/                # Utility scripts
+│   ├── mcp-server          # Unified command for managing MCP servers
 │   ├── mcp-setup-implementation  # Script to set up a new implementation
 │   ├── mcp-remove-implementation # Script to remove an implementation
 │   └── mcp-switch          # Script to switch between implementations
+├── servers/                # Directory for locally built MCP servers
+│   └── github-mcp-server/  # Example of a locally built server
 ├── setup-mcp.sh            # Setup script for MCP infrastructure
 └── wrappers/               # Wrapper scripts for MCP servers
     └── git-mcp-wrapper.sh  # Wrapper for Git MCP server
@@ -35,38 +39,69 @@ Run the setup script to create the necessary directory structure and symlinks:
 ./mcp/setup-mcp.sh
 ```
 
+This script will:
+- Create the required directories for MCP server implementations
+- Create directories for virtual environments
+- Set up configuration directories
+- Create symlinks for wrapper and utility scripts in `~/ppv/pillars/dotfiles/bin`
+
 ## Usage
 
-### Setting Up a New Implementation
+### Listing Available Implementations
 
 ```bash
-# Set up the kzms implementation for the git MCP server
-mcp-setup-implementation git kzms https://github.com/atxtechbro/kzms-mcp-server-git.git
+# List all available MCP servers and implementations
+mcp-server list
+```
 
-# Set up the cyanheads implementation for the git MCP server
-mcp-setup-implementation git cyanheads https://github.com/cyanheads/git-mcp-server.git
+### Adding a New Implementation
+
+```bash
+# Add a new implementation for the git MCP server
+mcp-server add git kzms https://github.com/atxtechbro/kzms-mcp-server-git.git
+
+# Add a new implementation for the git MCP server
+mcp-server add git cyanheads https://github.com/cyanheads/git-mcp-server.git
 ```
 
 ### Switching Between Implementations
 
 ```bash
-# Switch to the kzms implementation
-mcp-switch git kzms
-
-# Switch to the cyanheads implementation
-mcp-switch git cyanheads
+# Switch to a different implementation
+mcp-server update git kzms
 ```
 
 ### Removing an Implementation
 
 ```bash
-# Remove the kzms implementation for the git MCP server
-mcp-remove-implementation git kzms
+# Remove an implementation
+mcp-server remove git kzms
 ```
+
+### Building from Source
+
+For locally built MCP servers:
+
+1. Clone the repository into the `mcp/servers` directory:
+```bash
+git clone https://github.com/example/example-mcp-server.git ~/ppv/pillars/dotfiles/mcp/servers/example-mcp-server
+```
+
+2. Build the server (if needed):
+```bash
+cd ~/ppv/pillars/dotfiles/mcp/servers/example-mcp-server
+make build
+```
+
+3. The server will be automatically detected by the `mcp-server list` command.
 
 ### Updating MCP Configuration
 
-To use the wrapper script in your MCP configuration, copy the contents of `mcp/config/git-wrapper.json` to your `mcp/mcp.json` file.
+To use the wrapper script in your MCP configuration, copy the contents of `mcp/config/git-wrapper.json` to your `~/.aws/amazonq/mcp.json` file.
+
+## Git Worktree Support
+
+When working with git worktrees, the setup script automatically detects if it's running in a worktree and creates symlinks that point to the correct location. This allows you to test your changes in worktrees without manual intervention.
 
 ## Troubleshooting
 
@@ -82,3 +117,10 @@ If you see an error like "No implementation found for git MCP server", check:
 If you encounter issues with the virtual environment:
 1. Recreate the virtual environment: `uv venv ~/ppv/pipelines/venvs/mcp-servers/git-kzms --force`
 2. Reinstall the package: `~/ppv/pipelines/venvs/mcp-servers/git-kzms/bin/uv pip install -e ~/.local/share/mcp-servers/python/git/kzms`
+
+### Symlink Issues
+
+If commands like `mcp-server` are not found:
+1. Make sure `~/ppv/pillars/dotfiles/bin` is in your PATH
+2. Run `./mcp/setup-mcp.sh` to recreate the symlinks
+3. Check if you're in a git worktree and if the symlinks point to the correct location

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,141 +1,76 @@
-# MCP Servers Integration
+# MCP Server Configuration
 
-This directory contains wrapper scripts and configuration for MCP clients (Claude Code, OpenAI Codex, Claude Desktop, Cursor, VSCode, or Amazon Q).
+This directory contains configuration and scripts for managing Model Context Protocol (MCP) servers in a modular way.
 
-## MCP Server Origins
+## Overview
 
-Many of our MCP servers are sourced from the official [Model Context Protocol servers repository](https://github.com/modelcontextprotocol/servers), which provides a standardized collection of vetted MCP servers. This repository appears to be maintained with oversight from Anthropic and offers a consistent framework for building and deploying MCP servers.
+The MCP Server Configuration system allows you to:
+- Maintain multiple implementations of the same MCP server type
+- Switch between implementations seamlessly
+- Isolate dependencies using virtual environments
+- Preserve a consistent interface regardless of the underlying implementation
 
-Current servers from this source:
-- Google Maps
-- Brave Search
-- Filesystem
-- Google Drive
+## Directory Structure
 
-This standardized approach makes it easy to add more MCP servers in the future from this abundant collection.
-
-## Available MCP Integrations
-
-| Integration | Description | Authentication Method | Installation Method | Documentation |
-|-------------|-------------|----------------------|---------------------|---------------|
-| AWS Labs | AWS documentation, CDK | None required | PyPI packages via UVX | - |
-| GitHub | GitHub API integration | Uses GitHub CLI token | Custom setup script | [Our Fork](https://github.com/atxtechbro/github-mcp-server?tab=readme-ov-file#github-mcp-server) |
-| Atlassian | Jira and Confluence integration | API tokens from `.bash_secrets` | Custom setup script | - |
-| Google Maps | Google Maps API integration | API key from `.bash_secrets` | Docker container | - |
-| Brave Search | Web search via Brave | API key from `.bash_secrets` | Docker container | - |
-| Filesystem | Local filesystem operations | None required | Built from source | [Our Fork](https://github.com/atxtechbro/mcp-servers/tree/main/src/filesystem#filesystem-mcp-server) |
-| Git | Git repository operations | None required | Built from source | [Original Repo](https://github.com/cyanheads/git-mcp-server#git-mcp-server) |
-| Google Drive | Google Drive file operations | OAuth credentials from `.bash_secrets` | Docker container | [Official Docs](https://github.com/modelcontextprotocol/servers/tree/main/src/gdrive#authentication) |
-
-## Setup Instructions
-
-Each MCP integration has its own setup method:
-
-- **AWS Labs MCP Servers**: No setup script needed - these are installed automatically via UVX package manager from PyPI, making integration straightforward
-- `setup-atlassian-mcp.sh` - Sets up Atlassian (Jira/Confluence) integration
-- `setup-google-maps-mcp.sh` - Sets up Google Maps integration
-- `setup-brave-search-mcp.sh` - Sets up Brave Search integration
-- `setup-filesystem-mcp.sh` - Sets up Filesystem integration from source (allows customization)
-- `setup-gdrive-mcp.sh` - Sets up Google Drive integration
-- `setup-github-mcp.sh` - Sets up GitHub integration from source
-- `setup-git-mcp.sh` - Sets up Git integration from source
-
-For custom integrations, run the appropriate setup script:
-
-```bash
-# Example: Set up Google Maps integration
-./setup-google-maps-mcp.sh
+```
+mcp/
+├── config/                 # Configuration templates for different implementations
+│   ├── git-cyanheads.json  # Configuration for cyanheads Git MCP server
+│   ├── git-kzms.json       # Configuration for kzms Git MCP server
+│   └── git-wrapper.json    # Configuration using the wrapper script
+├── scripts/                # Utility scripts
+│   ├── mcp-setup-implementation  # Script to set up a new implementation
+│   └── mcp-switch          # Script to switch between implementations
+├── setup-mcp.sh            # Setup script for MCP infrastructure
+└── wrappers/               # Wrapper scripts for MCP servers
+    └── git-mcp-wrapper.sh  # Wrapper for Git MCP server
 ```
 
-## Secret Management
+## Setup
 
-All API keys and tokens are stored in `~/.bash_secrets` (not tracked in git) following our security best practices. The wrapper scripts load these secrets at runtime and pass them to the MCP servers.
-
-To add your secrets:
-
-1. Copy the template if you haven't already:
-   ```bash
-   cp ~/.bash_secrets.example ~/.bash_secrets
-   ```
-
-2. Edit the file to add your specific secrets:
-   ```bash
-   nano ~/.bash_secrets
-   ```
-
-3. Set proper permissions:
-   ```bash
-   chmod 600 ~/.bash_secrets
-   ```
-
-## Docker-based MCP Servers
-
-Some MCP servers (like Google Maps) use Docker for containerization. The setup scripts handle building the Docker images and configuring the wrapper scripts.
-
-Requirements:
-- Docker installed and running
-- Internet access to pull base images
-
-## Configuration
-
-The `mcp.json` file contains the configuration for all MCP servers. This file is used by Amazon Q and other MCP clients to discover and connect to the servers.
-
-## Filesystem MCP Server Configuration
-
-The Filesystem MCP server requires at least one allowed directory to be specified. By default, it uses your home directory (`$HOME`).
-
-If you want to restrict filesystem access to specific directories:
+Run the setup script to create the necessary directory structure and symlinks:
 
 ```bash
-# Set environment variable before starting Amazon Q
-export MCP_FILESYSTEM_RESTRICT_DIRS="/projects:/data:/tmp"
-q chat  # Start Amazon Q with restricted filesystem access
+./mcp/setup-mcp.sh
 ```
 
-This allows you to control which directories the Filesystem MCP server can access.
+## Usage
+
+### Setting Up a New Implementation
+
+```bash
+# Set up the kzms implementation for the git MCP server
+mcp-setup-implementation git kzms https://github.com/atxtechbro/kzms-mcp-server-git.git
+
+# Set up the cyanheads implementation for the git MCP server
+mcp-setup-implementation git cyanheads https://github.com/cyanheads/git-mcp-server.git
+```
+
+### Switching Between Implementations
+
+```bash
+# Switch to the kzms implementation
+mcp-switch git kzms
+
+# Switch to the cyanheads implementation
+mcp-switch git cyanheads
+```
+
+### Updating MCP Configuration
+
+To use the wrapper script in your MCP configuration, copy the contents of `mcp/config/git-wrapper.json` to your `mcp/mcp.json` file.
 
 ## Troubleshooting
 
-If you encounter issues with an MCP integration:
+### Implementation Not Found
 
-1. Check that the required secrets are properly set in `~/.bash_secrets`
-2. Verify that the wrapper script has execute permissions (`chmod +x wrapper-script.sh`)
-3. For Docker-based integrations, ensure Docker is running (`docker ps`)
-4. Check the logs from the MCP server for more detailed error messages
-## Adding New MCP Servers
+If you see an error like "No implementation found for git MCP server", check:
+1. The active implementation is correctly set
+2. The implementation directory exists
+3. The virtual environment is properly set up
 
-Based on our current experience, here's a working procedure for adding new MCP servers (subject to improvement as we learn more):
+### Virtual Environment Issues
 
-1. **Start with mcp.json configuration**:
-   - Add the server entry to `mcp.json` first, even if the wrapper script doesn't exist yet
-   - Define the command, args, and environment variables needed
-
-2. **Create the wrapper script**:
-   - Implement `<server-name>-mcp-wrapper.sh` that handles authentication and execution
-   - Ensure it properly sources credentials from `~/.bash_secrets` if needed
-
-3. **Implement the setup script**:
-   - Create `setup-<server-name>-mcp.sh` for one-time setup tasks
-   - For Docker-based servers, include image building steps
-   - For package-based servers, document installation requirements
-
-4. **Document the integration**:
-   - Add an entry to the MCP Integrations table in the README
-   - Classify the server by source, authentication method, and installation approach
-   - Create test documentation in `tests/test-<server-name>.md`
-
-This workflow represents our current understanding and approach, which we expect to refine as we gain more experience with different types of MCP servers and discover better patterns for integration.
-## Utility Functions
-
-To reduce code duplication and ensure consistent behavior across setup scripts, we use shared utility functions in the `utils/` directory:
-
-- `mcp-setup-utils.sh` - Common functions for MCP server setup scripts
-
-These utilities handle common tasks like:
-- Checking prerequisites (Docker, repository structure)
-- Setting up the MCP servers repository
-- Building Docker images
-- Updating secrets templates
-- Printing consistent setup completion messages
-
-See the [utils/README.md](utils/README.md) file for more details on available functions and usage.
+If you encounter issues with the virtual environment:
+1. Recreate the virtual environment: `uv venv ~/ppv/pipelines/venvs/mcp-servers/git-kzms --force`
+2. Reinstall the package: `~/ppv/pipelines/venvs/mcp-servers/git-kzms/bin/uv pip install -e ~/.local/share/mcp-servers/python/git/kzms`

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -20,6 +20,7 @@ mcp/
 │   └── git-wrapper.json    # Configuration using the wrapper script
 ├── scripts/                # Utility scripts
 │   ├── mcp-setup-implementation  # Script to set up a new implementation
+│   ├── mcp-remove-implementation # Script to remove an implementation
 │   └── mcp-switch          # Script to switch between implementations
 ├── setup-mcp.sh            # Setup script for MCP infrastructure
 └── wrappers/               # Wrapper scripts for MCP servers
@@ -54,6 +55,13 @@ mcp-switch git kzms
 
 # Switch to the cyanheads implementation
 mcp-switch git cyanheads
+```
+
+### Removing an Implementation
+
+```bash
+# Remove the kzms implementation for the git MCP server
+mcp-remove-implementation git kzms
 ```
 
 ### Updating MCP Configuration

--- a/mcp/config/git-cyanheads.json
+++ b/mcp/config/git-cyanheads.json
@@ -1,0 +1,9 @@
+{
+  "git": {
+    "command": "npx",
+    "args": ["git-mcp-server"],
+    "env": {
+      "FASTMCP_LOG_LEVEL": "ERROR"
+    }
+  }
+}

--- a/mcp/config/git-kzms.json
+++ b/mcp/config/git-kzms.json
@@ -1,0 +1,9 @@
+{
+  "git": {
+    "command": "uvx",
+    "args": ["run", "mcp_server_git"],
+    "env": {
+      "FASTMCP_LOG_LEVEL": "ERROR"
+    }
+  }
+}

--- a/mcp/config/git-wrapper.json
+++ b/mcp/config/git-wrapper.json
@@ -1,0 +1,9 @@
+{
+  "git": {
+    "command": "~/ppv/pipelines/bin/mcp-wrappers/git-mcp-wrapper.sh",
+    "args": [],
+    "env": {
+      "FASTMCP_LOG_LEVEL": "ERROR"
+    }
+  }
+}

--- a/mcp/scripts/mcp-remove-implementation
+++ b/mcp/scripts/mcp-remove-implementation
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# MCP Implementation Removal
+# Removes an MCP server implementation and its virtual environment
+
+SERVER=$1
+IMPLEMENTATION=$2
+
+if [ -z "$SERVER" ] || [ -z "$IMPLEMENTATION" ]; then
+  echo "Usage: mcp-remove-implementation <server> <implementation>"
+  echo "Example: mcp-remove-implementation git kzms"
+  exit 1
+fi
+
+# Define paths
+SERVERS_DIR=~/.local/share/mcp-servers/python/$SERVER/$IMPLEMENTATION
+VENV_DIR=~/ppv/pipelines/venvs/mcp-servers/$SERVER-$IMPLEMENTATION
+ACTIVE_IMPL_FILE=~/.config/mcp/active-implementations/$SERVER
+
+# Check if implementation exists
+if [ ! -d "$SERVERS_DIR" ]; then
+  echo "Error: Implementation $IMPLEMENTATION for $SERVER does not exist at $SERVERS_DIR"
+  exit 1
+fi
+
+# Check if this is the active implementation
+if [ -f "$ACTIVE_IMPL_FILE" ] && [ "$(cat "$ACTIVE_IMPL_FILE")" = "$IMPLEMENTATION" ]; then
+  echo "Warning: Removing the active implementation for $SERVER"
+  echo "You will need to switch to another implementation after removal"
+fi
+
+# Confirm removal
+read -p "Are you sure you want to remove $IMPLEMENTATION implementation for $SERVER? (y/N) " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+  echo "Operation cancelled"
+  exit 0
+fi
+
+# Remove the implementation directory
+echo "Removing implementation directory at $SERVERS_DIR..."
+rm -rf "$SERVERS_DIR"
+
+# Remove the virtual environment if it exists
+if [ -d "$VENV_DIR" ]; then
+  echo "Removing virtual environment at $VENV_DIR..."
+  rm -rf "$VENV_DIR"
+fi
+
+# If this was the active implementation, suggest switching to another one
+if [ -f "$ACTIVE_IMPL_FILE" ] && [ "$(cat "$ACTIVE_IMPL_FILE")" = "$IMPLEMENTATION" ]; then
+  # Find other available implementations
+  OTHER_IMPLS=$(find ~/.local/share/mcp-servers/python/$SERVER -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null)
+  
+  if [ -n "$OTHER_IMPLS" ]; then
+    echo "Available implementations for $SERVER:"
+    echo "$OTHER_IMPLS"
+    echo "Please switch to another implementation using:"
+    echo "  mcp-switch $SERVER <implementation>"
+  else
+    echo "No other implementations found for $SERVER"
+    echo "You may need to set up a new implementation"
+  fi
+fi
+
+echo "Successfully removed $IMPLEMENTATION implementation for $SERVER"

--- a/mcp/scripts/mcp-server
+++ b/mcp/scripts/mcp-server
@@ -46,15 +46,27 @@ list_servers() {
   fi
   
   # Find all server types (python, typescript, binary)
-  for server_type in $(find "$SERVERS_BASE_DIR" -mindepth 1 -maxdepth 1 -type d -exec basename {} \;); do
+  for server_type in $(find "$SERVERS_BASE_DIR" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null || echo ""); do
+    if [ -z "$server_type" ]; then
+      continue
+    fi
+    
     echo "[$server_type]"
     
     # Find all servers of this type
-    for server in $(find "$SERVERS_BASE_DIR/$server_type" -mindepth 1 -maxdepth 1 -type d -exec basename {} \;); do
+    for server in $(find "$SERVERS_BASE_DIR/$server_type" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null || echo ""); do
+      if [ -z "$server" ]; then
+        continue
+      fi
+      
       echo "  $server:"
       
       # Find all implementations for this server
-      for impl in $(find "$SERVERS_BASE_DIR/$server_type/$server" -mindepth 1 -maxdepth 1 -type d -exec basename {} \;); do
+      for impl in $(find "$SERVERS_BASE_DIR/$server_type/$server" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null || echo ""); do
+        if [ -z "$impl" ]; then
+          continue
+        fi
+        
         # Check if this is the active implementation
         if [ -f "$ACTIVE_IMPL_DIR/$server" ] && [ "$(cat "$ACTIVE_IMPL_DIR/$server")" = "$impl" ]; then
           echo "    * $impl (active)"
@@ -118,14 +130,18 @@ remove_server() {
     echo "Error: Missing server parameter"
     echo "Usage: mcp-server remove <server> [implementation]"
     exit 1
-  }
+  fi
   
   # If implementation is not specified, list available implementations
   if [ -z "$IMPLEMENTATION" ]; then
     echo "Available implementations for $SERVER:"
     for server_type in python typescript binary; do
       if [ -d "$SERVERS_BASE_DIR/$server_type/$SERVER" ]; then
-        for impl in $(find "$SERVERS_BASE_DIR/$server_type/$SERVER" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null); do
+        for impl in $(find "$SERVERS_BASE_DIR/$server_type/$SERVER" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null || echo ""); do
+          if [ -z "$impl" ]; then
+            continue
+          fi
+          
           if [ -f "$ACTIVE_IMPL_DIR/$SERVER" ] && [ "$(cat "$ACTIVE_IMPL_DIR/$SERVER")" = "$impl" ]; then
             echo "  * $impl (active)"
           else
@@ -188,7 +204,7 @@ remove_server() {
     OTHER_IMPLS=""
     for type in python typescript binary; do
       if [ -d "$SERVERS_BASE_DIR/$type/$SERVER" ]; then
-        FOUND_IMPLS=$(find "$SERVERS_BASE_DIR/$type/$SERVER" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null)
+        FOUND_IMPLS=$(find "$SERVERS_BASE_DIR/$type/$SERVER" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null || echo "")
         if [ -n "$FOUND_IMPLS" ]; then
           OTHER_IMPLS="$OTHER_IMPLS $FOUND_IMPLS"
         fi
@@ -215,14 +231,18 @@ update_server() {
     echo "Error: Missing server parameter"
     echo "Usage: mcp-server update <server> [implementation]"
     exit 1
-  }
+  fi
   
   # If implementation is not specified, list available implementations
   if [ -z "$IMPLEMENTATION" ]; then
     echo "Available implementations for $SERVER:"
     for server_type in python typescript binary; do
       if [ -d "$SERVERS_BASE_DIR/$server_type/$SERVER" ]; then
-        for impl in $(find "$SERVERS_BASE_DIR/$server_type/$SERVER" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null); do
+        for impl in $(find "$SERVERS_BASE_DIR/$server_type/$SERVER" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null || echo ""); do
+          if [ -z "$impl" ]; then
+            continue
+          fi
+          
           if [ -f "$ACTIVE_IMPL_DIR/$SERVER" ] && [ "$(cat "$ACTIVE_IMPL_DIR/$SERVER")" = "$impl" ]; then
             echo "  * $impl (active)"
           else

--- a/mcp/scripts/mcp-server
+++ b/mcp/scripts/mcp-server
@@ -9,7 +9,9 @@ set -e
 CONFIG_DIR=~/.config/mcp
 ACTIVE_IMPL_DIR="$CONFIG_DIR/active-implementations"
 SERVERS_BASE_DIR=~/.local/share/mcp-servers
+LOCAL_BUILDS_DIR=~/ppv/pillars/dotfiles/mcp/servers
 VENVS_BASE_DIR=~/ppv/pipelines/venvs/mcp-servers
+MCP_CONFIG_FILE=~/.aws/amazonq/mcp.json
 
 # Command and arguments
 COMMAND=$1
@@ -36,47 +38,103 @@ show_help() {
 
 # List all servers and implementations
 list_servers() {
-  echo "Available MCP servers and implementations:"
-  echo "----------------------------------------"
+  echo "Available MCP Servers:"
+  echo "======================"
   
-  # Check if any servers exist
-  if [ ! -d "$SERVERS_BASE_DIR" ]; then
+  # First, get all configured servers from mcp.json
+  if [ -f "$MCP_CONFIG_FILE" ]; then
+    # Extract server names from mcp.json using grep and sed
+    # This handles the case where jq might not be available
+    CONFIGURED_SERVERS=$(grep -o '"[^"]*": {' "$MCP_CONFIG_FILE" | sed 's/": {//g' | sed 's/"//g' | grep -v "env" | grep -v "mcpServers" | sort)
+  else
+    CONFIGURED_SERVERS=""
+    echo "Warning: MCP configuration file not found at $MCP_CONFIG_FILE"
+  fi
+  
+  # If no configured servers found, check if we have any local implementations
+  if [ -z "$CONFIGURED_SERVERS" ] && [ ! -d "$SERVERS_BASE_DIR" ] && [ ! -d "$LOCAL_BUILDS_DIR" ]; then
     echo "No MCP servers found."
     return
   fi
   
-  # Find all server types (python, typescript, binary)
-  for server_type in $(find "$SERVERS_BASE_DIR" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null || echo ""); do
-    if [ -z "$server_type" ]; then
-      continue
+  # Process each configured server
+  for server in $CONFIGURED_SERVERS; do
+    echo "• $server"
+    
+    # Check if we have local implementations for this server
+    FOUND_IMPLEMENTATIONS=false
+    
+    # Check for locally built implementations
+    if [ -d "$LOCAL_BUILDS_DIR/$server-mcp-server" ]; then
+      FOUND_IMPLEMENTATIONS=true
+      echo "  ✓ local-build - active"
     fi
     
-    echo "[$server_type]"
+    # Look for implementations across all server types
+    for server_type in python typescript binary; do
+      if [ -d "$SERVERS_BASE_DIR/$server_type/$server" ]; then
+        # Get all implementations for this server
+        for impl in $(find "$SERVERS_BASE_DIR/$server_type/$server" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null || echo ""); do
+          if [ -z "$impl" ]; then
+            continue
+          fi
+          
+          FOUND_IMPLEMENTATIONS=true
+          
+          # Check if this is the active implementation
+          if [ -f "$ACTIVE_IMPL_DIR/$server" ] && [ "$(cat "$ACTIVE_IMPL_DIR/$server")" = "$impl" ]; then
+            echo "  ✓ $impl ($server_type) - active"
+          else
+            echo "  - $impl ($server_type)"
+          fi
+        done
+      fi
+    done
     
-    # Find all servers of this type
-    for server in $(find "$SERVERS_BASE_DIR/$server_type" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null || echo ""); do
-      if [ -z "$server" ]; then
+    # If no implementations found, show a message
+    if [ "$FOUND_IMPLEMENTATIONS" = false ]; then
+      echo "  (No local implementations)"
+    fi
+    
+    echo ""
+  done
+  
+  # Now check for any local implementations that aren't in the configured servers
+  # This handles the case where someone has set up an implementation but not added it to mcp.json
+  if [ -d "$SERVERS_BASE_DIR" ]; then
+    for server_type in $(find "$SERVERS_BASE_DIR" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null || echo ""); do
+      if [ -z "$server_type" ]; then
         continue
       fi
       
-      echo "  $server:"
-      
-      # Find all implementations for this server
-      for impl in $(find "$SERVERS_BASE_DIR/$server_type/$server" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null || echo ""); do
-        if [ -z "$impl" ]; then
+      for server in $(find "$SERVERS_BASE_DIR/$server_type" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null || echo ""); do
+        if [ -z "$server" ]; then
           continue
         fi
         
-        # Check if this is the active implementation
-        if [ -f "$ACTIVE_IMPL_DIR/$server" ] && [ "$(cat "$ACTIVE_IMPL_DIR/$server")" = "$impl" ]; then
-          echo "    * $impl (active)"
-        else
-          echo "    - $impl"
+        # Check if this server is already in the configured servers
+        if ! echo "$CONFIGURED_SERVERS" | grep -q "^$server$"; then
+          echo "• $server (not configured in mcp.json)"
+          
+          # Get all implementations for this server
+          for impl in $(find "$SERVERS_BASE_DIR/$server_type/$server" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null || echo ""); do
+            if [ -z "$impl" ]; then
+              continue
+            fi
+            
+            # Check if this is the active implementation
+            if [ -f "$ACTIVE_IMPL_DIR/$server" ] && [ "$(cat "$ACTIVE_IMPL_DIR/$server")" = "$impl" ]; then
+              echo "  ✓ $impl ($server_type) - active"
+            else
+              echo "  - $impl ($server_type)"
+            fi
+          done
+          
+          echo ""
         fi
       done
     done
-    echo ""
-  done
+  fi
 }
 
 # Add a new server implementation
@@ -135,6 +193,8 @@ remove_server() {
   # If implementation is not specified, list available implementations
   if [ -z "$IMPLEMENTATION" ]; then
     echo "Available implementations for $SERVER:"
+    FOUND_IMPLEMENTATIONS=false
+    
     for server_type in python typescript binary; do
       if [ -d "$SERVERS_BASE_DIR/$server_type/$SERVER" ]; then
         for impl in $(find "$SERVERS_BASE_DIR/$server_type/$SERVER" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null || echo ""); do
@@ -142,14 +202,21 @@ remove_server() {
             continue
           fi
           
+          FOUND_IMPLEMENTATIONS=true
+          
           if [ -f "$ACTIVE_IMPL_DIR/$SERVER" ] && [ "$(cat "$ACTIVE_IMPL_DIR/$SERVER")" = "$impl" ]; then
-            echo "  * $impl (active)"
+            echo "  ✓ $impl ($server_type) - active"
           else
-            echo "  - $impl"
+            echo "  - $impl ($server_type)"
           fi
         done
       fi
     done
+    
+    if [ "$FOUND_IMPLEMENTATIONS" = false ]; then
+      echo "  No implementations found for $SERVER"
+    fi
+    
     echo "Please specify which implementation to remove:"
     echo "  mcp-server remove $SERVER <implementation>"
     exit 0
@@ -236,6 +303,8 @@ update_server() {
   # If implementation is not specified, list available implementations
   if [ -z "$IMPLEMENTATION" ]; then
     echo "Available implementations for $SERVER:"
+    FOUND_IMPLEMENTATIONS=false
+    
     for server_type in python typescript binary; do
       if [ -d "$SERVERS_BASE_DIR/$server_type/$SERVER" ]; then
         for impl in $(find "$SERVERS_BASE_DIR/$server_type/$SERVER" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null || echo ""); do
@@ -243,14 +312,21 @@ update_server() {
             continue
           fi
           
+          FOUND_IMPLEMENTATIONS=true
+          
           if [ -f "$ACTIVE_IMPL_DIR/$SERVER" ] && [ "$(cat "$ACTIVE_IMPL_DIR/$SERVER")" = "$impl" ]; then
-            echo "  * $impl (active)"
+            echo "  ✓ $impl ($server_type) - active"
           else
-            echo "  - $impl"
+            echo "  - $impl ($server_type)"
           fi
         done
       fi
     done
+    
+    if [ "$FOUND_IMPLEMENTATIONS" = false ]; then
+      echo "  No implementations found for $SERVER"
+    fi
+    
     echo "Please specify which implementation to update:"
     echo "  mcp-server update $SERVER <implementation>"
     exit 0

--- a/mcp/scripts/mcp-server
+++ b/mcp/scripts/mcp-server
@@ -1,0 +1,297 @@
+#!/bin/bash
+
+# mcp-server - Unified command for managing MCP servers
+# Provides a simple interface for adding, removing, updating, and listing MCP servers
+
+set -e
+
+# Configuration paths
+CONFIG_DIR=~/.config/mcp
+ACTIVE_IMPL_DIR="$CONFIG_DIR/active-implementations"
+SERVERS_BASE_DIR=~/.local/share/mcp-servers
+VENVS_BASE_DIR=~/ppv/pipelines/venvs/mcp-servers
+
+# Command and arguments
+COMMAND=$1
+SERVER=$2
+IMPLEMENTATION=$3
+REPO_URL=$4
+
+# Help function
+show_help() {
+  echo "Usage: mcp-server <command> [options]"
+  echo ""
+  echo "Commands:"
+  echo "  add <server> <implementation> <repo-url>  Add a new MCP server implementation"
+  echo "  remove <server> [implementation]          Remove an MCP server implementation"
+  echo "  update <server> [implementation]          Update an MCP server implementation"
+  echo "  list                                      List all available MCP servers and implementations"
+  echo ""
+  echo "Examples:"
+  echo "  mcp-server add git kzms https://github.com/atxtechbro/kzms-mcp-server-git.git"
+  echo "  mcp-server remove git kzms"
+  echo "  mcp-server update git"
+  echo "  mcp-server list"
+}
+
+# List all servers and implementations
+list_servers() {
+  echo "Available MCP servers and implementations:"
+  echo "----------------------------------------"
+  
+  # Check if any servers exist
+  if [ ! -d "$SERVERS_BASE_DIR" ]; then
+    echo "No MCP servers found."
+    return
+  fi
+  
+  # Find all server types (python, typescript, binary)
+  for server_type in $(find "$SERVERS_BASE_DIR" -mindepth 1 -maxdepth 1 -type d -exec basename {} \;); do
+    echo "[$server_type]"
+    
+    # Find all servers of this type
+    for server in $(find "$SERVERS_BASE_DIR/$server_type" -mindepth 1 -maxdepth 1 -type d -exec basename {} \;); do
+      echo "  $server:"
+      
+      # Find all implementations for this server
+      for impl in $(find "$SERVERS_BASE_DIR/$server_type/$server" -mindepth 1 -maxdepth 1 -type d -exec basename {} \;); do
+        # Check if this is the active implementation
+        if [ -f "$ACTIVE_IMPL_DIR/$server" ] && [ "$(cat "$ACTIVE_IMPL_DIR/$server")" = "$impl" ]; then
+          echo "    * $impl (active)"
+        else
+          echo "    - $impl"
+        fi
+      done
+    done
+    echo ""
+  done
+}
+
+# Add a new server implementation
+add_server() {
+  if [ -z "$SERVER" ] || [ -z "$IMPLEMENTATION" ] || [ -z "$REPO_URL" ]; then
+    echo "Error: Missing required parameters"
+    echo "Usage: mcp-server add <server> <implementation> <repo-url>"
+    exit 1
+  fi
+  
+  # Determine server type based on repo URL (default to python)
+  SERVER_TYPE="python"
+  if [[ "$REPO_URL" == *typescript* ]] || [[ "$REPO_URL" == *ts* ]]; then
+    SERVER_TYPE="typescript"
+  elif [[ "$REPO_URL" == *binary* ]] || [[ "$REPO_URL" == *bin* ]]; then
+    SERVER_TYPE="binary"
+  fi
+  
+  # Create directories
+  SERVERS_DIR="$SERVERS_BASE_DIR/$SERVER_TYPE/$SERVER/$IMPLEMENTATION"
+  VENV_DIR="$VENVS_BASE_DIR/$SERVER-$IMPLEMENTATION"
+  
+  mkdir -p "$SERVERS_DIR"
+  mkdir -p "$(dirname "$VENV_DIR")"
+  
+  # Clone repository
+  echo "Cloning $REPO_URL to $SERVERS_DIR..."
+  git clone "$REPO_URL" "$SERVERS_DIR"
+  
+  # For Python servers, create a virtual environment and install the package
+  if [ "$SERVER_TYPE" = "python" ]; then
+    echo "Creating virtual environment at $VENV_DIR..."
+    python -m venv "$VENV_DIR"
+    
+    echo "Installing package in development mode..."
+    cd "$SERVERS_DIR"
+    "$VENV_DIR/bin/pip" install -e .
+  fi
+  
+  # Set as active implementation
+  mkdir -p "$ACTIVE_IMPL_DIR"
+  echo "$IMPLEMENTATION" > "$ACTIVE_IMPL_DIR/$SERVER"
+  
+  echo "Successfully set up $IMPLEMENTATION implementation for $SERVER MCP server"
+  echo "The server is now active and ready to use"
+}
+
+# Remove a server implementation
+remove_server() {
+  if [ -z "$SERVER" ]; then
+    echo "Error: Missing server parameter"
+    echo "Usage: mcp-server remove <server> [implementation]"
+    exit 1
+  }
+  
+  # If implementation is not specified, list available implementations
+  if [ -z "$IMPLEMENTATION" ]; then
+    echo "Available implementations for $SERVER:"
+    for server_type in python typescript binary; do
+      if [ -d "$SERVERS_BASE_DIR/$server_type/$SERVER" ]; then
+        for impl in $(find "$SERVERS_BASE_DIR/$server_type/$SERVER" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null); do
+          if [ -f "$ACTIVE_IMPL_DIR/$SERVER" ] && [ "$(cat "$ACTIVE_IMPL_DIR/$SERVER")" = "$impl" ]; then
+            echo "  * $impl (active)"
+          else
+            echo "  - $impl"
+          fi
+        done
+      fi
+    done
+    echo "Please specify which implementation to remove:"
+    echo "  mcp-server remove $SERVER <implementation>"
+    exit 0
+  fi
+  
+  # Find the server type
+  SERVER_TYPE=""
+  for type in python typescript binary; do
+    if [ -d "$SERVERS_BASE_DIR/$type/$SERVER/$IMPLEMENTATION" ]; then
+      SERVER_TYPE="$type"
+      break
+    fi
+  done
+  
+  if [ -z "$SERVER_TYPE" ]; then
+    echo "Error: Implementation $IMPLEMENTATION for $SERVER not found"
+    exit 1
+  fi
+  
+  # Define paths
+  SERVERS_DIR="$SERVERS_BASE_DIR/$SERVER_TYPE/$SERVER/$IMPLEMENTATION"
+  VENV_DIR="$VENVS_BASE_DIR/$SERVER-$IMPLEMENTATION"
+  ACTIVE_IMPL_FILE="$ACTIVE_IMPL_DIR/$SERVER"
+  
+  # Check if this is the active implementation
+  if [ -f "$ACTIVE_IMPL_FILE" ] && [ "$(cat "$ACTIVE_IMPL_FILE")" = "$IMPLEMENTATION" ]; then
+    echo "Warning: Removing the active implementation for $SERVER"
+    echo "You will need to switch to another implementation after removal"
+  fi
+  
+  # Confirm removal
+  read -p "Are you sure you want to remove $IMPLEMENTATION implementation for $SERVER? (y/N) " -n 1 -r
+  echo
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Operation cancelled"
+    exit 0
+  fi
+  
+  # Remove the implementation directory
+  echo "Removing implementation directory at $SERVERS_DIR..."
+  rm -rf "$SERVERS_DIR"
+  
+  # Remove the virtual environment if it exists
+  if [ -d "$VENV_DIR" ]; then
+    echo "Removing virtual environment at $VENV_DIR..."
+    rm -rf "$VENV_DIR"
+  fi
+  
+  # If this was the active implementation, suggest switching to another one
+  if [ -f "$ACTIVE_IMPL_FILE" ] && [ "$(cat "$ACTIVE_IMPL_FILE")" = "$IMPLEMENTATION" ]; then
+    # Find other available implementations across all server types
+    OTHER_IMPLS=""
+    for type in python typescript binary; do
+      if [ -d "$SERVERS_BASE_DIR/$type/$SERVER" ]; then
+        FOUND_IMPLS=$(find "$SERVERS_BASE_DIR/$type/$SERVER" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null)
+        if [ -n "$FOUND_IMPLS" ]; then
+          OTHER_IMPLS="$OTHER_IMPLS $FOUND_IMPLS"
+        fi
+      fi
+    done
+    
+    if [ -n "$OTHER_IMPLS" ]; then
+      echo "Available implementations for $SERVER:"
+      echo "$OTHER_IMPLS" | tr ' ' '\n' | sed 's/^/  - /'
+      echo "Please switch to another implementation using:"
+      echo "  mcp-server update $SERVER <implementation>"
+    else
+      echo "No other implementations found for $SERVER"
+      echo "You may need to set up a new implementation"
+    fi
+  fi
+  
+  echo "Successfully removed $IMPLEMENTATION implementation for $SERVER"
+}
+
+# Update a server implementation
+update_server() {
+  if [ -z "$SERVER" ]; then
+    echo "Error: Missing server parameter"
+    echo "Usage: mcp-server update <server> [implementation]"
+    exit 1
+  }
+  
+  # If implementation is not specified, list available implementations
+  if [ -z "$IMPLEMENTATION" ]; then
+    echo "Available implementations for $SERVER:"
+    for server_type in python typescript binary; do
+      if [ -d "$SERVERS_BASE_DIR/$server_type/$SERVER" ]; then
+        for impl in $(find "$SERVERS_BASE_DIR/$server_type/$SERVER" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null); do
+          if [ -f "$ACTIVE_IMPL_DIR/$SERVER" ] && [ "$(cat "$ACTIVE_IMPL_DIR/$SERVER")" = "$impl" ]; then
+            echo "  * $impl (active)"
+          else
+            echo "  - $impl"
+          fi
+        done
+      fi
+    done
+    echo "Please specify which implementation to update:"
+    echo "  mcp-server update $SERVER <implementation>"
+    exit 0
+  fi
+  
+  # Find the server type
+  SERVER_TYPE=""
+  for type in python typescript binary; do
+    if [ -d "$SERVERS_BASE_DIR/$type/$SERVER/$IMPLEMENTATION" ]; then
+      SERVER_TYPE="$type"
+      break
+    fi
+  done
+  
+  if [ -z "$SERVER_TYPE" ]; then
+    echo "Error: Implementation $IMPLEMENTATION for $SERVER not found"
+    exit 1
+  fi
+  
+  # Define paths
+  SERVERS_DIR="$SERVERS_BASE_DIR/$SERVER_TYPE/$SERVER/$IMPLEMENTATION"
+  VENV_DIR="$VENVS_BASE_DIR/$SERVER-$IMPLEMENTATION"
+  
+  # Update the repository
+  echo "Updating $IMPLEMENTATION implementation for $SERVER..."
+  cd "$SERVERS_DIR"
+  git pull
+  
+  # For Python servers, update the package
+  if [ "$SERVER_TYPE" = "python" ] && [ -d "$VENV_DIR" ]; then
+    echo "Updating package installation..."
+    "$VENV_DIR/bin/pip" install -e .
+  fi
+  
+  # Set as active implementation
+  mkdir -p "$ACTIVE_IMPL_DIR"
+  echo "$IMPLEMENTATION" > "$ACTIVE_IMPL_DIR/$SERVER"
+  
+  echo "Successfully updated and activated $IMPLEMENTATION implementation for $SERVER"
+}
+
+# Main command processing
+case "$COMMAND" in
+  add)
+    add_server
+    ;;
+  remove)
+    remove_server
+    ;;
+  update)
+    update_server
+    ;;
+  list)
+    list_servers
+    ;;
+  help|--help|-h)
+    show_help
+    ;;
+  *)
+    echo "Error: Unknown command '$COMMAND'"
+    show_help
+    exit 1
+    ;;
+esac

--- a/mcp/scripts/mcp-setup-implementation
+++ b/mcp/scripts/mcp-setup-implementation
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# MCP Implementation Setup
+# Sets up a new MCP server implementation with its own virtual environment
+
+SERVER=$1
+IMPLEMENTATION=$2
+REPO_URL=$3
+
+if [ -z "$SERVER" ] || [ -z "$IMPLEMENTATION" ] || [ -z "$REPO_URL" ]; then
+  echo "Usage: mcp-setup-implementation <server> <implementation> <repo-url>"
+  echo "Example: mcp-setup-implementation git kzms https://github.com/atxtechbro/kzms-mcp-server-git.git"
+  exit 1
+fi
+
+# Create directories
+SERVERS_DIR=~/.local/share/mcp-servers/python/$SERVER/$IMPLEMENTATION
+VENV_DIR=~/ppv/pipelines/venvs/mcp-servers/$SERVER-$IMPLEMENTATION
+
+mkdir -p "$SERVERS_DIR"
+mkdir -p "$(dirname "$VENV_DIR")"
+
+# Clone repository
+echo "Cloning $REPO_URL to $SERVERS_DIR..."
+git clone "$REPO_URL" "$SERVERS_DIR"
+
+# Create virtual environment
+echo "Creating virtual environment at $VENV_DIR..."
+uv venv "$VENV_DIR"
+
+# Install package
+echo "Installing package in development mode..."
+cd "$SERVERS_DIR"
+"$VENV_DIR/bin/uv" pip install -e .
+
+# Set as active implementation
+mkdir -p ~/.config/mcp/active-implementations
+echo "$IMPLEMENTATION" > ~/.config/mcp/active-implementations/$SERVER
+
+echo "Successfully set up $IMPLEMENTATION implementation for $SERVER MCP server"
+echo "To use it, make sure your mcp.json points to the wrapper script"

--- a/mcp/scripts/mcp-switch
+++ b/mcp/scripts/mcp-switch
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# MCP Implementation Switcher
+# Switches between different implementations of the same MCP server type
+
+SERVER=$1
+IMPLEMENTATION=$2
+
+if [ -z "$SERVER" ] || [ -z "$IMPLEMENTATION" ]; then
+  echo "Usage: mcp-switch <server> <implementation>"
+  echo "Example: mcp-switch git kzms"
+  exit 1
+fi
+
+# Create directory if it doesn't exist
+mkdir -p ~/.config/mcp/active-implementations
+
+# Set the active implementation
+echo "$IMPLEMENTATION" > ~/.config/mcp/active-implementations/$SERVER
+
+echo "Switched $SERVER MCP server to $IMPLEMENTATION implementation"

--- a/mcp/setup-mcp.sh
+++ b/mcp/setup-mcp.sh
@@ -29,33 +29,33 @@ mkdir -p ~/ppv/pipelines/venvs/mcp-servers
 mkdir -p ~/.config/mcp/active-implementations
 
 # Create symlinks for wrapper scripts
-mkdir -p ~/ppv/pipelines/bin/mcp-wrappers
+mkdir -p ~/ppv/pillars/dotfiles/bin/mcp-wrappers
 
 # Use dynamic paths based on whether we're in a worktree
 if [[ "$IS_WORKTREE_PATH" == "true" ]]; then
   # In worktree - use current path for testing
-  ln -sf "$REPO_ROOT/mcp/wrappers/git-mcp-wrapper.sh" ~/ppv/pipelines/bin/mcp-wrappers/git-mcp-wrapper.sh
+  ln -sf "$REPO_ROOT/mcp/wrappers/git-mcp-wrapper.sh" ~/ppv/pillars/dotfiles/bin/mcp-wrappers/git-mcp-wrapper.sh
 else
   # In main repo or production - use standard path
-  ln -sf ~/ppv/pillars/dotfiles/mcp/wrappers/git-mcp-wrapper.sh ~/ppv/pipelines/bin/mcp-wrappers/git-mcp-wrapper.sh
+  ln -sf ~/ppv/pillars/dotfiles/mcp/wrappers/git-mcp-wrapper.sh ~/ppv/pillars/dotfiles/bin/mcp-wrappers/git-mcp-wrapper.sh
 fi
 
 # Create symlinks for utility scripts
-mkdir -p ~/ppv/pipelines/bin
+mkdir -p ~/ppv/pillars/dotfiles/bin
 
 # Use dynamic paths based on whether we're in a worktree
 if [[ "$IS_WORKTREE_PATH" == "true" ]]; then
   # In worktree - use current path for testing
-  ln -sf "$REPO_ROOT/mcp/scripts/mcp-switch" ~/ppv/pipelines/bin/mcp-switch
-  ln -sf "$REPO_ROOT/mcp/scripts/mcp-setup-implementation" ~/ppv/pipelines/bin/mcp-setup-implementation
-  ln -sf "$REPO_ROOT/mcp/scripts/mcp-remove-implementation" ~/ppv/pipelines/bin/mcp-remove-implementation
-  ln -sf "$REPO_ROOT/mcp/scripts/mcp-server" ~/ppv/pipelines/bin/mcp-server
+  ln -sf "$REPO_ROOT/mcp/scripts/mcp-switch" ~/ppv/pillars/dotfiles/bin/mcp-switch
+  ln -sf "$REPO_ROOT/mcp/scripts/mcp-setup-implementation" ~/ppv/pillars/dotfiles/bin/mcp-setup-implementation
+  ln -sf "$REPO_ROOT/mcp/scripts/mcp-remove-implementation" ~/ppv/pillars/dotfiles/bin/mcp-remove-implementation
+  ln -sf "$REPO_ROOT/mcp/scripts/mcp-server" ~/ppv/pillars/dotfiles/bin/mcp-server
 else
   # In main repo or production - use standard path
-  ln -sf ~/ppv/pillars/dotfiles/mcp/scripts/mcp-switch ~/ppv/pipelines/bin/mcp-switch
-  ln -sf ~/ppv/pillars/dotfiles/mcp/scripts/mcp-setup-implementation ~/ppv/pipelines/bin/mcp-setup-implementation
-  ln -sf ~/ppv/pillars/dotfiles/mcp/scripts/mcp-remove-implementation ~/ppv/pipelines/bin/mcp-remove-implementation
-  ln -sf ~/ppv/pillars/dotfiles/mcp/scripts/mcp-server ~/ppv/pipelines/bin/mcp-server
+  ln -sf ~/ppv/pillars/dotfiles/mcp/scripts/mcp-switch ~/ppv/pillars/dotfiles/bin/mcp-switch
+  ln -sf ~/ppv/pillars/dotfiles/mcp/scripts/mcp-setup-implementation ~/ppv/pillars/dotfiles/bin/mcp-setup-implementation
+  ln -sf ~/ppv/pillars/dotfiles/mcp/scripts/mcp-remove-implementation ~/ppv/pillars/dotfiles/bin/mcp-remove-implementation
+  ln -sf ~/ppv/pillars/dotfiles/mcp/scripts/mcp-server ~/ppv/pillars/dotfiles/bin/mcp-server
 fi
 
 echo "MCP server infrastructure setup complete!"

--- a/mcp/setup-mcp.sh
+++ b/mcp/setup-mcp.sh
@@ -13,6 +13,7 @@ REPO_ROOT="$( cd "$SCRIPT_DIR/.." && pwd )"
 # Detect if running in a worktree
 IS_WORKTREE=$(git rev-parse --is-inside-work-tree 2>/dev/null && echo "true" || echo "false")
 MAIN_REPO_PATH=$(git rev-parse --show-toplevel 2>/dev/null || echo "$HOME/ppv/pillars/dotfiles")
+IS_WORKTREE_PATH=$(echo "$MAIN_REPO_PATH" | grep -q "pr-" && echo "true" || echo "false")
 
 echo "Setting up MCP server infrastructure..."
 
@@ -31,7 +32,7 @@ mkdir -p ~/.config/mcp/active-implementations
 mkdir -p ~/ppv/pipelines/bin/mcp-wrappers
 
 # Use dynamic paths based on whether we're in a worktree
-if [[ "$IS_WORKTREE" == "true" && "$MAIN_REPO_PATH" != "$HOME/ppv/pillars/dotfiles" ]]; then
+if [[ "$IS_WORKTREE_PATH" == "true" ]]; then
   # In worktree - use current path for testing
   ln -sf "$REPO_ROOT/mcp/wrappers/git-mcp-wrapper.sh" ~/ppv/pipelines/bin/mcp-wrappers/git-mcp-wrapper.sh
 else
@@ -43,7 +44,7 @@ fi
 mkdir -p ~/ppv/pipelines/bin
 
 # Use dynamic paths based on whether we're in a worktree
-if [[ "$IS_WORKTREE" == "true" && "$MAIN_REPO_PATH" != "$HOME/ppv/pillars/dotfiles" ]]; then
+if [[ "$IS_WORKTREE_PATH" == "true" ]]; then
   # In worktree - use current path for testing
   ln -sf "$REPO_ROOT/mcp/scripts/mcp-switch" ~/ppv/pipelines/bin/mcp-switch
   ln -sf "$REPO_ROOT/mcp/scripts/mcp-setup-implementation" ~/ppv/pipelines/bin/mcp-setup-implementation
@@ -61,7 +62,7 @@ echo "MCP server infrastructure setup complete!"
 echo ""
 
 # Display warning if in worktree mode
-if [[ "$IS_WORKTREE" == "true" && "$MAIN_REPO_PATH" != "$HOME/ppv/pillars/dotfiles" ]]; then
+if [[ "$IS_WORKTREE_PATH" == "true" ]]; then
   echo "⚠️  Running in worktree mode - symlinks point to this worktree"
   echo "   These symlinks will need to be updated when merging to main"
   echo ""

--- a/mcp/setup-mcp.sh
+++ b/mcp/setup-mcp.sh
@@ -28,19 +28,12 @@ mkdir -p ~/ppv/pipelines/bin
 ln -sf ~/ppv/pillars/dotfiles/mcp/scripts/mcp-switch ~/ppv/pipelines/bin/mcp-switch
 ln -sf ~/ppv/pillars/dotfiles/mcp/scripts/mcp-setup-implementation ~/ppv/pipelines/bin/mcp-setup-implementation
 ln -sf ~/ppv/pillars/dotfiles/mcp/scripts/mcp-remove-implementation ~/ppv/pipelines/bin/mcp-remove-implementation
+ln -sf ~/ppv/pillars/dotfiles/mcp/scripts/mcp-server ~/ppv/pipelines/bin/mcp-server
 
 echo "MCP server infrastructure setup complete!"
 echo ""
-echo "To set up the kzms Git MCP server implementation, run:"
-echo "  mcp-setup-implementation git kzms https://github.com/atxtechbro/kzms-mcp-server-git.git"
-echo ""
-echo "To update your MCP configuration, edit ~/ppv/pillars/dotfiles/mcp/mcp.json:"
-echo '{
-  "git": {
-    "command": "~/ppv/pipelines/bin/mcp-wrappers/git-mcp-wrapper.sh",
-    "args": [],
-    "env": {
-      "FASTMCP_LOG_LEVEL": "ERROR"
-    }
-  }
-}'
+echo "To manage your MCP servers, use the following commands:"
+echo "  mcp-server add git kzms https://github.com/atxtechbro/kzms-mcp-server-git.git"
+echo "  mcp-server remove git"
+echo "  mcp-server update git"
+echo "  mcp-server list"

--- a/mcp/setup-mcp.sh
+++ b/mcp/setup-mcp.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# MCP Setup Script
+# Creates the necessary directory structure for MCP server implementations
+# Following the "spilled coffee principle" for reproducible environments
+
+set -e
+
+echo "Setting up MCP server infrastructure..."
+
+# Create directories for MCP server implementations
+mkdir -p ~/.local/share/mcp-servers/{python,typescript,binary}
+mkdir -p ~/.local/share/mcp-servers/python/git/{kzms,cyanheads}
+mkdir -p ~/.local/share/mcp-servers/typescript/git/{cyanheads}
+
+# Create directories for virtual environments
+mkdir -p ~/ppv/pipelines/venvs/mcp-servers
+
+# Create directories for configuration
+mkdir -p ~/.config/mcp/active-implementations
+
+# Create symlinks for wrapper scripts
+mkdir -p ~/ppv/pipelines/bin/mcp-wrappers
+ln -sf ~/ppv/pillars/dotfiles/mcp/wrappers/git-mcp-wrapper.sh ~/ppv/pipelines/bin/mcp-wrappers/git-mcp-wrapper.sh
+
+# Create symlinks for utility scripts
+mkdir -p ~/ppv/pipelines/bin
+ln -sf ~/ppv/pillars/dotfiles/mcp/scripts/mcp-switch ~/ppv/pipelines/bin/mcp-switch
+ln -sf ~/ppv/pillars/dotfiles/mcp/scripts/mcp-setup-implementation ~/ppv/pipelines/bin/mcp-setup-implementation
+
+echo "MCP server infrastructure setup complete!"
+echo ""
+echo "To set up the kzms Git MCP server implementation, run:"
+echo "  mcp-setup-implementation git kzms https://github.com/atxtechbro/kzms-mcp-server-git.git"
+echo ""
+echo "To update your MCP configuration, edit ~/ppv/pillars/dotfiles/mcp/mcp.json:"
+echo '{
+  "git": {
+    "command": "~/ppv/pipelines/bin/mcp-wrappers/git-mcp-wrapper.sh",
+    "args": [],
+    "env": {
+      "FASTMCP_LOG_LEVEL": "ERROR"
+    }
+  }
+}'

--- a/mcp/setup-mcp.sh
+++ b/mcp/setup-mcp.sh
@@ -27,6 +27,7 @@ ln -sf ~/ppv/pillars/dotfiles/mcp/wrappers/git-mcp-wrapper.sh ~/ppv/pipelines/bi
 mkdir -p ~/ppv/pipelines/bin
 ln -sf ~/ppv/pillars/dotfiles/mcp/scripts/mcp-switch ~/ppv/pipelines/bin/mcp-switch
 ln -sf ~/ppv/pillars/dotfiles/mcp/scripts/mcp-setup-implementation ~/ppv/pipelines/bin/mcp-setup-implementation
+ln -sf ~/ppv/pillars/dotfiles/mcp/scripts/mcp-remove-implementation ~/ppv/pipelines/bin/mcp-remove-implementation
 
 echo "MCP server infrastructure setup complete!"
 echo ""

--- a/mcp/wrappers/git-mcp-wrapper.sh
+++ b/mcp/wrappers/git-mcp-wrapper.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Git MCP Server Wrapper
+# This script provides a consistent interface for different Git MCP server implementations
+# Following the "spilled coffee principle" for reproducible environments
+
+# Configuration
+ACTIVE_IMPL=$(cat ~/.config/mcp/active-implementations/git 2>/dev/null || echo "kzms")
+MCP_SERVERS_DIR=~/.local/share/mcp-servers
+VENVS_DIR=~/ppv/pipelines/venvs/mcp-servers
+
+# Check if virtual environment exists for active implementation
+if [ -d "$VENVS_DIR/git-$ACTIVE_IMPL" ]; then
+  PYTHON_BIN="$VENVS_DIR/git-$ACTIVE_IMPL/bin/python"
+else
+  PYTHON_BIN="python"
+fi
+
+# Implementation paths (in priority order)
+IMPLEMENTATIONS=(
+  "$MCP_SERVERS_DIR/python/git/$ACTIVE_IMPL/src/mcp_server_git/__main__.py"
+  "$MCP_SERVERS_DIR/typescript/git/$ACTIVE_IMPL/dist/index.js"
+  "$MCP_SERVERS_DIR/binary/git/$ACTIVE_IMPL"
+)
+
+# Find and execute the first available implementation
+for impl in "${IMPLEMENTATIONS[@]}"; do
+  if [ -f "$impl" ]; then
+    case "$impl" in
+      *.py)
+        exec "$PYTHON_BIN" "$impl" "$@"
+        ;;
+      *.js)
+        exec node "$impl" "$@"
+        ;;
+      *)
+        exec "$impl" "$@"
+        ;;
+    esac
+  fi
+done
+
+# Fallback to installed packages
+if [ "$ACTIVE_IMPL" = "kzms" ] && [ -d "$VENVS_DIR/git-kzms" ]; then
+  exec "$VENVS_DIR/git-kzms/bin/python" -m mcp_server_git "$@"
+elif [ "$ACTIVE_IMPL" = "kzms" ]; then
+  exec uvx run mcp_server_git "$@"
+elif [ "$ACTIVE_IMPL" = "cyanheads" ]; then
+  exec npx git-mcp-server "$@"
+else
+  echo "Error: No implementation found for git MCP server ($ACTIVE_IMPL)"
+  exit 1
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -43,6 +43,8 @@ export DOT_DEN
 export PATH="$DOT_DEN/mcp:$PATH"
 # Add MCP servers directory to PATH
 export PATH="$DOT_DEN/mcp/servers:$PATH"
+# Add dotfiles bin directory to PATH
+export PATH="$DOT_DEN/bin:$PATH"
 
 # Export flag to tell subscripts we're running from the main setup
 export SETUP_SCRIPT_RUNNING=true


### PR DESCRIPTION
## Overview

This PR implements a modular system for managing MCP server implementations, allowing easy switching between different implementations of the same MCP server type (e.g., kzms-mcp-server-git vs cyanheads/git-mcp-server).

## Changes

- Created directory structure for MCP configuration
- Implemented wrapper script for Git MCP server
- Created implementation switching script
- Added setup script for MCP infrastructure
- Created configuration templates for different implementations
- Added comprehensive documentation

## Usage

After merging this PR, you can:

1. Run the setup script to create the necessary directory structure:
   ```bash
   ./mcp/setup-mcp.sh
   ```

2. Set up the kzms implementation:
   ```bash
   mcp-setup-implementation git kzms https://github.com/atxtechbro/kzms-mcp-server-git.git
   ```

3. Switch between implementations:
   ```bash
   mcp-switch git kzms    # Switch to kzms implementation
   mcp-switch git cyanheads  # Switch to cyanheads implementation
   ```

4. Update your MCP configuration to use the wrapper script by copying the contents of `mcp/config/git-wrapper.json` to your `mcp/mcp.json` file.

## Testing

The implementation has been tested with:
- Switching between kzms and cyanheads implementations
- Setting up new implementations
- Using the wrapper script with different implementations

## Next Steps

Future improvements could include:
- Extending the system to other MCP server types
- Adding automatic discovery of new implementations
- Creating a unified management interface

Closes #299