### PR TITLE
feature/q alias ergonomics flow

### DIFF
--- a/.bash_aliases.d/q-cli.sh
+++ b/.bash_aliases.d/q-cli.sh
@@ -10,15 +10,9 @@ alias q-run="$HOME/ppv/pillars/q-cli/target/release/q"
 # Quick development testing (build and run in one step)
 alias q-dev="cd $HOME/ppv/pillars/q-cli && cargo run --bin q_cli -- chat"
 
-# Amazon Q documentation workflow
-alias q-doc-merge="git checkout main && git pull && git merge docs/update-amazonq-guidance --no-ff && git push origin main && echo '✅ AmazonQ.md changes merged with preserved history and pushed to main'"
-alias q-doc-add="add-amazonq"
-
 # Trust all tools command
 # Use with qsafe alias from clipboard.sh for a complete security workflow
 qtrust() {
     q chat "$@" "/tools trustall"
 }
-
-
 

--- a/.bash_aliases.d/q-cli.sh
+++ b/.bash_aliases.d/q-cli.sh
@@ -10,6 +10,12 @@ alias q-run="$HOME/ppv/pillars/q-cli/target/release/q"
 # Quick development testing (build and run in one step)
 alias q-dev="cd $HOME/ppv/pillars/q-cli && cargo run --bin q_cli -- chat"
 
+# Main Amazon Q command with resume and aliases loaded
+alias qq='source ~/.bash_aliases && q chat --resume'
+
+# Fresh Amazon Q session (no resume) - use when you want a clean start
+alias qf='source ~/.bash_aliases && q chat'
+
 # Trust all tools command
 # Use with qsafe alias from clipboard.sh for a complete security workflow
 qtrust() {


### PR DESCRIPTION
- **Fix qtrust alias parameter handling**
  Replace qtrust alias with function to properly handle command-line parameters.
  
  - Convert alias qtrust='q chat \"/tools trustall\"' to function
  - Function places parameters before \"/tools trustall\" command
  - Fixes issue where qtrust -r would incorrectly expand to:
    q chat \"/tools trustall\" -r (wrong)
  - Now correctly expands to:
    q chat -r \"/tools trustall\" (correct)
  
  Resolves #386

- **Remove qr alias for resume functionality**
  Remove the qr='q chat --resume' alias as it's redundant since users can
  directly use 'q chat -r' or 'q chat --resume' for the same functionality.

- **Add qq alias for enhanced Amazon Q experience\n\n- qq: Main command with resume and aliases loaded by default\n- qf: Fresh session without resume\n- Provides convenient muscle-memory command for daily use**
  

- **removed old AmazonQ.md merge tools to leverage global files instead with more support around it**
  