### PR TITLE
feat(mcp): auto-run MCP setup scripts to follow Spilled Coffee Principle

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -196,6 +196,28 @@ if [[ -f "$DOT_DEN/utils/mcp-environment.sh" ]]; then
   filter_mcp_config ~/.config/Claude/claude_desktop_config.json "$CURRENT_ENV"
 fi
 
+# Auto-run MCP setup scripts following Spilled Coffee Principle
+echo "Ensuring all MCP servers are built..."
+for setup_script in "$DOT_DEN"/mcp/setup-*-mcp.sh; do
+    if [[ -f "$setup_script" ]]; then
+        # Extract server name from setup script filename
+        # setup-github-mcp.sh → github
+        server_name=$(basename "$setup_script" | sed 's/setup-\(.*\)-mcp\.sh/\1/')
+        
+        # Check if corresponding binary exists in servers/
+        if [[ ! -f "$DOT_DEN/mcp/servers/$server_name" ]] && [[ ! -d "$DOT_DEN/mcp/servers/${server_name}-mcp-server" ]]; then
+            echo "Running $(basename "$setup_script") - server binary not found..."
+            if bash "$setup_script"; then
+                echo -e "${GREEN}✓ MCP server '$server_name' setup completed${NC}"
+            else
+                echo -e "${YELLOW}⚠ MCP server '$server_name' setup encountered issues (continuing...)${NC}"
+            fi
+        else
+            echo -e "${GREEN}✓ MCP server '$server_name' already built${NC}"
+        fi
+    fi
+done
+
 # Set up Git configuration
 echo "Setting up Git configuration..."
 gitconfig_path="$HOME/.gitconfig"


### PR DESCRIPTION
## Problem Solved

Fixes the **Spilled Coffee Principle** violation where MCP servers required manual setup steps beyond the main `setup.sh` script. Previously, users had to manually run each `setup-*-mcp.sh` script, breaking the principle that "anyone should be able to destroy their machine and be fully operational again that afternoon."

## Solution Implemented

Added automatic detection and execution of MCP setup scripts in `setup.sh`:

```bash
# Auto-run MCP setup scripts following Spilled Coffee Principle
echo "Ensuring all MCP servers are built..."
for setup_script in "$DOT_DEN"/mcp/setup-*-mcp.sh; do
    if [[ -f "$setup_script" ]]; then
        # Extract server name from setup script filename
        server_name=$(basename "$setup_script" | sed 's/setup-\(.*\)-mcp\.sh/\1/')
        
        # Check if corresponding binary exists in servers/
        if [[ ! -f "$DOT_DEN/mcp/servers/$server_name" ]] && [[ ! -d "$DOT_DEN/mcp/servers/${server_name}-mcp-server" ]]; then
            echo "Running $(basename "$setup_script") - server binary not found..."
            if bash "$setup_script"; then
                echo -e "${GREEN}✓ MCP server '$server_name' setup completed${NC}"
            else
                echo -e "${YELLOW}⚠ MCP server '$server_name' setup encountered issues (continuing...)${NC}"
            fi
        else
            echo -e "${GREEN}✓ MCP server '$server_name' already built${NC}"
        fi
    fi
done
```

## Key Features

✅ **True Spilled Coffee Compliance** - One `source setup.sh` makes you fully operational  
✅ **Idempotent** - Safe to run multiple times, only builds missing servers  
✅ **Automatic** - No manual intervention required for MCP server setup  
✅ **Auditable** - Clear logging with colored output showing what's being built  
✅ **Resilient** - Graceful error handling, continues on setup failures  
✅ **Smart Detection** - Checks for both binary files and source directories  

## Detection Logic

The implementation:
1. **Loops** through all `setup-*-mcp.sh` files in `mcp/` directory
2. **Extracts** server name using pattern matching (`setup-github-mcp.sh` → `github`)
3. **Checks** for existence of either:
   - `mcp/servers/{server_name}` (binary)
   - `mcp/servers/{server_name}-mcp-server/` (source directory)
4. **Runs** setup script only if server doesn't exist
5. **Reports** clear progress with colored status indicators

## Integration Point

Added after MCP configuration copying (line ~197) but before Git configuration setup, ensuring MCP servers are built before any dependent operations.

## Testing

This change has been designed to be:
- **Safe** - Only runs setup scripts when needed
- **Non-destructive** - Won't rebuild existing servers
- **Informative** - Clear output about what's happening and why

## Impact

Now when someone runs `source setup.sh`, they get:
- All MCP configuration files copied ✅
- All required MCP servers automatically built ✅  
- Full operational environment in one command ✅
- True adherence to the Spilled Coffee Principle ✅

Closes #431