### PR TITLE
Fix gitignore to properly ignore mcp/servers directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,14 +52,13 @@ env/
 .env/
 mcp/servers/aws-docs/venv/
 
-# MCP servers - Git repositories and build artifacts
-# We track the existence of these directories but not their contents
-# Each server is cloned from its own repository:
+# MCP servers directory
+# We don't track this directory in git, as each server is cloned from its own repository:
 # - filesystem-mcp-server: https://github.com/atxtechbro/filesystem-mcp-server
 # - github-mcp-server: https://github.com/atxtechbro/github-mcp-server (upstream: github/github-mcp-server)
 # - git-mcp-server: https://github.com/atxtechbro/git-mcp-server
 # - mcp-servers: https://github.com/atxtechbro/mcp-servers
-mcp/servers/*/.git/
-mcp/servers/*/node_modules/
-mcp/servers/*/.github/
-mcp/servers/*/.gitignore
+mcp/servers/
+
+# Clojure cache
+.cpcache/


### PR DESCRIPTION
## Description
This PR fixes the issue where the mcp/servers directory was still showing up in `git status` despite having gitignore rules.

## Changes
- Updates .gitignore to ignore the entire mcp/servers directory instead of just specific files within it
- Adds .cpcache/ to gitignore to prevent it from showing up in git status
- Improves documentation comments in .gitignore

## Problem Solved
Previously, we were only ignoring specific files and directories INSIDE the mcp/servers/* directories, but not the directories themselves. This change ignores the entire mcp/servers directory, which will prevent it from showing up in git status.

## Testing
- Verified that `git status` no longer shows mcp/servers as an untracked directory

## Principles Applied
- **Versioning Mindset**: Improves documentation in .gitignore
- **Spilled Coffee Principle**: Ensures clean git status output for better developer experience