### PR TITLE
feat(git): add git-delta installation script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -473,6 +473,30 @@ else
   echo "To use GitHub MCP features, install GitHub CLI and run: export GITHUB_TOKEN=\$(gh auth token)"
 fi
 
+# Git Delta setup
+echo -e "${DIVIDER}"
+echo "Checking Git Delta setup..."
+
+# Check if Git Delta is referenced in gitconfig
+if grep -q "delta" ~/.gitconfig 2>/dev/null; then
+  echo "Git Delta is referenced in your gitconfig."
+  
+  # Check if Git Delta is installed
+  if command -v delta &> /dev/null; then
+    echo -e "${GREEN}✓ Git Delta is already installed${NC}"
+  else
+    echo "Git Delta is not installed. Installing now..."
+    if [ -f "$DOT_DEN/utils/install-git-delta.sh" ]; then
+      bash "$DOT_DEN/utils/install-git-delta.sh"
+    else
+      echo -e "${RED}Git Delta installation script not found.${NC}"
+      echo "Please install Git Delta manually or your git diff commands may fail."
+    fi
+  fi
+else
+  echo "Git Delta is not referenced in your gitconfig. Skipping installation."
+fi
+
 # Docker setup
 echo -e "${DIVIDER}"
 echo "Checking Docker setup..."

--- a/utils/install-git-delta.sh
+++ b/utils/install-git-delta.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+# install-git-delta.sh - Automatic installation script for git-delta
+# Following the "Spilled Coffee Principle" - making setup reproducible across machines
+
+set -e  # Exit immediately if a command exits with a non-zero status
+
+echo "Git Delta Installation Script"
+echo "============================="
+
+# Detect OS and architecture
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+# Check if git-delta is already installed
+if command -v delta &> /dev/null; then
+    echo "Git Delta is already installed."
+    delta --version
+    exit 0
+fi
+
+echo "Installing Git Delta..."
+
+# Install based on detected OS
+if [[ "$OS" == "linux" ]]; then
+    # Debian/Ubuntu-based systems
+    if command -v apt-get &> /dev/null; then
+        echo "Installing via apt..."
+        sudo apt-get update
+        sudo apt-get install -y git-delta
+    
+    # Arch Linux
+    elif command -v pacman &> /dev/null; then
+        echo "Installing via pacman..."
+        sudo pacman -Sy --noconfirm git-delta
+    
+    # Fedora/RHEL-based systems
+    elif command -v dnf &> /dev/null; then
+        echo "Installing via dnf..."
+        sudo dnf install -y git-delta
+    
+    # Fallback to binary installation
+    else
+        echo "No package manager found. Installing from binary..."
+        
+        # Determine architecture
+        DELTA_ARCH=""
+        case "$ARCH" in
+            x86_64)
+                DELTA_ARCH="x86_64"
+                ;;
+            aarch64|arm64)
+                DELTA_ARCH="aarch64"
+                ;;
+            *)
+                echo "Unsupported architecture: $ARCH"
+                exit 1
+                ;;
+        esac
+        
+        # Get latest version
+        VERSION=$(curl -s https://api.github.com/repos/dandavison/delta/releases/latest | grep -Po '"tag_name": "\K[^"]*')
+        
+        # Download and install
+        TEMP_DIR=$(mktemp -d)
+        cd "$TEMP_DIR"
+        
+        FILENAME="delta-${VERSION}-${DELTA_ARCH}-unknown-linux-gnu.tar.gz"
+        curl -L -o delta.tar.gz "https://github.com/dandavison/delta/releases/download/${VERSION}/${FILENAME}"
+        
+        tar xzf delta.tar.gz
+        sudo install -o root -g root -m 0755 delta-*/delta /usr/local/bin/delta
+        
+        # Clean up
+        cd - > /dev/null
+        rm -rf "$TEMP_DIR"
+    fi
+
+elif [[ "$OS" == "darwin" ]]; then
+    # macOS with Homebrew
+    if command -v brew &> /dev/null; then
+        echo "Installing via Homebrew..."
+        brew install git-delta
+    else
+        echo "Homebrew not found. Please install Homebrew first."
+        echo "Run: /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\""
+        exit 1
+    fi
+
+else
+    echo "Unsupported operating system: $OS"
+    exit 1
+fi
+
+# Verify installation
+if command -v delta &> /dev/null; then
+    echo "Git Delta installed successfully!"
+    delta --version
+else
+    echo "Installation failed. Please install Git Delta manually."
+    exit 1
+fi


### PR DESCRIPTION
## Description

This PR adds automatic installation of git-delta when it's referenced in the gitconfig file, following the "Spilled Coffee Principle" - ensuring anyone can destroy their machine and be fully operational again that afternoon.

## Changes

- Created `utils/install-git-delta.sh` script that:
  - Detects OS and architecture
  - Installs git-delta using the appropriate package manager
  - Falls back to binary installation if needed
  - Verifies successful installation

- Modified `setup.sh` to:
  - Check if git-delta is referenced in gitconfig
  - Install git-delta automatically if needed
  - Skip installation if not referenced

## Benefits

- Prevents git diff commands from failing on new machines due to missing dependencies
- Maintains the enhanced diff viewing capabilities of git-delta
- Follows the "Spilled Coffee Principle" by making setup reproducible across machines
- Reduces manual intervention when setting up on a new system

## Testing

Tested on:
- Ubuntu-based system with apt
- Verified installation works correctly when git-delta is referenced in gitconfig