### PR TITLE
fix(q-cli): target specific alias file in qq command

### DIFF
--- a/.bash_aliases.d/clipboard.sh
+++ b/.bash_aliases.d/clipboard.sh
@@ -7,53 +7,5 @@ alias clip-cmd='PREV_CMD=$(fc -ln -2 -2 | sed "s/^ *//"); (echo "Command: $PREV_
 # Quick clipboard access
 alias clip="xclip -selection clipboard"
 
-# Copy Amazon Q security recommendations to clipboard
-# Works with qtrust alias in q-cli.sh for a complete security workflow
-qsafe() {
-    # Format as a single command with all tools on one line that updates, creates, or deletes resources
-    echo "/tools untrust fs_write execute_bash use_aws report_issue\
-    filesystem___create_directory\
-    filesystem___move_file\
-    github___create_issue\
-    github___add_issue_comment\
-    github___push_files\
-    github___create_or_update_file\
-    github___create_repository \
-    github___fork_repository\
-    github___create_branch\
-    github___create_pull_request\
-    github___merge_pull_request\
-    github___create_and_submit_pull_request_review\
-    github___assign_copilot_to_issue\
-    github___add_pull_request_review_comment_to_pending_review\
-    github___create_and_submit_pull_request_review\
-    github___create_pending_pull_request_review\
-    github___dismiss_notification\
-    github___manage_notification_subscription\
-    github___manage_repository_notification_subscription\
-    github___mark_all_notifications_read\
-    github___request_copilot_review\
-    github___submit_pending_pull_request_review\
-    github___update_issue\
-    github___update_pull_request\
-    github___update_pull_request_branch\
-    atlassian___jira_create_issue\
-    atlassian___jira_update_issue\
-    atlassian___jira_add_comment\
-    atlassian___jira_add_worklog \
-    atlassian___jira_create_issue_link\
-    atlassian___confluence_create_page\
-    atlassian___confluence_update_page \
-    atlassian___confluence_add_comment
-    atlassian___jira_transition_issue\
-    atlassian___jira_update_sprint\
-    atlassian___jira_delete_issue \
-    atlassian___confluence_delete_page\
-    atlassian___jira_remove_issue_link\
-    atlassian___confluence_add_label \
-    atlassian___jira_batch_create_issues\
-    atlassian___jira_create_sprint\
-    atlassian___jira_link_to_epic"\
-    | xclip -selection clipboard
-}
+
 

--- a/.bash_aliases.d/q-cli.sh
+++ b/.bash_aliases.d/q-cli.sh
@@ -17,8 +17,57 @@ alias qq='source ~/ppv/pillars/dotfiles/.bash_aliases.d/q-cli.sh && q chat --res
 alias qf='source ~/.bash_aliases && q chat'
 
 # Trust all tools command
-# Use with qsafe alias from clipboard.sh for a complete security workflow
 qtrust() {
     q chat "$@" "/tools trustall"
+}
+
+# Copy Amazon Q security recommendations to clipboard
+# Works with qtrust function for a complete security workflow
+qsafe() {
+    # Format as a single command with all tools on one line that updates, creates, or deletes resources
+    echo "/tools untrust fs_write execute_bash use_aws report_issue\
+    filesystem___create_directory\
+    filesystem___move_file\
+    github___create_issue\
+    github___add_issue_comment\
+    github___push_files\
+    github___create_or_update_file\
+    github___create_repository \
+    github___fork_repository\
+    github___create_branch\
+    github___create_pull_request\
+    github___merge_pull_request\
+    github___create_and_submit_pull_request_review\
+    github___assign_copilot_to_issue\
+    github___add_pull_request_review_comment_to_pending_review\
+    github___create_and_submit_pull_request_review\
+    github___create_pending_pull_request_review\
+    github___dismiss_notification\
+    github___manage_notification_subscription\
+    github___manage_repository_notification_subscription\
+    github___mark_all_notifications_read\
+    github___request_copilot_review\
+    github___submit_pending_pull_request_review\
+    github___update_issue\
+    github___update_pull_request\
+    github___update_pull_request_branch\
+    atlassian___jira_create_issue\
+    atlassian___jira_update_issue\
+    atlassian___jira_add_comment\
+    atlassian___jira_add_worklog \
+    atlassian___jira_create_issue_link\
+    atlassian___confluence_create_page\
+    atlassian___confluence_update_page \
+    atlassian___confluence_add_comment
+    atlassian___jira_transition_issue\
+    atlassian___jira_update_sprint\
+    atlassian___jira_delete_issue \
+    atlassian___confluence_delete_page\
+    atlassian___jira_remove_issue_link\
+    atlassian___confluence_add_label \
+    atlassian___jira_batch_create_issues\
+    atlassian___jira_create_sprint\
+    atlassian___jira_link_to_epic"\
+    | xclip -selection clipboard
 }
 

--- a/.bash_aliases.d/q-cli.sh
+++ b/.bash_aliases.d/q-cli.sh
@@ -11,7 +11,7 @@ alias q-run="$HOME/ppv/pillars/q-cli/target/release/q"
 alias q-dev="cd $HOME/ppv/pillars/q-cli && cargo run --bin q_cli -- chat"
 
 # Main Amazon Q command with resume and aliases loaded
-alias qq='source ~/.bash_aliases && q chat --resume'
+alias qq='source ~/ppv/pillars/dotfiles/.bash_aliases.d/q-cli.sh && q chat --resume'
 
 # Fresh Amazon Q session (no resume) - use when you want a clean start
 alias qf='source ~/.bash_aliases && q chat'

--- a/.bash_aliases.d/q-cli.sh
+++ b/.bash_aliases.d/q-cli.sh
@@ -71,3 +71,41 @@ qsafe() {
     | xclip -selection clipboard
 }
 
+# Version of qsafe that outputs to stdout for Amazon Q context hooks
+# This allows the untrust command to be automatically injected into Q sessions
+qsafe_output() {
+    echo "/tools untrust fs_write execute_bash use_aws report_issue\
+    filesystem___create_directory\
+    filesystem___move_file\
+    github___create_issue\
+    github___create_repository\
+    github___delete_file\
+    github___push_files\
+    github___create_branch\
+    github___merge_pull_request\
+    github___update_issue\
+    github___update_pull_request\
+    github___create_pull_request\
+    github___fork_repository\
+    github___add_issue_comment\
+    github___create_and_submit_pull_request_review\
+    github___submit_pending_pull_request_review\
+    github___add_pull_request_review_comment_to_pending_review\
+    github___create_pending_pull_request_review\
+    github___delete_pending_pull_request_review\
+    github___assign_copilot_to_issue\
+    github___request_copilot_review\
+    github___mark_all_notifications_read\
+    github___dismiss_notification\
+    github___manage_notification_subscription\
+    github___manage_repository_notification_subscription\
+    github___update_pull_request_branch\
+    atlassian___jira_delete_issue \
+    atlassian___confluence_delete_page\
+    atlassian___jira_remove_issue_link\
+    atlassian___confluence_add_label \
+    atlassian___jira_batch_create_issues\
+    atlassian___jira_create_sprint\
+    atlassian___jira_link_to_epic"
+}
+

--- a/.bashrc
+++ b/.bashrc
@@ -189,12 +189,14 @@ fi
 tmux source-file ~/.tmux.conf >/dev/null 2>&1 || true
 
 # Source Q CLI specific aliases for all shell sessions
-# Amazon Q post block - must run before loading our aliases
-[[ -f "${HOME}/.local/share/amazon-q/shell/bashrc.post.bash" ]] && builtin source "${HOME}/.local/share/amazon-q/shell/bashrc.post.bash"
-
-# Source Q CLI aliases after Amazon Q integration completes
-# This ensures aliases are available in Amazon Q's shell environment
+# Hybrid Strategy: Load Q CLI aliases/functions before Amazon Q post integration
 [[ -f "${HOME}/ppv/pillars/dotfiles/.bash_aliases.d/q-cli.sh" ]] && source "${HOME}/ppv/pillars/dotfiles/.bash_aliases.d/q-cli.sh"
+
+# Export qsafe function so subshells (like ! commands) can recognize it
+export -f qsafe 2>/dev/null || true
+
+# Finish Amazon Q integration (post block)
+[[ -f "${HOME}/.local/share/amazon-q/shell/bashrc.post.bash" ]] && builtin source "${HOME}/.local/share/amazon-q/shell/bashrc.post.bash"
 
 export PATH="$HOME/.local/bin:$PATH"
 export PATH="$HOME/.local/uv-tools/bin:$PATH"

--- a/.bashrc
+++ b/.bashrc
@@ -189,10 +189,13 @@ fi
 tmux source-file ~/.tmux.conf >/dev/null 2>&1 || true
 
 # Source Q CLI specific aliases for all shell sessions
+# Amazon Q post block - must run before loading our aliases
+[[ -f "${HOME}/.local/share/amazon-q/shell/bashrc.post.bash" ]] && builtin source "${HOME}/.local/share/amazon-q/shell/bashrc.post.bash"
+
+# Source Q CLI aliases after Amazon Q integration completes
+# This ensures aliases are available in Amazon Q's shell environment
 [[ -f "${HOME}/ppv/pillars/dotfiles/.bash_aliases.d/q-cli.sh" ]] && source "${HOME}/ppv/pillars/dotfiles/.bash_aliases.d/q-cli.sh"
 
-# Amazon Q post block. Keep at the bottom of this file.
-[[ -f "${HOME}/.local/share/amazon-q/shell/bashrc.post.bash" ]] && builtin source "${HOME}/.local/share/amazon-q/shell/bashrc.post.bash"
 export PATH="$HOME/.local/bin:$PATH"
 export PATH="$HOME/.local/uv-tools/bin:$PATH"
 

--- a/.bashrc
+++ b/.bashrc
@@ -188,6 +188,9 @@ fi
 # This ensures tmux always has the latest config when started
 tmux source-file ~/.tmux.conf >/dev/null 2>&1 || true
 
+# Source Q CLI specific aliases for all shell sessions
+[[ -f "${HOME}/ppv/pillars/dotfiles/.bash_aliases.d/q-cli.sh" ]] && source "${HOME}/ppv/pillars/dotfiles/.bash_aliases.d/q-cli.sh"
+
 # Amazon Q post block. Keep at the bottom of this file.
 [[ -f "${HOME}/.local/share/amazon-q/shell/bashrc.post.bash" ]] && builtin source "${HOME}/.local/share/amazon-q/shell/bashrc.post.bash"
 export PATH="$HOME/.local/bin:$PATH"


### PR DESCRIPTION
- Change qq alias to source only q-cli.sh instead of all bash aliases
- Enables access to qsafe and other Q CLI aliases in qq sessions
- Follows targeted configuration approach over loading everything