### PR TITLE
fix: general macOS cleanup and Amazon Q rules modularization

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -175,9 +175,9 @@ fi
 
 # Apply environment-specific MCP server configuration
 if [[ -f "$DOT_DEN/utils/mcp-environment.sh" ]]; then
-  # Source the MCP environment utility
+  # Source the MCP environment utility (suppress function definition output)
   # shellcheck disable=SC1090
-  source "$DOT_DEN/utils/mcp-environment.sh"
+  source "$DOT_DEN/utils/mcp-environment.sh" >/dev/null
   
   # Detect current environment
   CURRENT_ENV=$(detect_environment)

--- a/setup.sh
+++ b/setup.sh
@@ -500,5 +500,8 @@ echo -e "${GREEN}✅ Dotfiles setup complete!${NC}"
 echo "Your development environment is now configured and ready to use."
 echo -e "${DIVIDER}"
 
+# Clear the error trap to prevent it from persisting in the shell session
+trap - ERR
+
 # Final debug message
 echo "Debug: Setup script completed successfully"


### PR DESCRIPTION
## Changes

This PR includes several improvements focused on macOS compatibility and Amazon Q rules modularization:

### 1. Fix Function Definition Output
- Add redirect to suppress function definition output when sourcing mcp-environment.sh
- Resolves unwanted output during setup script execution

### 2. Cross-Platform Clipboard Support
- Create utils/clipboard.sh for unified clipboard access across macOS/Linux
- Replace hardcoded xclip usage with clipboard_copy/clipboard_paste functions
- Support pbcopy/pbpaste (macOS), xclip, and xsel with graceful fallback
- Update qsafe, clip, clip-cmd aliases and linusfiles script

### 3. README Optimization
- Remove manual package installation sections
- Update setup description to reflect spilled coffee principle automation
- Focus README on AI context rather than human instructions
- Significantly reduce token count while maintaining essential information

### 4. Amazon Q Rules Modularization
- Create .amazonq/rules/ directory structure
- Split AmazonQ.md into repo-specific and global rules
- Move git workflow rules to .amazonq/rules/git-workflow.md
- Move automation principles to .amazonq/rules/automation-principles.md
- Add hello-world.md test rule
- Keep only repo-specific content in root AmazonQ.md
- Add Amazon Q rules installation to setup.sh

## Testing Done
- Verified setup script runs without unwanted output
- Tested clipboard functionality on macOS
- Confirmed Amazon Q rules are properly installed
- Checked all symlinks and configurations

## Related Issues
- Closes #390 (Amazon Q rules modularization)

## Screenshots
None required - changes are primarily functional and structural.

## Checklist
- [x] Follows conventional commit messages
- [x] Includes appropriate documentation updates
- [x] Tested on macOS
- [x] Maintains backward compatibility
- [x] Follows the spilled coffee principle