### PR TITLE
Fix Clojure MCP integration

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -12,4 +12,5 @@
                 com.bhauman/clojure-mcp {:git/url "https://github.com/bhauman/clojure-mcp.git"
                                          :git/sha "83627e7095f0ebab3d5503a5b2ee94aa6953cb0d"}}
          :exec-fn clojure-mcp.main/start-mcp-server
-         :exec-args {:port 7888}}}}
+         :exec-args {:port 7888
+                     :host "localhost"}}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,8 @@
+{:paths ["src"]
+ :deps {}
+ :aliases {
+   ;; nREPL server for AI to connect to
+   :nrepl {:extra-paths ["test"] 
+           :extra-deps {nrepl/nrepl {:mvn/version "1.3.1"}}
+           :jvm-opts ["-Djdk.attach.allowAttachSelf"]
+           :main-opts ["-m" "nrepl.cmdline" "--port" "7888"]}}}

--- a/mcp/README-clojure-mcp.md
+++ b/mcp/README-clojure-mcp.md
@@ -11,25 +11,35 @@ The Clojure MCP integration requires two separate processes:
 
 Both must be running for the integration to work properly.
 
-## Usage
+## Setup Instructions
 
-### Starting the nREPL Server
+### Step 1: Configure Your Project
 
-First, start an nREPL server in your project directory:
+Make sure your project has the nREPL configuration in `deps.edn`:
+
+```clojure
+{:aliases {
+  ;; nREPL server for AI to connect to
+  :nrepl {:extra-paths ["test"] 
+          :extra-deps {nrepl/nrepl {:mvn/version "1.3.1"}}
+          :jvm-opts ["-Djdk.attach.allowAttachSelf"]
+          :main-opts ["-m" "nrepl.cmdline" "--port" "7888"]}}}
+```
+
+### Step 2: Start the nREPL Server
+
+Start an nREPL server in your project directory:
 
 ```bash
+cd /path/to/your/project
 clojure -M:nrepl
 ```
 
-This will start an nREPL server on port 7888.
+You should see: `nREPL server started on port 7888 on host localhost - nrepl://localhost:7888`
 
-### Starting the Clojure MCP Server
+### Step 3: Use Amazon Q with Clojure MCP
 
-After the nREPL server is running, open a new terminal and start the Clojure MCP server:
-
-```bash
-clj-mcp-start
-```
+After the nREPL server is running, you can use Amazon Q which will automatically connect to the Clojure MCP server.
 
 ## Troubleshooting
 
@@ -39,4 +49,8 @@ Steps to resolve:
 
 1. Ensure you've started the nREPL server with `clojure -M:nrepl`
 2. Check that the nREPL server is running on port 7888
-3. Only then start the Clojure MCP server with `clj-mcp-start`
+3. Then try using Amazon Q again
+
+## Advanced Configuration
+
+For advanced configuration options, see the [official Clojure MCP documentation](https://github.com/bhauman/clojure-mcp).

--- a/mcp/clojure-mcp-wrapper.sh
+++ b/mcp/clojure-mcp-wrapper.sh
@@ -1,14 +1,16 @@
-#!/bin/bash
-# clojure-mcp-wrapper.sh - Wrapper script for Clojure MCP server
-# This script follows the pattern of other MCP wrapper scripts in the repository
-
-set -e
+#!/bin/bash -x
+# clojure-mcp-wrapper.sh - Robust wrapper script for Clojure MCP server
+# Following the "Spilled Coffee Principle" - works regardless of where it's called from
 
 # Define colors for output
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 RED='\033[0;31m'
 NC='\033[0m' # No Color
+
+# Get the absolute path of the script directory
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+PROJECT_DIR="$( cd "$SCRIPT_DIR/.." &> /dev/null && pwd )"
 
 # Define log file
 LOG_FILE="/tmp/clojure-mcp-debug.log"
@@ -24,10 +26,15 @@ log() {
 
 # Log environment information
 log "Starting Clojure MCP wrapper script"
-log "Current directory: $(pwd)"
-log "Script location: $(readlink -f "$0")"
+log "Script directory: $SCRIPT_DIR"
+log "Project directory: $PROJECT_DIR"
+log "Current directory before switch: $(pwd)"
 log "User: $(whoami)"
 log "PATH: $PATH"
+
+# Change to the project directory
+cd "$PROJECT_DIR"
+log "Changed to project directory: $(pwd)"
 
 # Check if the server is already running
 if pgrep -f "clojure.*:mcp" > /dev/null; then
@@ -42,13 +49,40 @@ if ! command -v clojure &> /dev/null; then
   exit 1
 fi
 
+# Check if deps.edn exists in the project directory
+if [ ! -f "$PROJECT_DIR/deps.edn" ]; then
+  log "${RED}Error: deps.edn not found in $PROJECT_DIR${NC}"
+  log "Please ensure the deps.edn file exists with proper nREPL and MCP configurations."
+  exit 1
+fi
+
 # Check if an nREPL server is running on port 7888
 log "Checking for nREPL server on port 7888..."
 if ! (echo > /dev/tcp/localhost/7888) 2>/dev/null; then
-  log "${RED}Error: No nREPL server found on port 7888${NC}"
-  log "Please start an nREPL server first with: ${YELLOW}clojure -M:nrepl${NC}"
-  log "Then run this command again."
-  exit 1
+  log "${YELLOW}No nREPL server found on port 7888. Starting one...${NC}"
+  
+  # Start nREPL server in the background
+  clojure -M:nrepl &
+  NREPL_PID=$!
+  log "Started nREPL server with PID: $NREPL_PID"
+  
+  # Wait for nREPL server to start
+  for i in {1..10}; do
+    if (echo > /dev/tcp/localhost/7888) 2>/dev/null; then
+      log "${GREEN}nREPL server is now running on port 7888${NC}"
+      break
+    fi
+    log "Waiting for nREPL server to start... ($i/10)"
+    sleep 1
+  done
+  
+  # Check if nREPL server started successfully
+  if ! (echo > /dev/tcp/localhost/7888) 2>/dev/null; then
+    log "${RED}Error: Failed to start nREPL server${NC}"
+    exit 1
+  fi
+else
+  log "${GREEN}nREPL server already running on port 7888${NC}"
 fi
 
 # Use the MCP protocol to communicate with the client
@@ -57,5 +91,8 @@ log "Sent MCP initialization message"
 
 # Start the MCP server
 log "${GREEN}Starting Clojure MCP server...${NC}"
-log "Using port 7888 to connect to nREPL server"
-exec clojure -X:mcp 2>> "$LOG_FILE"
+log "Using port 7888 for MCP server and nREPL connection"
+log "Using deps.edn from: $PROJECT_DIR/deps.edn"
+
+# Execute with full path to ensure consistency
+cd "$PROJECT_DIR" && exec clojure -X:mcp 2>> "$LOG_FILE"

--- a/mcp/clojure-mcp-wrapper.sh
+++ b/mcp/clojure-mcp-wrapper.sh
@@ -57,4 +57,5 @@ log "Sent MCP initialization message"
 
 # Start the MCP server
 log "${GREEN}Starting Clojure MCP server...${NC}"
+log "Using port 7888 to connect to nREPL server"
 exec clojure -X:mcp 2>> "$LOG_FILE"

--- a/mcp/clojure-mcp-wrapper.sh
+++ b/mcp/clojure-mcp-wrapper.sh
@@ -2,7 +2,24 @@
 # clojure-mcp-wrapper.sh - Wrapper script for Clojure MCP server
 # This script follows the pattern of other MCP wrapper scripts in the repository
 
-set -e
+# Define log file
+LOG_FILE="/tmp/clojure-mcp-debug.log"
+
+# Clear previous log
+echo "=== Clojure MCP Wrapper Debug Log $(date) ===" > "$LOG_FILE"
+
+# Log function
+log() {
+  echo "$(date +"%Y-%m-%d %H:%M:%S") - $1" >> "$LOG_FILE"
+  echo "$1" >&2
+}
+
+# Log environment information
+log "Starting Clojure MCP wrapper script"
+log "Current directory: $(pwd)"
+log "Script location: $(readlink -f "$0")"
+log "User: $(whoami)"
+log "PATH: $PATH"
 
 # Define colors for output
 GREEN='\033[0;32m'
@@ -12,25 +29,44 @@ NC='\033[0m' # No Color
 
 # Check if the server is already running
 if pgrep -f "clojure.*:mcp" > /dev/null; then
-  echo -e "${YELLOW}Clojure MCP server is already running${NC}"
+  log "${YELLOW}Clojure MCP server is already running${NC}"
   exit 0
 fi
 
 # Check for required dependencies
 if ! command -v clojure &> /dev/null; then
-  echo -e "${RED}Error: clojure is required but not installed.${NC}"
-  echo -e "Please install clojure first."
+  log "${RED}Error: clojure is required but not installed.${NC}"
+  log "Please install clojure first."
   exit 1
 fi
 
-# Check if an nREPL server is running on port 7888
-if ! nc -z localhost 7888 2>/dev/null; then
-  echo -e "${RED}Error: No nREPL server found on port 7888${NC}"
-  echo -e "Please start an nREPL server first with: ${YELLOW}clojure -M:nrepl${NC}"
-  echo -e "Then run this command again."
-  exit 1
+# Check if netcat is available for port checking
+if ! command -v nc &> /dev/null; then
+  log "${YELLOW}Warning: nc command not found, using alternative method to check port${NC}"
+  # Alternative method to check if port is open
+  if ! (echo > /dev/tcp/localhost/7888) 2>/dev/null; then
+    log "${RED}Error: No nREPL server found on port 7888${NC}"
+    log "Please start an nREPL server first with: ${YELLOW}clojure -M:nrepl${NC}"
+    log "Then run this command again."
+    exit 1
+  fi
+else
+  # Check if an nREPL server is running on port 7888
+  if ! nc -z localhost 7888 2>/dev/null; then
+    log "${RED}Error: No nREPL server found on port 7888${NC}"
+    log "Please start an nREPL server first with: ${YELLOW}clojure -M:nrepl${NC}"
+    log "Then run this command again."
+    exit 1
+  fi
 fi
 
-# Start the server
-echo -e "${GREEN}Starting Clojure MCP server...${NC}"
-exec clojure -X:mcp
+# Log that we're starting the server
+log "${GREEN}Starting Clojure MCP server...${NC}"
+
+# Use the MCP protocol to communicate with the client
+echo '{"jsonrpc":"2.0","id":1,"method":"mcp.init","params":{"version":"0.1","capabilities":{}}}' >&2
+log "Sent MCP initialization message"
+
+# Run the server with proper error handling
+log "Executing: clojure -X:mcp"
+exec clojure -X:mcp 2>> "$LOG_FILE"

--- a/mcp/clojure-mcp-wrapper.sh
+++ b/mcp/clojure-mcp-wrapper.sh
@@ -51,13 +51,10 @@ if ! (echo > /dev/tcp/localhost/7888) 2>/dev/null; then
   exit 1
 fi
 
-# Log that we're starting the server
-log "${GREEN}Starting Clojure MCP server...${NC}"
-
 # Use the MCP protocol to communicate with the client
 echo '{"jsonrpc":"2.0","id":1,"method":"mcp.init","params":{"version":"0.1","capabilities":{}}}' >&2
 log "Sent MCP initialization message"
 
-# Run the server with proper error handling - use port 7889 for the MCP server
-log "Executing: clojure -X:mcp :port 7889"
-exec clojure -X:mcp :port 7889 2>> "$LOG_FILE"
+# Start the MCP server
+log "${GREEN}Starting Clojure MCP server...${NC}"
+exec clojure -X:mcp 2>> "$LOG_FILE"

--- a/mcp/test-minimal/README.md
+++ b/mcp/test-minimal/README.md
@@ -1,0 +1,55 @@
+# Minimal Clojure MCP Test Case
+
+This is a minimal test case for troubleshooting the Clojure MCP integration. It contains only the essential components needed to test the integration between the nREPL server and the Clojure MCP server.
+
+## Directory Structure
+
+```
+test-minimal/
+├── deps.edn         # Minimal dependencies configuration
+├── src/
+│   └── user/
+│       └── core.clj # Simple Clojure source file
+└── test-wrapper.sh  # Test wrapper script
+```
+
+## How to Test
+
+1. Run the test wrapper script:
+
+```bash
+cd /home/linuxmint-lp/ppv/pillars/dotfiles/mcp/test-minimal
+./test-wrapper.sh
+```
+
+The script will:
+- Check if an nREPL server is running on port 7888
+- Start an nREPL server if one is not already running
+- Wait for the nREPL server to start
+- Send the MCP initialization message
+- Start the Clojure MCP server
+
+2. Check the log file for any errors:
+
+```bash
+cat /tmp/clojure-mcp-test.log
+```
+
+## Troubleshooting
+
+If the test fails, check the following:
+
+1. Is the nREPL server running on port 7888?
+   ```bash
+   nc -zv localhost 7888
+   ```
+
+2. Are there any errors in the log file?
+   ```bash
+   cat /tmp/clojure-mcp-test.log
+   ```
+
+3. Is the Clojure MCP server trying to connect to the correct port?
+   ```bash
+   grep "port" /home/linuxmint-lp/ppv/pillars/dotfiles/mcp/test-minimal/deps.edn
+   ```

--- a/mcp/test-minimal/deps.edn
+++ b/mcp/test-minimal/deps.edn
@@ -1,15 +1,13 @@
 {:paths ["src"]
  :deps {}
  :aliases {
-   ;; nREPL server for AI to connect to
-   :nrepl {:extra-paths ["test"] 
-           :extra-deps {nrepl/nrepl {:mvn/version "1.3.1"}}
-           :jvm-opts ["-Djdk.attach.allowAttachSelf"]
-           :main-opts ["-m" "nrepl.cmdline" "--port" "7888"]},
+   ;; nREPL server configuration
+   :nrepl {:extra-deps {nrepl/nrepl {:mvn/version "1.3.1"}}
+           :main-opts ["-m" "nrepl.cmdline" "--port" "7888"]}
    
-   ;; MCP server for AI assistance
+   ;; MCP server configuration
    :mcp {:deps {org.slf4j/slf4j-nop {:mvn/version "2.0.16"}
                 com.bhauman/clojure-mcp {:git/url "https://github.com/bhauman/clojure-mcp.git"
                                          :git/sha "83627e7095f0ebab3d5503a5b2ee94aa6953cb0d"}}
          :exec-fn clojure-mcp.main/start-mcp-server
-         :exec-args {:port 7888}}}}
+         :exec-args {:port 7889}}}}

--- a/mcp/test-minimal/deps.edn
+++ b/mcp/test-minimal/deps.edn
@@ -5,9 +5,10 @@
    :nrepl {:extra-deps {nrepl/nrepl {:mvn/version "1.3.1"}}
            :main-opts ["-m" "nrepl.cmdline" "--port" "7888"]}
    
-   ;; MCP server configuration
+   ;; MCP server configuration - explicitly set host to localhost
    :mcp {:deps {org.slf4j/slf4j-nop {:mvn/version "2.0.16"}
                 com.bhauman/clojure-mcp {:git/url "https://github.com/bhauman/clojure-mcp.git"
                                          :git/sha "83627e7095f0ebab3d5503a5b2ee94aa6953cb0d"}}
          :exec-fn clojure-mcp.main/start-mcp-server
-         :exec-args {:port 7889}}}}
+         :exec-args {:port 7888
+                     :host "localhost"}}}}

--- a/mcp/test-minimal/src/user/core.clj
+++ b/mcp/test-minimal/src/user/core.clj
@@ -1,0 +1,4 @@
+(ns user.core)
+
+(defn hello []
+  "Hello, world!")

--- a/mcp/test-minimal/test-wrapper.sh
+++ b/mcp/test-minimal/test-wrapper.sh
@@ -1,0 +1,40 @@
+#!/bin/bash -x
+# Simple wrapper script for testing Clojure MCP
+
+# Define log file
+LOG_FILE="/tmp/clojure-mcp-test.log"
+echo "=== Clojure MCP Test Log $(date) ===" > "$LOG_FILE"
+
+# Get the absolute path of the script directory
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "$SCRIPT_DIR"
+
+echo "Current directory: $(pwd)" | tee -a "$LOG_FILE"
+echo "Script directory: $SCRIPT_DIR" | tee -a "$LOG_FILE"
+
+# Check if an nREPL server is running on port 7888
+if ! (echo > /dev/tcp/localhost/7888) 2>/dev/null; then
+  echo "No nREPL server found on port 7888. Starting one..." | tee -a "$LOG_FILE"
+  clojure -M:nrepl &
+  NREPL_PID=$!
+  echo "Started nREPL server with PID: $NREPL_PID" | tee -a "$LOG_FILE"
+  
+  # Wait for nREPL server to start
+  for i in {1..10}; do
+    if (echo > /dev/tcp/localhost/7888) 2>/dev/null; then
+      echo "nREPL server is now running on port 7888" | tee -a "$LOG_FILE"
+      break
+    fi
+    echo "Waiting for nREPL server to start... ($i/10)" | tee -a "$LOG_FILE"
+    sleep 1
+  done
+else
+  echo "nREPL server already running on port 7888" | tee -a "$LOG_FILE"
+fi
+
+# Use the MCP protocol to communicate with the client
+echo '{"jsonrpc":"2.0","id":1,"method":"mcp.init","params":{"version":"0.1","capabilities":{}}}' | tee -a "$LOG_FILE"
+
+# Start the MCP server
+echo "Starting Clojure MCP server..." | tee -a "$LOG_FILE"
+exec clojure -X:mcp 2>> "$LOG_FILE"


### PR DESCRIPTION
This PR fixes the Clojure MCP integration by:

1. Creating a minimal test case to isolate and identify the issue
2. Explicitly setting the host parameter in deps.edn
3. Updating the wrapper script to automatically start the nREPL server
4. Adding comprehensive documentation

The changes follow the 'Spilled Coffee Principle' by making the configuration explicit and reproducible, ensuring it works consistently across different environments.