### PR TITLE
feat(clojure-mcp): expand scope beyond dotfiles repo

### DIFF
--- a/mcp/clojure-mcp-wrapper.sh
+++ b/mcp/clojure-mcp-wrapper.sh
@@ -10,7 +10,9 @@ NC='\033[0m' # No Color
 
 # Get the absolute path of the script directory
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-PROJECT_DIR="$( cd "$SCRIPT_DIR/.." &> /dev/null && pwd )"
+# Use HOME environment variable if set, otherwise default to parent directory
+# This allows Clojure MCP to access files beyond the dotfiles repo
+PROJECT_DIR="${CLOJURE_MCP_PROJECT_DIR:-$HOME}"
 
 # Define log file
 LOG_FILE="/tmp/clojure-mcp-debug.log"


### PR DESCRIPTION
This PR expands the scope of the Clojure MCP server beyond just the dotfiles repository.

## Changes
- Modified `clojure-mcp-wrapper.sh` to use `$CLOJURE_MCP_PROJECT_DIR` environment variable with fallback to `$HOME`
- Removed the redundant delayed wrapper script

## Benefits
- Allows Clojure MCP to access files across the entire home directory by default
- Maintains configurability through environment variables, aligning with dotfiles principles
- Keeps changes minimal and focused

This change enables the Clojure MCP server to work with Clojure projects anywhere in the filesystem while maintaining the dotfiles philosophy of configuration over modification.