### PR TITLE
fix/bashrc interactive check

### DIFF
--- a/.bash_aliases.d/q-cli.sh
+++ b/.bash_aliases.d/q-cli.sh
@@ -11,7 +11,7 @@ alias q-run="$HOME/ppv/pillars/q-cli/target/release/q"
 alias q-dev="cd $HOME/ppv/pillars/q-cli && cargo run --bin q_cli -- chat"
 
 # Main Amazon Q command with resume and aliases loaded
-alias qq='source ~/ppv/pillars/dotfiles/.bash_aliases.d/q-cli.sh && q chat --resume'
+alias qq='source ~/.bash_aliases && q chat --resume'
 
 # Fresh Amazon Q session (no resume) - use when you want a clean start
 alias qf='source ~/.bash_aliases && q chat'

--- a/.bash_aliases.d/q-cli.sh
+++ b/.bash_aliases.d/q-cli.sh
@@ -11,7 +11,7 @@ alias q-run="$HOME/ppv/pillars/q-cli/target/release/q"
 alias q-dev="cd $HOME/ppv/pillars/q-cli && cargo run --bin q_cli -- chat"
 
 # Main Amazon Q command with resume and aliases loaded
-alias qq='source ~/.bash_aliases && q chat --resume'
+alias qq='source ~/ppv/pillars/dotfiles/.bash_aliases.d/q-cli.sh && q chat --resume'
 
 # Fresh Amazon Q session (no resume) - use when you want a clean start
 alias qf='source ~/.bash_aliases && q chat'

--- a/.bashrc
+++ b/.bashrc
@@ -4,19 +4,6 @@
 # see /usr/share/doc/bash/examples/startup-files (in the package bash-doc)
 # for examples
 
-# # .bashrc or .zshrc
-# alias linusfiles='function _linusfiles() {
-#     echo "Listing files tracked by git and copying contents to clipboard, approved by Linus Torvalds himself!";
-#     git ls-files > /tmp/torvalds_files.txt;
-#     while IFS= read -r file; do
-#         echo "File: $file" >> /tmp/torvalds_content.txt;
-#         cat "$file" >> /tmp/torvalds_content.txt;
-#         echo -e "\n\n" >> /tmp/torvalds_content.txt;
-#     done < /tmp/torvalds_files.txt;
-#     xclip -sel clip < /tmp/torvalds_content.txt;
-#     echo "Done! The files have been copied to your clipboard.";
-# }; _linusfiles'
-
 export GPG_TTY=$(tty)
 # Note: Removed interactive check to ensure consistent behavior
 # across all shell contexts and prevent debugging issues

--- a/.bashrc
+++ b/.bashrc
@@ -18,11 +18,8 @@
 # }; _linusfiles'
 
 export GPG_TTY=$(tty)
-# If not running interactively, don't do anything
-case $- in
-    *i*) ;;
-      *) return;;
-esac
+# Note: Removed interactive check to ensure consistent behavior
+# across all shell contexts and prevent debugging issues
 
 # don't put duplicate lines or lines starting with space in the history.
 # See bash(1) for more options


### PR DESCRIPTION
- **fix(bash): remove interactive check causing return 1 errors**
  - Remove interactive shell check that was causing early returns
  - Ensures consistent behavior across interactive and non-interactive contexts
  - Fixes multiple 'return 1' errors when sourcing .bashrc
  - Improves reproducibility and debugging experience