### PR TITLE
Fix: Resolve issue #313 with GitHub MCP server binary path

### DIFF
--- a/mcp/github-mcp-wrapper.sh
+++ b/mcp/github-mcp-wrapper.sh
@@ -13,7 +13,8 @@ fi
 export GITHUB_PERSONAL_ACCESS_TOKEN="$TOKEN"
 
 # Path to the GitHub MCP server binary
-GITHUB_BINARY_PATH="$(dirname "$0")/servers/github"
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+GITHUB_BINARY_PATH="$SCRIPT_DIR/servers/github"
 
 # Check if the binary exists and is executable
 if [ ! -x "$GITHUB_BINARY_PATH" ]; then


### PR DESCRIPTION
## Problem
The GitHub MCP wrapper script was using a relative path to find the binary, which could fail depending on how the script was invoked. This was causing issue #313 where the GitHub MCP server integration was failing because it couldn't locate the binary.

## Solution
This PR modifies the `github-mcp-wrapper.sh` script to use `readlink -f` to get the absolute path of the script directory, ensuring the binary is found correctly regardless of how the wrapper is called.

## Changes
- Added `SCRIPT_DIR` variable that uses `readlink -f` to get the absolute path of the script
- Updated the `GITHUB_BINARY_PATH` to use this absolute path

## Testing
The script now correctly locates the GitHub MCP server binary regardless of the current working directory when the script is invoked.

Fixes #313