### PR TITLE
fix/work machine environment config

### DIFF
--- a/.bash_exports
+++ b/.bash_exports
@@ -5,3 +5,8 @@ export RUST_BACKTRACE=full
 
 # Add MCP wrapper scripts to PATH for cross-machine portability
 export PATH="$PATH:$HOME/ppv/pillars/dotfiles/mcp"
+
+# Load machine-specific exports if they exist
+if [ -f ~/.bash_exports.local ]; then
+    . ~/.bash_exports.local
+fi

--- a/.bash_exports.local.example
+++ b/.bash_exports.local.example
@@ -1,0 +1,14 @@
+# Machine-specific environment exports
+# This file is not version controlled - customize for your specific machine
+# Copy this file to ~/.bash_exports.local and modify as needed
+
+# ==== ENVIRONMENT CONFIGURATION ====
+# Set to "true" on work machines, "false" on personal machines
+# Controls which MCP servers are enabled/disabled
+export WORK_MACHINE="false"
+
+# ==== MACHINE-SPECIFIC EXPORTS ====
+# Add any other machine-specific environment variables here
+# Examples:
+# export CUSTOM_PATH="/path/specific/to/this/machine"
+# export MACHINE_ROLE="development"

--- a/.bash_secrets.example
+++ b/.bash_secrets.example
@@ -8,11 +8,6 @@
 # Your actual secrets file should NEVER be committed to git
 # =========================================================
 
-# ==== ENVIRONMENT CONFIGURATION ====
-# Set to "true" on work machines, "false" on personal machines
-# Controls which MCP servers are enabled/disabled
-export WORK_MACHINE="false"
-
 # ==== AUTHENTICATION TOKENS ====
 # Examples of common authentication tokens
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@
 *.keystore
 .bash_secrets
 
+# Machine-specific configuration
+.bash_exports.local
+
 # Private SSH keys
 id_rsa
 id_dsa

--- a/docs/mcp-environment.md
+++ b/docs/mcp-environment.md
@@ -12,7 +12,7 @@ The system allows you to automatically enable or disable certain MCP servers bas
 
 ## How It Works
 
-1. Set the `WORK_MACHINE` environment variable in your `~/.bash_secrets` file:
+1. Set the `WORK_MACHINE` environment variable in your `~/.bash_exports.local` file:
    ```bash
    # Set to "true" on work machines, "false" on personal machines
    export WORK_MACHINE="false"

--- a/setup.sh
+++ b/setup.sh
@@ -217,12 +217,27 @@ if [[ -f "$work_gitconfig_source" ]]; then
     echo -e "${GREEN}✓ Work Git configuration linked${NC}"
 fi
 
+# Create machine-specific exports file from template
+if [[ -f "$DOT_DEN/.bash_exports.local.example" && ! -f ~/.bash_exports.local ]]; then
+    echo "Creating machine-specific exports file from template..."
+    cp "$DOT_DEN/.bash_exports.local.example" ~/.bash_exports.local
+    echo "Created ~/.bash_exports.local from template. Please edit to configure your environment."
+fi
+
 # Create secrets file from template
 if [[ -f "$DOT_DEN/.bash_secrets.example" && ! -f ~/.bash_secrets ]]; then
     echo "Creating secrets file from template..."
     cp "$DOT_DEN/.bash_secrets.example" ~/.bash_secrets
     chmod 600 ~/.bash_secrets
     echo "Created ~/.bash_secrets from template. Please edit to add your secrets."
+fi
+
+# Source bash exports early to make environment variables available for MCP configuration
+echo "Loading environment variables from bash_exports..."
+if [[ -f ~/.bash_exports ]]; then
+  # shellcheck disable=SC1090
+  source ~/.bash_exports
+  echo -e "${GREEN}✓ Environment variables loaded successfully${NC}"
 fi
 
 # Set up Amazon Q global rules
@@ -496,14 +511,6 @@ if [[ -f ~/.bash_aliases ]]; then
   # shellcheck disable=SC1090
   source ~/.bash_aliases
   echo -e "${GREEN}✓ Bash aliases loaded successfully${NC}"
-fi
-
-# Source bash exports to make environment variables available
-echo "Loading environment variables from bash_exports..."
-if [[ -f ~/.bash_exports ]]; then
-  # shellcheck disable=SC1090
-  source ~/.bash_exports
-  echo -e "${GREEN}✓ Environment variables loaded successfully${NC}"
 fi
 
 echo -e "${DIVIDER}"

--- a/utils/mcp-environment.sh
+++ b/utils/mcp-environment.sh
@@ -6,7 +6,7 @@
 # Default environment-specific server configurations
 # Format: Array of server names to disable in specific environments
 PERSONAL_DISABLED_SERVERS=("atlassian" "gitlab")
-WORK_DISABLED_SERVERS=("gdrive")
+WORK_DISABLED_SERVERS=()
 DEVELOPMENT_DISABLED_SERVERS=()
 PRODUCTION_DISABLED_SERVERS=("experimental" "beta")
 


### PR DESCRIPTION
- **fix(config): move WORK_MACHINE from secrets to exports**
  - Create .bash_exports.local for machine-specific environment config
  - Move WORK_MACHINE from .bash_secrets to .bash_exports.local
  - Fix setup.sh to source bash_exports before MCP environment detection
  - Update documentation to reflect proper configuration location
  - Add .bash_exports.local to .gitignore for machine-specific settings
  
  This fixes the issue where MCP environment filtering wasn't working
  because WORK_MACHINE wasn't available during setup. Environment
  configuration belongs in exports, not secrets.
  

- **feat(mcp): allow gdrive MCP server in work environments**
  Remove gdrive from WORK_DISABLED_SERVERS array to allow Google Drive
  access on work machines now that credentials are properly configured.
  