### PR TITLE
refactor(mcp): Update setup-clojure-mcp.sh to clone into mcp/servers/

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -26,6 +26,7 @@ This standardized approach makes it easy to add more MCP servers in the future f
 | Filesystem | Local filesystem operations | None required | Built from source | [Our Fork](https://github.com/atxtechbro/mcp-servers/tree/main/src/filesystem#filesystem-mcp-server) |
 | Git | Git repository operations | None required | Built from source | [Our Repository](https://github.com/atxtechbro/git-mcp-server#git-mcp-server) |
 | Google Drive | Google Drive file operations | OAuth credentials from `.bash_secrets` | Docker container | [Official Docs](https://github.com/modelcontextprotocol/servers/tree/main/src/gdrive#authentication) |
+| Clojure | REPL-driven development | None required | Cloned from source | [Official Repo](https://github.com/bhauman/clojure-mcp) |
 
 ## Setup Instructions
 
@@ -118,6 +119,7 @@ Based on our current experience, here's a working procedure for adding new MCP s
    - Create `setup-<server-name>-mcp.sh` for one-time setup tasks
    - For Docker-based servers, include image building steps
    - For package-based servers, document installation requirements
+   - Clone source repositories into the `servers/` subdirectory
 
 4. **Document the integration**:
    - Add an entry to the MCP Integrations table in the README

--- a/mcp/clojure-mcp-wrapper.sh
+++ b/mcp/clojure-mcp-wrapper.sh
@@ -10,7 +10,7 @@ NC='\033[0m' # No Color
 
 # Get the absolute path of the script directory
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-PROJECT_DIR="$( cd "$SCRIPT_DIR/.." &> /dev/null && pwd )"
+PROJECT_DIR="$( cd "$SCRIPT_DIR/servers/clojure-mcp" &> /dev/null && pwd )"
 
 # Define log file
 LOG_FILE="/tmp/clojure-mcp-debug.log"

--- a/mcp/setup-clojure-mcp.sh
+++ b/mcp/setup-clojure-mcp.sh
@@ -12,7 +12,7 @@ NC='\033[0m' # No Color
 
 # Define paths
 DOTFILES_DIR="$HOME/ppv/pillars/dotfiles"
-CLOJURE_MCP_DIR="$DOTFILES_DIR/mcp/clojure-mcp"
+CLOJURE_MCP_DIR="$DOTFILES_DIR/mcp/servers"
 CONFIG_DIR="$HOME/.clojure-mcp"
 
 echo -e "${GREEN}Setting up Clojure MCP server...${NC}"
@@ -72,6 +72,9 @@ check_dependency "git"
 check_dependency "java"
 check_dependency "clojure"
 
+# Create servers directory if it doesn't exist
+mkdir -p "$CLOJURE_MCP_DIR"
+
 # Clone or update the Clojure MCP repository
 if [ -d "$CLOJURE_MCP_DIR/clojure-mcp" ]; then
   echo -e "${YELLOW}Updating existing Clojure MCP repository...${NC}"
@@ -79,7 +82,6 @@ if [ -d "$CLOJURE_MCP_DIR/clojure-mcp" ]; then
   git pull
 else
   echo -e "${YELLOW}Cloning Clojure MCP repository...${NC}"
-  mkdir -p "$CLOJURE_MCP_DIR"
   git clone https://github.com/bhauman/clojure-mcp.git "$CLOJURE_MCP_DIR/clojure-mcp"
 fi
 


### PR DESCRIPTION
## Description
This PR updates the Clojure MCP setup script to clone the repository into the standardized `mcp/servers/` directory structure, following our dotfiles philosophy of maintaining clear organization and separation of concerns.

## Changes
- Modified `setup-clojure-mcp.sh` to clone into `mcp/servers/clojure-mcp` instead of the current location
- Updated `clojure-mcp-wrapper.sh` to use the new path
- Updated README.md to document the standardized approach for MCP servers
- Created `mcp/servers/` directory for all MCP server repositories

## Testing
- Verified that the script creates the proper directory structure
- Confirmed that the wrapper script correctly references the new path

## Related Issues
Closes #359

## Checklist
- [x] Code follows the project's coding style
- [x] Documentation has been updated
- [x] Changes are consistent with the "Spilled Coffee Principle"
- [x] Changes follow the "Versioning Mindset" with incremental improvements