### PR TITLE
Add dedicated Claude Desktop MCP configuration

### DIFF
--- a/mcp/claude-desktop-mcp.json
+++ b/mcp/claude-desktop-mcp.json
@@ -1,0 +1,9 @@
+{
+  "servers": [
+    {
+      "name": "clojure-mcp",
+      "url": "http://localhost:7777",
+      "enabled": true
+    }
+  ]
+}

--- a/setup.sh
+++ b/setup.sh
@@ -152,7 +152,7 @@ ln -sf "$DOT_DEN"/mcp/mcp.json ~/.aws/amazonq/mcp.json
 
 # Claude Desktop MCP integration
 mkdir -p ~/.config/Claude
-cp "$DOT_DEN"/mcp/mcp.json ~/.config/Claude/claude_desktop_config.json
+cp "$DOT_DEN"/mcp/claude-desktop-mcp.json ~/.config/Claude/mcp.json
 
 # Set up Git configuration
 echo "Setting up Git configuration..."


### PR DESCRIPTION
## Overview
This PR adds a dedicated configuration file for Claude Desktop that only includes the Clojure MCP server.

## Changes
- Create `claude-desktop-mcp.json` with only the Clojure MCP server configuration
- Update `setup.sh` to use this dedicated configuration file

## Approach
This PR follows a minimalist approach that:
1. Creates a dedicated JSON file with only the Clojure MCP server configuration
2. Updates setup.sh to copy this file to the correct location
3. Keeps changes focused and minimal

Closes #348