### PR TITLE
fix(setup): replace grep -P with BSD grep compatible patterns for macOS

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -429,7 +429,7 @@ install_or_update_gh_cli() {
       echo "Using direct binary installation..."
       (
         # Get latest version
-        VERSION=$(curl -s https://api.github.com/repos/cli/cli/releases/latest | grep -Po '"tag_name": "v\K[^"]*')
+        VERSION=$(curl -s https://api.github.com/repos/cli/cli/releases/latest | grep -o '"tag_name": "v[^"]*"' | cut -d'"' -f4 | sed 's/^v//')
         
         # Download and extract
         curl -Lo gh.tar.gz "https://github.com/cli/cli/releases/latest/download/gh_${VERSION}_linux_amd64.tar.gz"
@@ -461,7 +461,7 @@ if command -v gh &> /dev/null; then
   echo "Current GitHub CLI version: $CURRENT_VERSION"
   
   # Get the latest available version from GitHub
-  LATEST_VERSION=$(curl -s https://api.github.com/repos/cli/cli/releases/latest | grep -Po '"tag_name": "v\K[^"]*')
+  LATEST_VERSION=$(curl -s https://api.github.com/repos/cli/cli/releases/latest | grep -o '"tag_name": "v[^"]*"' | cut -d'"' -f4 | sed 's/^v//')
   
   # Check if update is needed
   if [[ -n "$LATEST_VERSION" && "$CURRENT_VERSION" != "$LATEST_VERSION" ]]; then

--- a/utils/install-git-delta.sh
+++ b/utils/install-git-delta.sh
@@ -59,7 +59,7 @@ if [[ "$OS" == "linux" ]]; then
         esac
         
         # Get latest version
-        VERSION=$(curl -s https://api.github.com/repos/dandavison/delta/releases/latest | grep -Po '"tag_name": "\K[^"]*')
+        VERSION=$(curl -s https://api.github.com/repos/dandavison/delta/releases/latest | grep -o '"tag_name": "[^"]*"' | cut -d'"' -f4)
         
         # Download and install
         TEMP_DIR=$(mktemp -d)


### PR DESCRIPTION
## Description
This PR fixes the "grep: invalid option -- P" error on macOS by replacing Perl regex patterns with BSD grep compatible alternatives. macOS uses BSD grep by default, which doesn't support the `-P` (Perl regex) flag that GNU grep supports on Linux.

## Changes
- **setup.sh**: Replace two instances of `grep -P` used for GitHub CLI version extraction
- **utils/install-git-delta.sh**: Replace one instance of `grep -P` used for Git Delta version extraction
- Use POSIX-compatible `grep -o` + `cut` + `sed` pipeline instead of Perl regex
- Maintain identical functionality across macOS (BSD grep) and Linux (GNU grep)

## Technical Details

### Before (Perl regex - Linux only):
```bash
grep -Po '"tag_name": "v\K[^"]*'  # Extract version after "v"
grep -Po '"tag_name": "\K[^"]*'   # Extract version directly
```

### After (POSIX compatible - macOS + Linux):
```bash
grep -o '"tag_name": "v[^"]*"' | cut -d'"' -f4 | sed 's/^v//'  # Extract and remove "v"
grep -o '"tag_name": "[^"]*"' | cut -d'"' -f4                  # Extract directly
```

## Testing
Verified on both platforms:
- **macOS**: BSD grep successfully extracts version numbers
- **Linux**: GNU grep maintains existing functionality
- **Sample JSON**: `{"tag_name": "v2.74.1"}` → `2.74.1`

## Spilled Coffee Principle
This change ensures that macOS users can:
1. Clone the dotfiles repo
2. Run setup.sh without grep errors
3. Get proper GitHub CLI and Git Delta version detection
4. Be "fully operational that afternoon" without manual intervention

Fixes #403