### PR TITLE
fix(amazonq): use absolute paths for truly global context

### DIFF
--- a/.amazonq/global_context.json
+++ b/.amazonq/global_context.json
@@ -1,0 +1,8 @@
+{
+  "paths": [
+    "~/.amazonq/rules/**/*.md",
+    "README.md",
+    "AmazonQ.md"
+  ],
+  "hooks": {}
+}

--- a/utils/setup-amazonq-rules.py
+++ b/utils/setup-amazonq-rules.py
@@ -1,23 +1,24 @@
 #!/usr/bin/env python3
 """
 Amazon Q Global Rules Setup
-Symlinks global rules and validates installation
+Symlinks global rules and sets up proper global context configuration
 """
 
 import os
 import sys
-import glob
 import shutil
 from datetime import datetime
 from pathlib import Path
 
 def setup_amazonq_rules():
-    """Set up Amazon Q global rules with symlinks and validation"""
+    """Set up Amazon Q global rules with symlinks and proper global configuration"""
     
     # Paths
     dotfiles_dir = Path.home() / "ppv" / "pillars" / "dotfiles"
     source_rules = dotfiles_dir / ".amazonq" / "rules"
     target_rules = Path.home() / ".amazonq" / "rules"
+    source_global_config = dotfiles_dir / ".amazonq" / "global_context.json"
+    target_global_config = Path.home() / ".aws" / "amazonq" / "global_context.json"
     
     print("Setting up Amazon Q global rules...")
     
@@ -25,7 +26,11 @@ def setup_amazonq_rules():
         print(f"❌ No Amazon Q rules found in {source_rules}")
         return False
     
-    # Handle existing target
+    if not source_global_config.exists():
+        print(f"❌ No global context config found in {source_global_config}")
+        return False
+    
+    # Handle existing target rules
     if target_rules.exists() and not target_rules.is_symlink():
         # Preserve existing rules as backup outside auto-discovery path
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -52,9 +57,17 @@ def setup_amazonq_rules():
     target_rules.symlink_to(source_rules)
     print("✅ Amazon Q global rules symlinked")
     
+    # Set up global context configuration
+    target_global_config.parent.mkdir(parents=True, exist_ok=True)
+    
+    # Copy the global context configuration file
+    shutil.copy2(str(source_global_config), str(target_global_config))
+    print("✅ Global context configuration installed")
+    print("   This fixes Amazon Q's counter-intuitive default of using relative paths for 'global' context")
+    
     # Validation: Assert file counts match
     source_files = list(source_rules.glob("**/*.md"))
-    target_files = list(target_rules.glob("**/*.md"))  # Now check the symlinked target
+    target_files = list(target_rules.glob("**/*.md"))
     
     print(f"\nValidation:")
     print(f"Source files: {len(source_files)}")
@@ -62,6 +75,7 @@ def setup_amazonq_rules():
     
     if len(source_files) == len(target_files):
         print("✅ File count assertion passed")
+        print("✅ Amazon Q global rules setup complete")
         return True
     else:
         print("❌ File count assertion failed!")


### PR DESCRIPTION
## Problem

Amazon Q's "global" context with the 🌍 globe emoji was only working in the dotfiles repository, not across all repositories as expected. This defeated the core philosophy of the dotfiles system - global should mean global.

## Root Cause

Amazon Q CLI's default global context configuration uses **relative paths** instead of absolute paths:

```rust
// In Amazon Q CLI source code
paths: vec![
    ".amazonq/rules/**/*.md".to_string(),  // ❌ Relative to current directory
    "README.md".to_string(),
    AMAZONQ_FILENAME.to_string(),
],
```

This meant the global context only worked in directories that happened to have a local `.amazonq/rules/` directory.

## Solution

1. **Added proper global context configuration** (`.amazonq/global_context.json`) with absolute paths:
   ```json
   {
     "paths": [
       "~/.amazonq/rules/**/*.md",  // ✅ Absolute path to home directory
       "README.md",
       "AmazonQ.md"
     ],
     "hooks": {}
   }
   ```

2. **Updated setup script** to install both the symlinked rules and the global configuration file

3. **Maintained elegant symlink approach** - single source of truth, no file duplication

## Testing

Before fix (in pipelines repo):
```
🌍 global:
    .amazonq/rules/**/*.md 
    README.md (1 match)
    AmazonQ.md

1 matched file in use  // ❌ Only local README
```

After fix (in pipelines repo):
```
🌍 global:
    ~/.amazonq/rules/**/*.md (6 matches)  // ✅ All global rules found
    README.md (1 match)
    AmazonQ.md

7 matched files in use  // ✅ Global + local context
```

## Principles Followed

- **Spilled Coffee Principle**: Fully automated setup, no manual commands
- **Snowball Method**: Global context now truly accumulates across all repositories
- **Versioning Mindset**: Improved existing files rather than creating new ones

The 🌍 global context should actually be global, not relative to the current directory.