### PR TITLE
fix(setup): add shellcheck directive to ignore SC1090 warning

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -570,6 +570,7 @@ fi
 # Source bash aliases to make them immediately available
 echo "Loading bash aliases into current session..."
 if [[ -f ~/.bash_aliases ]]; then
+  # shellcheck disable=SC1090
   source ~/.bash_aliases
   echo -e "${GREEN}✓ Bash aliases loaded successfully${NC}"
 fi


### PR DESCRIPTION
## Description

This PR fixes the shellcheck warning that's causing the CI lint job to fail in PR #385.

## Changes

- Added a shellcheck directive `# shellcheck disable=SC1090` before sourcing ~/.bash_aliases
- This tells shellcheck to ignore the SC1090 warning for non-constant source paths

## Issue Fixed

The CI job was failing with the following warning:
```
In setup.sh line 573:
  source ~/.bash_aliases
         ^-------------^ SC1090 (warning): ShellCheck can't follow non-constant source. Use a directive to specify location.
```

This is a common shellcheck warning that occurs when sourcing files with paths that can't be statically analyzed. Since ~/.bash_aliases is a valid path that we've already checked exists with the if statement, it's safe to disable this specific warning.

## Testing

- Verified locally that shellcheck no longer reports this warning when run with the directive in place