### PR TITLE
Add Clojure MCP test scripts

### DIFF
--- a/mcp/tests/test-clojure-mcp-happy-path.sh
+++ b/mcp/tests/test-clojure-mcp-happy-path.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# Enable debug mode to see all commands as they're executed
-set -x
-
 # =========================================================
 # TEST HARNESS FOR CLOJURE MCP SERVER - HAPPY PATH
 # =========================================================
@@ -16,6 +13,66 @@ source "$SCRIPT_DIR/lib/test-harness.sh"
 
 # Define test directory
 DOTFILES_DIR="/home/linuxmint-lp/ppv/pillars/dotfiles"
+
+# Custom run_test function that shows more output and checks for tool usage
+custom_run_test() {
+  local test_name="$1"
+  local command="$2"
+  local expected_pattern="$3"
+  local tool_pattern="$4"
+  
+  echo -e "\n${BLUE}TEST:${NC} $test_name"
+  echo "Command: $command"
+  TOTAL=$((TOTAL+1))
+  
+  # Run the command through the specified model CLI
+  echo "Running test through $TEST_MODEL CLI..."
+  
+  case "$TEST_MODEL" in
+    q)
+      # Use trust-all-tools to avoid interactive prompts
+      echo "Executing: $TEST_MODEL chat --no-interactive --trust-all-tools \"$command\""
+      full_result=$($TEST_MODEL chat --no-interactive --trust-all-tools "$command" 2>/dev/null)
+      ;;
+    claude)
+      # Assuming claude CLI has similar interface
+      echo "Executing: $TEST_MODEL chat --no-interactive --trust-all-tools \"$command\""
+      full_result=$($TEST_MODEL chat --no-interactive --trust-all-tools "$command" 2>/dev/null)
+      ;;
+    *)
+      echo -e "${RED}Error: Unknown model $TEST_MODEL${NC}"
+      FAILED=$((FAILED+1))
+      return 1
+      ;;
+  esac
+  
+  # Show a portion of the response
+  echo -e "\n${YELLOW}Response excerpt (first 500 chars):${NC}"
+  echo "${full_result:0:500}"
+  echo -e "${YELLOW}...[truncated]...${NC}"
+  
+  # Check if the result contains the expected pattern
+  if echo "$full_result" | grep -q -E "$expected_pattern"; then
+    echo -e "${GREEN}✓ PASSED${NC}: Output contains expected result pattern: '$expected_pattern'"
+  else
+    echo -e "${RED}✗ FAILED${NC}: Expected result pattern not found"
+    echo "Expected result pattern: $expected_pattern"
+    FAILED=$((FAILED+1))
+    echo "----------------------------------------"
+    return 1
+  fi
+  
+  # Check if the result contains the tool usage pattern
+  if echo "$full_result" | grep -q -E "$tool_pattern"; then
+    echo -e "${GREEN}✓ PASSED${NC}: Output contains tool usage pattern: '$tool_pattern'"
+    PASSED=$((PASSED+1))
+  else
+    echo -e "${RED}✗ FAILED${NC}: Tool usage pattern not found"
+    echo "Expected tool usage pattern: $tool_pattern"
+    FAILED=$((FAILED+1))
+  fi
+  echo "----------------------------------------"
+}
 
 # Initialize test suite
 init_test_suite "CLOJURE MCP SERVER - HAPPY PATH" "Clojure"
@@ -33,25 +90,28 @@ echo -e "${YELLOW}Testing from dotfiles directory...${NC}"
 sleep 3
 
 # Test: Basic Clojure Evaluation
-run_test "Basic Clojure Evaluation" \
-         "Using Clojure, what is the result of (+ 2 2)?" \
-         "(4|four)"
+custom_run_test "Basic Clojure Evaluation" \
+         "Please use clojure_eval tool to evaluate and calculate (+ 2 2) in Clojure" \
+         "(4|four)" \
+         "(Using tool: clojure_eval|🛠️.*clojure_eval|clojure_mcp)"
 
 # Wait between tests
 sleep 5
 
-# Test: Clojure Function Definition
-run_test "Clojure Function Definition" \
-         "In Clojure, how do I define a function named add-two that adds 2 to its argument?" \
-         "(defn add-two|\\(defn add-two \\[x\\] \\(\\+ x 2\\)\\))"
+# Test: Clojure Function Definition and Evaluation
+custom_run_test "Clojure Function Definition and Evaluation" \
+         "Use the clojure_eval tool to define a function named add-two that adds 2 to its argument in Clojure, then evaluate (add-two 3)" \
+         "(5|five)" \
+         "(Using tool: clojure_eval|🛠️.*clojure_eval|clojure_mcp)"
 
 # Wait between tests
 sleep 5
 
-# Test: Read deps.edn File
-run_test "Read deps.edn File" \
-         "Read the deps.edn file in the current directory and explain what it contains" \
-         "(nREPL|MCP|server|clojure-mcp)"
+# Test: Read deps.edn File with Clojure MCP
+custom_run_test "Read deps.edn File with Clojure MCP" \
+         "Use clojure_eval or another Clojure MCP tool to read and analyze the deps.edn file in the current directory" \
+         "(nREPL|MCP|server|clojure-mcp)" \
+         "(Using tool: clojure_eval|🛠️.*clojure_eval|clojure_mcp)"
 
 # Print summary
 print_summary

--- a/mcp/tests/test-clojure-mcp-happy-path.sh
+++ b/mcp/tests/test-clojure-mcp-happy-path.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Enable debug mode to see all commands as they're executed
+set -x
+
+# =========================================================
+# TEST HARNESS FOR CLOJURE MCP SERVER - HAPPY PATH
+# =========================================================
+# PURPOSE: Automated testing of Clojure MCP server functionality
+# Tests the basic functionality when launched from dotfiles repository
+# =========================================================
+
+# Source the common test harness
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/test-harness.sh"
+
+# Define test directory
+DOTFILES_DIR="/home/linuxmint-lp/ppv/pillars/dotfiles"
+
+# Initialize test suite
+init_test_suite "CLOJURE MCP SERVER - HAPPY PATH" "Clojure"
+
+# Give extra time for MCP servers to fully load
+echo -e "${YELLOW}Giving extra time for MCP servers to fully initialize...${NC}"
+sleep 15
+
+# Basic Clojure evaluation test from dotfiles directory
+echo -e "\n${BLUE}SECTION:${NC} Testing Clojure MCP from dotfiles directory"
+
+# Test from dotfiles directory (should always work)
+cd "$DOTFILES_DIR"
+echo -e "${YELLOW}Testing from dotfiles directory...${NC}"
+sleep 3
+
+# Test: Clojure Tool Usage and Evaluation
+run_test "Clojure Tool Usage and Evaluation" \
+         "Evaluate (+ 2 2) using Clojure" \
+         "(Using tool: clojure_eval|🛠️.*clojure_eval)"
+
+# Wait between tests
+sleep 5
+
+# Test: Clojure Function Definition with Tool Usage
+run_test "Clojure Function Definition with Tool Usage" \
+         "Define a function named add-two that adds 2 to its argument in Clojure and evaluate it with input 3" \
+         "(Using tool: clojure_eval|🛠️.*clojure_eval)"
+
+# Print summary
+print_summary
+
+# Exit with appropriate status code
+if [ $FAILED -gt 0 ]; then
+  exit 1
+else
+  exit 0
+fi

--- a/mcp/tests/test-clojure-mcp-happy-path.sh
+++ b/mcp/tests/test-clojure-mcp-happy-path.sh
@@ -32,18 +32,26 @@ cd "$DOTFILES_DIR"
 echo -e "${YELLOW}Testing from dotfiles directory...${NC}"
 sleep 3
 
-# Test: Clojure Tool Usage and Evaluation
-run_test "Clojure Tool Usage and Evaluation" \
-         "Evaluate (+ 2 2) using Clojure" \
-         "(Using tool: clojure_eval|🛠️.*clojure_eval)"
+# Test: Basic Clojure Evaluation
+run_test "Basic Clojure Evaluation" \
+         "Using Clojure, what is the result of (+ 2 2)?" \
+         "(4|four)"
 
 # Wait between tests
 sleep 5
 
-# Test: Clojure Function Definition with Tool Usage
-run_test "Clojure Function Definition with Tool Usage" \
-         "Define a function named add-two that adds 2 to its argument in Clojure and evaluate it with input 3" \
-         "(Using tool: clojure_eval|🛠️.*clojure_eval)"
+# Test: Clojure Function Definition
+run_test "Clojure Function Definition" \
+         "In Clojure, how do I define a function named add-two that adds 2 to its argument?" \
+         "(defn add-two|\\(defn add-two \\[x\\] \\(\\+ x 2\\)\\))"
+
+# Wait between tests
+sleep 5
+
+# Test: Read deps.edn File
+run_test "Read deps.edn File" \
+         "Read the deps.edn file in the current directory and explain what it contains" \
+         "(nREPL|MCP|server|clojure-mcp)"
 
 # Print summary
 print_summary

--- a/mcp/tests/test-clojure-mcp.sh
+++ b/mcp/tests/test-clojure-mcp.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+# Enable debug mode to see all commands as they're executed
+set -x
+
+# =========================================================
+# TEST HARNESS FOR CLOJURE MCP SERVER
+# =========================================================
+# PURPOSE: Automated testing of Clojure MCP server functionality
+# Tests the ability to use Clojure MCP from different directories
+# =========================================================
+
+# Source the common test harness
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/test-harness.sh"
+
+# Define test directories
+# These directories represent different locations to test from
+DOTFILES_DIR="/home/linuxmint-lp/ppv/pillars/dotfiles"
+PILLARS_DIR="/home/linuxmint-lp/ppv/pillars"
+PIPELINES_DIR="/home/linuxmint-lp/ppv/pipelines"
+HOME_DIR="/home/linuxmint-lp"
+TMP_DIR="/tmp"
+RANDOM_DIR="/tmp/random-dir-$$"
+
+# Create random directory if it doesn't exist
+mkdir -p "$RANDOM_DIR"
+
+# Function to run cleanup operations
+cleanup() {
+  echo -e "\n${BLUE}CLEANUP:${NC} Removing temporary directories"
+  [ -d "$RANDOM_DIR" ] && rm -rf "$RANDOM_DIR"
+  echo "Cleanup complete"
+}
+
+# Run cleanup on script exit
+trap cleanup EXIT
+
+# Initialize test suite
+init_test_suite "CLOJURE MCP SERVER" "Clojure"
+
+# Basic Clojure evaluation test from different directories
+echo -e "\n${BLUE}SECTION:${NC} Testing Clojure MCP from different directories"
+
+# Test from dotfiles directory (should always work)
+cd "$DOTFILES_DIR"
+run_test "Evaluate Clojure from dotfiles directory" \
+         "Using Clojure, what is the result of (+ 2 2)?" \
+         "(4|four)"
+
+# Test from pillars directory (should work with our changes)
+cd "$PILLARS_DIR"
+run_test "Evaluate Clojure from pillars directory" \
+         "Using Clojure, what is the result of (+ 2 2)?" \
+         "(4|four)"
+
+# Test from pipelines directory (should work with our changes)
+cd "$PIPELINES_DIR"
+run_test "Evaluate Clojure from pipelines directory" \
+         "Using Clojure, what is the result of (+ 2 2)?" \
+         "(4|four)"
+
+# Test from home directory (may or may not work)
+cd "$HOME_DIR"
+run_test "Evaluate Clojure from home directory" \
+         "Using Clojure, what is the result of (+ 2 2)?" \
+         "(4|four)"
+
+# Test from /tmp directory (may or may not work)
+cd "$TMP_DIR"
+run_test "Evaluate Clojure from /tmp directory" \
+         "Using Clojure, what is the result of (+ 2 2)?" \
+         "(4|four)"
+
+# Test from random directory (may or may not work)
+cd "$RANDOM_DIR"
+run_test "Evaluate Clojure from random directory" \
+         "Using Clojure, what is the result of (+ 2 2)?" \
+         "(4|four)"
+
+# Test file access from different directories
+echo -e "\n${BLUE}SECTION:${NC} Testing Clojure MCP file access from different directories"
+
+# Create a test file in the random directory
+TEST_FILE="$RANDOM_DIR/test-file.clj"
+echo '(defn add-two [x] (+ x 2))' > "$TEST_FILE"
+
+# Test reading a file from random directory
+cd "$RANDOM_DIR"
+run_test "Read file from current directory" \
+         "Read the file test-file.clj in the current directory and explain what it does" \
+         "(add-two|function|adds 2)"
+
+# Test reading a file from dotfiles when in a different directory
+cd "$TMP_DIR"
+run_test "Read file from dotfiles while in /tmp" \
+         "Read the file deps.edn in the dotfiles directory and explain what it contains" \
+         "(nREPL|MCP|server|clojure-mcp)"
+
+# Print summary
+print_summary
+
+# Exit with appropriate status code
+if [ $FAILED -gt 0 ]; then
+  exit 1
+else
+  exit 0
+fi


### PR DESCRIPTION
## Overview
This PR adds automated test scripts for the Clojure MCP server to verify its functionality and identify issues.

## Changes
- Add `test-clojure-mcp-happy-path.sh` script to test Clojure MCP functionality
- Implement custom test function with appropriate verbosity
- Add specific tests for Clojure evaluation, function definition, and file reading
- Include checks for proper tool usage

## Key Findings
The tests reveal that the Clojure MCP tools are not properly exposed to Amazon Q CLI. When explicitly asked to use the `clojure_eval` tool, Amazon Q responds that it doesn't have access to that tool. Instead, it uses other tools like the filesystem's `read_file` tool or falls back to providing information from its training data.

## Related Issues
- #354 Clojure MCP server only works within dotfiles repository
- #355 Create automated test for Clojure MCP server (happy path)

## Next Steps
1. Investigate why the Clojure MCP tools are not properly exposed
2. Check the Clojure MCP server implementation
3. Verify the MCP configuration
4. Consider modifying the Clojure MCP server to better expose its tools