### PR TITLE
fix(setup): auto-install Homebrew on macOS following spilled coffee principle

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -386,6 +386,19 @@ fi
 echo -e "${DIVIDER}"
 echo "Checking GitHub CLI..."
 
+# Ensure Homebrew is available on macOS before proceeding
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  # Source the Homebrew utility script
+  if [[ -f "$DOT_DEN/utils/ensure-homebrew.sh" ]]; then
+    source "$DOT_DEN/utils/ensure-homebrew.sh"
+    ensure_homebrew_on_macos || {
+      echo -e "${RED}Failed to ensure Homebrew is installed. GitHub CLI installation may fail.${NC}"
+    }
+  else
+    echo -e "${RED}Homebrew utility script not found at $DOT_DEN/utils/ensure-homebrew.sh${NC}"
+  fi
+fi
+
 install_or_update_gh_cli() {
   echo "Installing/updating GitHub CLI using official method..."
   
@@ -433,7 +446,9 @@ install_or_update_gh_cli() {
       echo "Using Homebrew installation..."
       (brew install gh || brew upgrade gh) || echo -e "${YELLOW}Failed to install/update GitHub CLI via Homebrew. Continuing...${NC}"
     else
-      echo -e "${YELLOW}Homebrew not found. Please install Homebrew first to install GitHub CLI on macOS.${NC}"
+      echo -e "${RED}Homebrew installation failed earlier. Cannot install GitHub CLI.${NC}"
+      echo "Please install Homebrew manually: https://brew.sh"
+      return 1
     fi
   else
     echo -e "${YELLOW}Unsupported OS: $OSTYPE. Please install GitHub CLI manually.${NC}"

--- a/utils/ensure-homebrew.sh
+++ b/utils/ensure-homebrew.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# =========================================================
+# HOMEBREW AUTO-INSTALLER FOR MACOS
+# =========================================================
+# PURPOSE: Automatically install Homebrew on macOS if missing
+# This follows the "spilled coffee principle" - users should be
+# fully operational after running setup without manual intervention
+# =========================================================
+
+# Define colors for consistent output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No Color
+
+ensure_homebrew_on_macos() {
+  # Only run on macOS
+  if [[ "$OSTYPE" != "darwin"* ]]; then
+    return 0
+  fi
+
+  if ! command -v brew &> /dev/null; then
+    echo -e "${YELLOW}Homebrew not found on macOS. Installing Homebrew automatically...${NC}"
+    echo "This follows the 'spilled coffee principle' - you should be fully operational after setup."
+    
+    # Install Homebrew
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    
+    # Add Homebrew to PATH for current session
+    if [[ -f "/opt/homebrew/bin/brew" ]]; then
+      # Apple Silicon Macs
+      eval "$(/opt/homebrew/bin/brew shellenv)"
+      # Add to bash_profile if not already present
+      if ! grep -q 'eval "$(/opt/homebrew/bin/brew shellenv)"' ~/.bash_profile 2>/dev/null; then
+        echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.bash_profile
+      fi
+    elif [[ -f "/usr/local/bin/brew" ]]; then
+      # Intel Macs
+      eval "$(/usr/local/bin/brew shellenv)"
+      # Add to bash_profile if not already present
+      if ! grep -q 'eval "$(/usr/local/bin/brew shellenv)"' ~/.bash_profile 2>/dev/null; then
+        echo 'eval "$(/usr/local/bin/brew shellenv)"' >> ~/.bash_profile
+      fi
+    fi
+    
+    # Verify installation
+    if command -v brew &> /dev/null; then
+      echo -e "${GREEN}✓ Homebrew installed successfully${NC}"
+      return 0
+    else
+      echo -e "${RED}Homebrew installation failed. Please install manually.${NC}"
+      echo "Visit: https://brew.sh"
+      return 1
+    fi
+  else
+    echo -e "${GREEN}✓ Homebrew is already installed${NC}"
+    return 0
+  fi
+}
+
+# If script is executed directly (not sourced), run the function
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  ensure_homebrew_on_macos
+fi


### PR DESCRIPTION
## Description
This PR fixes the macOS setup issue where GitHub CLI installation fails due to missing Homebrew. Following our "spilled coffee principle", the setup script now automatically installs Homebrew when needed, ensuring users are fully operational after running setup.

## Changes
- Create new utility script `utils/ensure-homebrew.sh` for Homebrew management
- Auto-detect and install Homebrew if missing on macOS
- Handle both Apple Silicon and Intel Mac PATH configurations
- Prevent duplicate PATH entries in bash_profile
- Improve error messaging for GitHub CLI installation
- Keep setup.sh clean by extracting Homebrew logic to utility file

## Testing
Tested on:
- Fresh macOS installation (Homebrew not present)
- Existing macOS installation with Homebrew
- Both Apple Silicon and Intel Mac architectures
- Linux systems (no changes to behavior)

## Spilled Coffee Principle
This change ensures that even if a macOS user "spills coffee" on their machine:
1. They can clone the dotfiles repo
2. Run setup.sh
3. Get a fully functional environment without manual intervention

Fixes #399