### PR TITLE
Add Claude Desktop Clojure MCP configuration

### DIFF
--- a/mcp/README-claude-desktop.md
+++ b/mcp/README-claude-desktop.md
@@ -1,0 +1,83 @@
+# Claude Desktop MCP Integration
+
+This document explains how to configure Claude Desktop to use the Clojure MCP server.
+
+## Prerequisites
+
+- Claude Desktop must be installed:
+  - **Windows/macOS**: Download from [https://claude.ai/download](https://claude.ai/download)
+  - **Linux**: Use our fork at [https://github.com/atxtechbro/claude-desktop-debian](https://github.com/atxtechbro/claude-desktop-debian)
+
+## Configuration
+
+Claude Desktop needs to be configured to use only the Clojure MCP server. The configuration file location depends on your operating system:
+
+### Windows
+```
+%APPDATA%\Claude\mcp.json
+```
+
+### macOS
+```
+~/Library/Application Support/Claude/mcp.json
+```
+
+### Linux
+```
+~/.config/Claude/mcp.json
+```
+
+The configuration file should contain:
+```json
+{
+  "servers": [
+    {
+      "name": "clojure-mcp",
+      "url": "http://localhost:7777",
+      "enabled": true
+    }
+  ]
+}
+```
+
+## Setup Script
+
+For convenience, you can use the `configure-claude-desktop-mcp.sh` script to automatically create the proper configuration file for your operating system:
+
+```bash
+# Run the configuration script
+bash ~/ppv/pillars/dotfiles/mcp/configure-claude-desktop-mcp.sh
+```
+
+## Linux Installation (if needed)
+
+If you're on Linux and don't have Claude Desktop installed, you can use our fork of the Claude Desktop Debian package:
+
+```bash
+# Clone the repository
+git clone https://github.com/atxtechbro/claude-desktop-debian.git
+cd claude-desktop-debian
+
+# Build and install
+./build.sh
+sudo apt install ./claude-desktop_*_amd64.deb
+```
+
+## Usage
+
+1. Start the Clojure MCP server:
+   ```bash
+   ~/ppv/pillars/dotfiles/mcp/clojure-mcp-wrapper.sh start
+   ```
+
+2. Launch Claude Desktop
+   - The application will automatically connect to the Clojure MCP server
+   - You can verify this by checking if Clojure functions are available
+
+## Troubleshooting
+
+If Claude Desktop doesn't connect to the Clojure MCP server:
+
+1. Verify the MCP configuration file exists and has the correct content
+2. Ensure the Clojure MCP server is running
+3. Restart Claude Desktop after making any configuration changes

--- a/mcp/claude-desktop-mcp.json
+++ b/mcp/claude-desktop-mcp.json
@@ -1,0 +1,9 @@
+{
+  "servers": [
+    {
+      "name": "clojure-mcp",
+      "url": "http://localhost:7777",
+      "enabled": true
+    }
+  ]
+}

--- a/mcp/configure-claude-desktop-mcp.sh
+++ b/mcp/configure-claude-desktop-mcp.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# configure-claude-desktop-mcp.sh - Configure Claude Desktop to use Clojure MCP server
+# This script follows the "Spilled Coffee Principle" and "Versioning Mindset"
+
+set -e
+
+# Define colors for output
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Define paths
+DOTFILES_DIR="$HOME/ppv/pillars/dotfiles"
+CONFIG_DIR=""
+MCP_CONFIG_FILE=""
+
+# Detect operating system
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  echo "macOS detected"
+  CONFIG_DIR="$HOME/Library/Application Support/Claude"
+  MCP_CONFIG_FILE="$CONFIG_DIR/mcp.json"
+elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" || "$OSTYPE" == "cygwin" ]]; then
+  echo "Windows detected"
+  CONFIG_DIR="$APPDATA/Claude"
+  MCP_CONFIG_FILE="$CONFIG_DIR/mcp.json"
+else
+  echo "Linux detected"
+  CONFIG_DIR="$HOME/.config/Claude"
+  MCP_CONFIG_FILE="$CONFIG_DIR/mcp.json"
+fi
+
+echo -e "${YELLOW}Configuring Claude Desktop to use Clojure MCP server...${NC}"
+
+# Create configuration directory if it doesn't exist
+mkdir -p "$CONFIG_DIR"
+
+# Create MCP configuration specifically for Clojure MCP server
+cat > "$MCP_CONFIG_FILE" << EOF
+{
+  "servers": [
+    {
+      "name": "clojure-mcp",
+      "url": "http://localhost:7777",
+      "enabled": true
+    }
+  ]
+}
+EOF
+
+echo -e "${GREEN}✓ MCP configuration created at $MCP_CONFIG_FILE${NC}"
+echo -e "Claude Desktop will now use only the Clojure MCP server."
+echo -e "\nMake sure the Clojure MCP server is running with:"
+echo -e "${YELLOW}$DOTFILES_DIR/mcp/clojure-mcp-wrapper.sh start${NC}"

--- a/setup.sh
+++ b/setup.sh
@@ -151,8 +151,19 @@ mkdir -p ~/.aws/amazonq
 ln -sf "$DOT_DEN"/mcp/mcp.json ~/.aws/amazonq/mcp.json
 
 # Claude Desktop MCP integration
-mkdir -p ~/.config/Claude
-cp "$DOT_DEN"/mcp/mcp.json ~/.config/Claude/claude_desktop_config.json
+# Check if Claude Desktop configuration script exists and offer to run it
+if [[ -f "$DOT_DEN/mcp/configure-claude-desktop-mcp.sh" ]]; then
+  echo -e "${YELLOW}Claude Desktop MCP integration is available.${NC}"
+  echo -e "Would you like to configure Claude Desktop to use the Clojure MCP server? (y/n)"
+  read -r setup_claude
+  if [[ "$setup_claude" =~ ^[Yy]$ ]]; then
+    echo "Configuring Claude Desktop to use Clojure MCP server..."
+    bash "$DOT_DEN/mcp/configure-claude-desktop-mcp.sh"
+  else
+    echo "Skipping Claude Desktop configuration. You can run it later with:"
+    echo -e "${GREEN}bash $DOT_DEN/mcp/configure-claude-desktop-mcp.sh${NC}"
+  fi
+fi
 
 # Set up Git configuration
 echo "Setting up Git configuration..."


### PR DESCRIPTION
## Overview
This PR adds configuration for Claude Desktop to use only the Clojure MCP server, providing a focused solution that assumes Claude Desktop is already installed or available from official sources.

## Changes
- Create dedicated `claude-desktop-mcp.json` with only Clojure MCP server configuration
- Add `configure-claude-desktop-mcp.sh` script for cross-platform configuration
- Update `setup.sh` to offer Claude Desktop MCP configuration
- Add `README-claude-desktop.md` with installation and configuration instructions

## Approach
This PR follows a minimalist approach that:
1. Assumes Claude Desktop is already installed or available from official sources
2. Focuses solely on configuring Claude Desktop to use only the Clojure MCP server
3. Provides cross-platform support (Windows, macOS, Linux)
4. Follows the Versioning Mindset principle by building on existing work

## Testing
- Verified the configuration script works on Linux
- Confirmed the configuration file is properly created
- Tested integration with setup.sh

Closes #348