### PR TITLE
feat(amazon-q): set chat edit mode to vi

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -260,6 +260,11 @@ if command -v q >/dev/null 2>&1; then
   else
     echo "Amazon Q telemetry already disabled"
   fi
+  
+  # Configure Amazon Q to use vi edit mode
+  echo "Setting Amazon Q chat edit mode to vi..."
+  q settings chat.editMode vi >/dev/null 2>&1
+  echo -e "${GREEN}✓ Amazon Q chat edit mode set to vi${NC}"
 fi
   
 # Node.js setup with NVM


### PR DESCRIPTION
## Description

This PR adds configuration to the setup script that sets Amazon Q's chat edit mode to vi, providing a more familiar editing experience for users who prefer vi-style editing.

## Changes

- Added commands to run `q settings chat.editMode vi` during setup
- Added appropriate logging to show when the setting is applied
- Placed the configuration within the existing Amazon Q setup section

## Benefits

- Provides a consistent vi-style editing experience across all machines
- Follows the "Spilled Coffee Principle" by ensuring this preference is automatically configured
- Improves productivity for users familiar with vi keybindings
- Eliminates the need to manually configure this setting on each new machine

## Testing

- Verified that the command runs successfully when Amazon Q is installed
- Confirmed that the setting persists after setup