### PR TITLE
Document MCP servers in .gitignore and ignore Git artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,15 @@ venv/
 env/
 .env/
 mcp/servers/aws-docs/venv/
+
+# MCP servers - Git repositories and build artifacts
+# We track the existence of these directories but not their contents
+# Each server is cloned from its own repository:
+# - filesystem-mcp-server: https://github.com/atxtechbro/filesystem-mcp-server
+# - github-mcp-server: https://github.com/atxtechbro/github-mcp-server (upstream: github/github-mcp-server)
+# - git-mcp-server: https://github.com/atxtechbro/git-mcp-server
+# - mcp-servers: https://github.com/atxtechbro/mcp-servers
+mcp/servers/*/.git/
+mcp/servers/*/node_modules/
+mcp/servers/*/.github/
+mcp/servers/*/.gitignore


### PR DESCRIPTION
## Description
This PR updates the .gitignore file to properly handle MCP server repositories while using the .gitignore itself as documentation.

## Changes
- Updates .gitignore to properly handle MCP server repositories
- Uses .gitignore as documentation for MCP server repositories
- Lists repository URLs for each MCP server
- Follows the Versioning Mindset principle by documenting context

## Testing
- Verified that the .gitignore patterns correctly handle the MCP server directories

## Principles Applied
- **Versioning Mindset**: Uses .gitignore as documentation to provide context about MCP servers
- **Spilled Coffee Principle**: Ensures proper handling of repository files for quick recovery