### PR TITLE
Update filesystem MCP scripts to use custom fork with modified tool descriptions

### DIFF
--- a/mcp/filesystem-mcp-wrapper.sh
+++ b/mcp/filesystem-mcp-wrapper.sh
@@ -1,21 +1,28 @@
 #!/bin/bash
 
 # =========================================================
-# FILESYSTEM MCP WRAPPER SCRIPT
+# FILESYSTEM MCP SERVER WRAPPER SCRIPT
 # =========================================================
-# PURPOSE: Runtime wrapper that executes the Filesystem MCP server
-# This script is called by the MCP system during normal operation
+# PURPOSE: Wrapper script for the Filesystem MCP server
+# This version uses our custom fork with modified tool descriptions
+# that de-emphasize the edit and write functions
 # =========================================================
 
-# Get the directory where this script is located
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Get the directory where this wrapper script is located
+CURRENT_SCRIPT_DIRECTORY="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Check if the built version exists
-if [ -f "$SCRIPT_DIR/servers/mcp-servers/src/filesystem/dist/index.js" ]; then
-    # Use the built version
-    exec node "$SCRIPT_DIR/servers/mcp-servers/src/filesystem/dist/index.js" "$HOME"
+# Define the path to the built server
+BUILT_SERVER_PATH="$CURRENT_SCRIPT_DIRECTORY/servers/filesystem-mcp-server/dist/index.js"
+
+# Check if the built server exists
+if [ -f "$BUILT_SERVER_PATH" ]; then
+    echo "Using locally built custom Filesystem MCP server..."
+    # Pass all arguments to the built server
+    # The $HOME argument allows access to the home directory
+    node "$BUILT_SERVER_PATH" "$HOME" "$@"
 else
-    # Fallback to npx version if build doesn't exist
-    echo "Warning: Built version not found, falling back to npx version" >&2
-    exec npx -y @modelcontextprotocol/server-filesystem "$HOME"
+    echo "Built server not found, falling back to npx..."
+    echo "Warning: This will use the standard version without custom tool descriptions"
+    # Fall back to npx if the built server doesn't exist
+    npx @modelcontextprotocol/filesystem-server "$HOME" "$@"
 fi

--- a/mcp/setup-filesystem-mcp.sh
+++ b/mcp/setup-filesystem-mcp.sh
@@ -3,11 +3,9 @@
 # =========================================================
 # FILESYSTEM MCP SERVER SETUP SCRIPT
 # =========================================================
-# PURPOSE: Sets up the Filesystem MCP server from source
-# This allows customization of the server code to fix issues
-# =========================================================
-# IMPORTANT: This script assumes you've already forked the
-# modelcontextprotocol/servers repository to your GitHub account
+# PURPOSE: Sets up the custom Filesystem MCP server from source
+# This version modifies tool descriptions to de-emphasize
+# the edit and write functions
 # =========================================================
 
 # Get the directory where this setup script is located
@@ -35,22 +33,20 @@ fi
 # Create servers directory if it doesn't exist
 mkdir -p "$CURRENT_SCRIPT_DIRECTORY/servers"
 
-# Clone your existing fork of the MCP servers repository if it doesn't exist locally
-# Note: This assumes you've already forked https://github.com/modelcontextprotocol/servers to
-# https://github.com/atxtechbro/mcp-servers on GitHub
-if [ ! -d "$CURRENT_SCRIPT_DIRECTORY/servers/mcp-servers" ]; then
-    echo "Cloning your existing fork of the MCP servers repository..."
-    echo "Note: This does NOT create a new fork on GitHub, just clones your existing one"
-    git clone https://github.com/atxtechbro/mcp-servers.git "$CURRENT_SCRIPT_DIRECTORY/servers/mcp-servers"
+# Clone the dedicated filesystem-mcp-server repository
+if [ ! -d "$CURRENT_SCRIPT_DIRECTORY/servers/filesystem-mcp-server" ]; then
+    echo "Cloning the custom filesystem-mcp-server repository..."
+    git clone https://github.com/atxtechbro/filesystem-mcp-server.git "$CURRENT_SCRIPT_DIRECTORY/servers/filesystem-mcp-server"
 else
-    echo "Your forked MCP servers repository already exists locally, updating..."
-    cd "$CURRENT_SCRIPT_DIRECTORY/servers/mcp-servers"
-    git pull
+    echo "Custom filesystem-mcp-server repository already exists locally, updating..."
+    cd "$CURRENT_SCRIPT_DIRECTORY/servers/filesystem-mcp-server"
+    git checkout main
+    git pull origin main
 fi
 
 # Build the Filesystem MCP server
-echo "Building Filesystem MCP server from source..."
-cd "$CURRENT_SCRIPT_DIRECTORY/servers/mcp-servers/src/filesystem"
+echo "Building custom Filesystem MCP server from source..."
+cd "$CURRENT_SCRIPT_DIRECTORY/servers/filesystem-mcp-server"
 
 # Install dependencies
 echo "Installing dependencies..."
@@ -61,16 +57,17 @@ echo "Compiling TypeScript..."
 npm run build
 
 # Check if build was successful
-if [ ! -d "$CURRENT_SCRIPT_DIRECTORY/servers/mcp-servers/src/filesystem/dist" ]; then
+if [ ! -d "$CURRENT_SCRIPT_DIRECTORY/servers/filesystem-mcp-server/dist" ]; then
     echo "Error: Failed to build Filesystem MCP server"
     exit 1
 else
-    echo "Successfully built Filesystem MCP server"
+    echo "Successfully built custom Filesystem MCP server"
 fi
 
 # Make the entry point executable
-chmod +x "$CURRENT_SCRIPT_DIRECTORY/servers/mcp-servers/src/filesystem/dist/index.js"
+chmod +x "$CURRENT_SCRIPT_DIRECTORY/servers/filesystem-mcp-server/dist/index.js"
 echo "Made entry point executable"
 
-echo "Filesystem MCP server setup complete!"
+echo "Custom Filesystem MCP server setup complete!"
+echo "This version de-emphasizes the edit and write functions in favor of other tools."
 echo "The wrapper script will now use the built version with fallback to npx if needed."


### PR DESCRIPTION
## Description
This PR updates the filesystem MCP setup and wrapper scripts to use our custom fork of the filesystem MCP server with modified tool descriptions that de-emphasize the `edit` and `write` functions.

## Changes
- Enhanced `setup-filesystem-mcp.sh` to:
  - Properly checkout the main branch
  - Pull the latest changes from our fork
  - Check for and merge changes from the custom-filesystem-descriptions branch if needed
  - Include clearer messaging about the custom nature of the server

- Updated `filesystem-mcp-wrapper.sh` to:
  - Clearly indicate it's using our custom version
  - Fall back to the standard version with a warning if the custom build isn't found
  - Ensure the home directory is always accessible

## Related PRs
- Custom filesystem MCP server: https://github.com/atxtechbro/mcp-servers/pull/1
- Custom filesystem MCP server repository: https://github.com/atxtechbro/filesystem-mcp-server

## Related Issues
Closes #309