### PR TITLE
fix(iterm2): harden clipboard access settings to prevent repeated prompts

### DIFF
--- a/utils/configure-iterm2.sh
+++ b/utils/configure-iterm2.sh
@@ -105,7 +105,13 @@ configure_iterm2() {
     defaults write com.googlecode.iterm2 "WindowStyle" -int 0
     defaults write com.googlecode.iterm2 "UseBorder" -bool false
     
-    echo -e "${GREEN}✓ iTerm2 configured for tmux workflow (140x45, Monaco 14pt)${NC}"
+    # Clipboard access settings - harden to prevent repeated prompts
+    defaults write com.googlecode.iterm2 "AllowClipboardAccess" -bool true
+    defaults write com.googlecode.iterm2 "SuppressRestartAnnouncement" -bool true
+    defaults write com.googlecode.iterm2 "NoSyncSuppressClipboardAccessDeniedWarning" -bool true
+    defaults write com.googlecode.iterm2 "NoSyncNeverRemindPrefsChangesLostForFile" -bool true
+    
+    echo -e "${GREEN}✓ iTerm2 configured for tmux workflow (140x45, Monaco 14pt, clipboard access hardened)${NC}"
     
     if pgrep -x "iTerm2" > /dev/null; then
         echo -e "${YELLOW}iTerm2 restart required for changes to take effect${NC}"


### PR DESCRIPTION
## Problem
iTerm2 keeps showing the "Allow sending of clipboard contents" dialog even after selecting "Always", disrupting workflow.

## Solution
Added hardened clipboard access settings to the iTerm2 configuration script:

- `AllowClipboardAccess=true` - Enable clipboard access
- `NoSyncSuppressClipboardAccessDeniedWarning=true` - Suppress denial warnings  
- `NoSyncNeverRemindPrefsChangesLostForFile=true` - Prevent pref change reminders
- `SuppressRestartAnnouncement=true` - Reduce restart notifications

## Changes
- Modified `utils/configure-iterm2.sh` to include clipboard hardening settings
- Updated success message to reflect clipboard access hardening

This integrates the clipboard permission fix directly into our existing plist-based iTerm2 configuration system, making it persistent and reproducible.