### PR TITLE
Add Clojure MCP home directory setup

### DIFF
--- a/mcp/setup-clojure-mcp-home.sh
+++ b/mcp/setup-clojure-mcp-home.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# setup-clojure-mcp-home.sh - Set up Clojure MCP in the home directory
+# This script follows the "Spilled Coffee Principle" and "Versioning Mindset"
+
+set -e
+
+# Define paths
+DOTFILES_DIR="$HOME/ppv/pillars/dotfiles"
+HOME_DIR="$HOME"
+
+echo "Setting up Clojure MCP in the home directory..."
+
+# Check if source deps.edn exists
+if [ ! -f "$DOTFILES_DIR/deps.edn" ]; then
+  echo "Error: Source deps.edn not found in $DOTFILES_DIR"
+  exit 1
+fi
+
+# Copy deps.edn to home directory
+echo "Copying deps.edn to home directory..."
+cp "$DOTFILES_DIR/deps.edn" "$HOME_DIR/deps.edn"
+
+# Create symlink for clojure-mcp-wrapper.sh in home directory
+echo "Creating symlink for clojure-mcp-wrapper.sh in home directory..."
+ln -sf "$DOTFILES_DIR/mcp/clojure-mcp-wrapper.sh" "$HOME_DIR/clojure-mcp-wrapper.sh"
+
+echo "Clojure MCP setup in home directory complete!"
+echo "You can now run Clojure MCP from your home directory with:"
+echo "cd ~ && ./clojure-mcp-wrapper.sh"

--- a/setup.sh
+++ b/setup.sh
@@ -154,6 +154,20 @@ ln -sf "$DOT_DEN"/mcp/mcp.json ~/.aws/amazonq/mcp.json
 mkdir -p ~/.config/Claude
 cp "$DOT_DEN"/mcp/mcp.json ~/.config/Claude/claude_desktop_config.json
 
+# Clojure MCP home setup
+echo "Setting up Clojure MCP in home directory..."
+if [ -f "$DOT_DEN/deps.edn" ]; then
+  # Copy deps.edn to home directory for Clojure MCP
+  cp "$DOT_DEN/deps.edn" "$HOME/deps.edn"
+  echo "Copied deps.edn to home directory for Clojure MCP"
+  
+  # Create symlink for clojure-mcp-wrapper.sh in home directory
+  ln -sf "$DOT_DEN/mcp/clojure-mcp-wrapper.sh" "$HOME/clojure-mcp-wrapper.sh"
+  echo "Created symlink for clojure-mcp-wrapper.sh in home directory"
+else
+  echo "Warning: deps.edn not found in $DOT_DEN. Skipping Clojure MCP home setup."
+fi
+
 # Set up Git configuration
 echo "Setting up Git configuration..."
 gitconfig_path="$HOME/.gitconfig"


### PR DESCRIPTION
## Overview
This PR adds support for running Clojure MCP from the home directory by automatically setting up the necessary files during dotfiles installation.

## Changes
- Add Clojure MCP home directory setup to main setup.sh
- Copy deps.edn to home directory for Clojure MCP
- Create symlink for clojure-mcp-wrapper.sh in home directory
- Create standalone setup script for manual execution if needed

## Motivation
The Clojure MCP wrapper script was recently modified to look for deps.edn in the home directory instead of the dotfiles directory. This change broke functionality for users who didn't have deps.edn in their home directory.

This PR follows the Spilled Coffee Principle by ensuring that the necessary files are automatically set up in the home directory during dotfiles installation, making the system more resilient and easier to use.

## Testing
- Verified that deps.edn is properly copied to the home directory
- Confirmed that the clojure-mcp-wrapper.sh symlink is created in the home directory
- Tested running Clojure MCP from the home directory