### PR TITLE
Add Python REPL MCP server integration

### DIFF
--- a/mcp/README-python-mcp.md
+++ b/mcp/README-python-mcp.md
@@ -1,0 +1,130 @@
+# Python REPL MCP Server
+
+This integration provides a Python REPL (Read-Eval-Print Loop) as an MCP server, allowing you to execute Python code through the Model Context Protocol with a persistent session.
+
+## Features
+
+- **Persistent Python Session**: Variables persist between executions
+- **Environment Variables**: Support for .env files
+- **Package Management**: Install packages directly from PyPI
+- **Project Management**: Create timestamped project directories
+- **File Operations**: Create and load files within the REPL
+- **Comprehensive Logging**: Logs stored in the logs directory
+
+## Setup
+
+The setup script (`setup-python-mcp.sh`) handles all installation and configuration:
+
+```bash
+# Run the setup script
+./mcp/setup-python-mcp.sh
+```
+
+## Usage with Amazon Q CLI
+
+Add the following to your Amazon Q configuration:
+
+```json
+{
+  "mcpServers": {
+    "python-repl": {
+      "command": "py-mcp-start"
+    }
+  }
+}
+```
+
+## Available Tools
+
+Based on the actual source code, the following tools are available:
+
+1. `execute_python`: Execute Python code with persistent variables
+   - `code`: Python code to execute
+   - `reset`: Optional boolean to reset the session (default: false)
+
+2. `list_variables`: Show all variables in the current session
+
+3. `install_package`: Install a package from PyPI using `uv`
+   - `package`: Name of the package to install
+
+4. `initialize_project`: Create a new project directory with timestamp prefix
+   - `project_name`: Name for the project directory
+
+5. `create_file`: Create a new file with specified content
+   - `filename`: Path to the file (supports nested directories)
+   - `content`: Content to write to the file
+
+6. `load_file`: Load and execute a Python script in the current session
+   - `filename`: Path to the Python script to load
+
+## Examples
+
+Initialize a new project:
+
+```python
+# Create a new project directory
+initialize_project("data_analysis")
+```
+
+Create and execute a script:
+
+```python
+# Create a new Python file
+create_file("script.py", """
+def greet(name):
+    return f"Hello, {name}!"
+""")
+
+# Load and execute the script
+load_file("script.py")
+
+# Use the loaded function
+print(greet("World"))
+```
+
+Install and use a package:
+
+```python
+# Install pandas
+install_package("pandas")
+
+# Use the installed package
+import pandas as pd
+df = pd.DataFrame({'A': [1, 2, 3]})
+print(df)
+```
+
+List all variables:
+
+```python
+# Show all variables in the current session
+list_variables()
+```
+
+Reset the session:
+
+```python
+# Use execute_python with reset=true to clear all variables
+execute_python("", reset=True)
+```
+
+## Environment Variables
+
+The server supports `.env` file for environment variables management. Create a `.env` file in the mcp-python directory to store your environment variables. These variables will be automatically loaded and accessible in your Python REPL session using:
+
+```python
+import os
+
+# Access environment variables
+my_var = os.environ.get('MY_VARIABLE')
+# or
+my_var = os.getenv('MY_VARIABLE')
+```
+
+## Alignment with Dotfiles Philosophy
+
+This integration follows our core principles:
+
+1. **The Spilled Coffee Principle**: Easy setup and recovery with a single script
+2. **The Snowball Method**: Persistent REPL session accumulates knowledge over time
+3. **The Versioning Mindset**: Supports incremental improvements through file operations

--- a/mcp/mcp.json
+++ b/mcp/mcp.json
@@ -76,6 +76,13 @@
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"
       }
+    },
+    "python-repl": {
+      "command": "py-mcp-start",
+      "args": [],
+      "env": {
+        "FASTMCP_LOG_LEVEL": "ERROR"
+      }
     }
   }
 }

--- a/mcp/setup-python-mcp.sh
+++ b/mcp/setup-python-mcp.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Python MCP Server setup script
+# Following the Spilled Coffee Principle: anyone should be able to destroy their machine
+# and be fully operational again that afternoon.
+
+set -e
+
+# Ensure directory exists
+mkdir -p "$HOME/ppv/pillars/dotfiles/mcp"
+
+# Ensure uv is installed
+if ! command -v uv &> /dev/null; then
+    echo "Installing uv package manager..."
+    curl -sSf https://install.python-uv.org | sh
+fi
+
+# Clone the repository (using the enhanced fork with .env support and additional tools)
+REPO_DIR="$HOME/ppv/pillars/dotfiles/mcp/mcp-python"
+if [ ! -d "$REPO_DIR" ]; then
+    echo "Cloning mcp-python repository..."
+    git clone https://github.com/piplin-es/mcp-python.git "$REPO_DIR"
+else
+    echo "Repository already exists, updating..."
+    cd "$REPO_DIR"
+    git pull
+fi
+
+# Install dependencies
+cd "$REPO_DIR"
+echo "Installing dependencies..."
+uv pip install -e .
+
+# Create a wrapper script for easy starting
+WRAPPER_SCRIPT="$HOME/ppv/pillars/dotfiles/mcp/py-mcp-start"
+cat > "$WRAPPER_SCRIPT" << 'EOF'
+#!/bin/bash
+# Start the Python MCP server
+# This script follows the Snowball Method principle by maintaining persistent context
+
+cd "$HOME/ppv/pillars/dotfiles/mcp/mcp-python"
+uv run mcp_python
+EOF
+
+# Make the wrapper script executable
+chmod +x "$WRAPPER_SCRIPT"
+
+# Create a symlink to the wrapper script in a directory in PATH
+mkdir -p "$HOME/.local/bin"
+ln -sf "$WRAPPER_SCRIPT" "$HOME/.local/bin/py-mcp-start"
+
+# Create a sample .env file template if it doesn't exist
+ENV_EXAMPLE="$REPO_DIR/.env.example"
+if [ ! -f "$ENV_EXAMPLE" ]; then
+    echo "Creating .env.example template..."
+    cat > "$ENV_EXAMPLE" << 'EOF'
+# Python MCP Server Environment Variables
+# Copy this file to .env and customize as needed
+
+# API Keys (if needed by your Python scripts)
+OPENAI_API_KEY=your_openai_api_key_here
+ANTHROPIC_API_KEY=your_anthropic_api_key_here
+
+# Project Settings
+PROJECTS_ROOT=$HOME/projects
+EOF
+fi
+
+# Create logs directory
+mkdir -p "$REPO_DIR/logs"
+
+echo "Python MCP server setup complete!"
+echo "To start the server, run: py-mcp-start"
+echo "To configure your MCP client, see the README-python-mcp.md file"


### PR DESCRIPTION
## Overview

This PR adds integration for the Python REPL MCP server based on the [piplin-es/mcp-python](https://github.com/piplin-es/mcp-python) repository. The implementation follows the instructions in issue #368.

## Implementation Details

I've cloned and analyzed the actual source code from the repository to ensure accurate configuration:

1. Created a setup script (`mcp/setup-python-mcp.sh`) that:
   - Installs the `uv` package manager if needed
   - Clones the piplin-es/mcp-python repository
   - Installs dependencies
   - Creates a wrapper script for easy starting
   - Sets up environment variable templates

2. Added documentation (`mcp/README-python-mcp.md`) with:
   - Features overview
   - Setup instructions
   - Amazon Q CLI configuration
   - Available tools (verified from source code)
   - Usage examples
   - Environment variable configuration

## Features

The Python REPL MCP server provides:
- Persistent Python sessions (supporting our "Snowball Method" principle)
- Environment variable management via `.env` files
- Package installation capabilities
- File and project management tools
- Integration with any MCP-compatible client

## Testing

To test this integration:
1. Run the setup script: `./mcp/setup-python-mcp.sh`
2. Start the server: `py-mcp-start`
3. Configure your MCP client (Amazon Q, Claude, etc.)
4. Try the examples in the documentation

## Alignment with Dotfiles Philosophy

This integration aligns with our core principles:
1. **The Spilled Coffee Principle**: Easy setup and recovery with a single script
2. **The Snowball Method**: Persistent REPL session accumulates knowledge over time
3. **The Versioning Mindset**: Supports incremental improvements through file operations

Closes #368