### PR TITLE
fix(nvim-dap): Force buffer switch with unsaved changes during debugging

### DIFF
--- a/nvim/lua/config/dap.lua
+++ b/nvim/lua/config/dap.lua
@@ -290,7 +290,8 @@ dap.listeners.after.event_stopped['dapui_focus'] = function()
       
       if path then
         -- Open file at location and center screen
-        vim.cmd("edit " .. vim.fn.fnameescape(path))
+        -- Use edit! to force buffer switch even with unsaved changes (VS Code-like behavior)
+        vim.cmd("edit! " .. vim.fn.fnameescape(path))
         vim.api.nvim_win_set_cursor(0, {session.current_frame.line, 0})
         vim.cmd("normal! zz")
         
@@ -331,7 +332,8 @@ dap.listeners.after.scopes['dapui_frame_focus'] = function()
       
       if path then
         -- Open file at location and center screen
-        vim.cmd("edit " .. vim.fn.fnameescape(path))
+        -- Use edit! to force buffer switch even with unsaved changes (VS Code-like behavior)
+        vim.cmd("edit! " .. vim.fn.fnameescape(path))
         vim.api.nvim_win_set_cursor(0, {session.current_frame.line, 0})
         vim.cmd("normal! zz")
         


### PR DESCRIPTION
## Description
This PR fixes the error that occurs during debugging when trying to switch buffers with unsaved changes.

## Changes
- Use `edit!` instead of `edit` to force buffer switching even with unsaved changes
- Match VS Code's behavior which switches to debug location regardless of buffer state
- Fix error: E37: No write since last change

## Related Issue
Closes #326