### PR TITLE
Fix npm prefix configuration conflict with nvm

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -255,6 +255,11 @@ fi
 echo -e "${DIVIDER}"
 echo "Setting up Node.js with NVM..."
 
+# Fix npm prefix configuration conflict with nvm
+if [ -f "$DOT_DEN/utils/fix-npm-nvm-conflict.sh" ]; then
+  bash "$DOT_DEN/utils/fix-npm-nvm-conflict.sh"
+fi
+
 # Ensure NVM directory exists
 export NVM_DIR="$HOME/.nvm"
 

--- a/utils/fix-npm-nvm-conflict.sh
+++ b/utils/fix-npm-nvm-conflict.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Fix npm prefix configuration conflict with nvm
+
+# Check if .npmrc exists and has prefix setting
+if [ -f "$HOME/.npmrc" ] && grep -q "prefix=" "$HOME/.npmrc"; then
+  # Create backup and remove prefix line in one operation
+  sed '/prefix=/d' "$HOME/.npmrc" > "$HOME/.npmrc.new"
+  mv "$HOME/.npmrc" "$HOME/.npmrc.bak"
+  mv "$HOME/.npmrc.new" "$HOME/.npmrc"
+fi


### PR DESCRIPTION
## Description
This PR fixes the npm prefix configuration conflict with nvm (Issue #319).

## Changes
- Added a small utility script `utils/fix-npm-nvm-conflict.sh` that:
  - Checks if `.npmrc` exists and contains a `prefix=` setting
  - Creates a backup of the original file
  - Removes the prefix line that conflicts with nvm
- Updated `setup.sh` to run this script during the Node.js setup phase

## Testing
- Tested with `.npmrc` containing `prefix=/usr/local`
- Confirmed that the script successfully removes the prefix line
- Verified that nvm works correctly after the fix

Fixes #319