### PR TITLE
fix(mcp): capture runtime errors from server processes

### DIFF
--- a/bin/check-mcp-errors
+++ b/bin/check-mcp-errors
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# =========================================================
+# CHECK MCP ERRORS UTILITY
+# =========================================================
+# PURPOSE: View and manage MCP server error logs
+# USAGE: 
+#   check-mcp-errors          - Show recent errors
+#   check-mcp-errors --tail   - Follow errors in real-time
+#   check-mcp-errors --clear  - Clear the error log
+# =========================================================
+
+MCP_ERROR_LOG="$HOME/mcp-errors.log"
+
+show_usage() {
+    echo "Usage: check-mcp-errors [--tail|--clear]"
+    echo ""
+    echo "Options:"
+    echo "  (no args)  Show recent MCP errors"
+    echo "  --tail     Follow errors in real-time"
+    echo "  --clear    Clear the error log"
+    echo ""
+    echo "Error log location: $MCP_ERROR_LOG"
+}
+
+case "${1:-}" in
+    --tail)
+        if [[ -f "$MCP_ERROR_LOG" ]]; then
+            echo "Following MCP errors in real-time (Ctrl+C to stop)..."
+            echo "Log file: $MCP_ERROR_LOG"
+            echo "----------------------------------------"
+            tail -f "$MCP_ERROR_LOG"
+        else
+            echo "No MCP error log found at: $MCP_ERROR_LOG"
+            echo "Errors will appear here when MCP servers encounter issues."
+        fi
+        ;;
+    --clear)
+        if [[ -f "$MCP_ERROR_LOG" ]]; then
+            > "$MCP_ERROR_LOG"
+            echo "MCP error log cleared: $MCP_ERROR_LOG"
+        else
+            echo "No MCP error log found to clear: $MCP_ERROR_LOG"
+        fi
+        ;;
+    --help|-h)
+        show_usage
+        ;;
+    "")
+        if [[ -f "$MCP_ERROR_LOG" ]]; then
+            echo "Recent MCP errors:"
+            echo "Log file: $MCP_ERROR_LOG"
+            echo "----------------------------------------"
+            # Show last 20 lines, or entire file if smaller
+            tail -20 "$MCP_ERROR_LOG"
+            echo "----------------------------------------"
+            echo "Use 'check-mcp-errors --tail' to follow in real-time"
+            echo "Use 'check-mcp-errors --clear' to clear the log"
+        else
+            echo "No MCP error log found at: $MCP_ERROR_LOG"
+            echo "This is normal if no MCP servers have encountered errors yet."
+            echo "Errors will be logged here when they occur."
+        fi
+        ;;
+    *)
+        echo "Unknown option: $1"
+        show_usage
+        exit 1
+        ;;
+esac

--- a/mcp/atlassian-mcp-wrapper.sh
+++ b/mcp/atlassian-mcp-wrapper.sh
@@ -35,7 +35,7 @@ mcp_check_env_var "ATLASSIAN" "ATLASSIAN_JIRA_USERNAME" "Add: export ATLASSIAN_J
 mcp_check_env_var "ATLASSIAN" "ATLASSIAN_JIRA_API_TOKEN" "Add: export ATLASSIAN_JIRA_API_TOKEN=\"your_api_token\""
 
 # Run the MCP Atlassian server with credentials from environment variables
-exec uvx mcp-atlassian \
+mcp_exec_with_logging "ATLASSIAN" uvx mcp-atlassian \
   --confluence-url="$ATLASSIAN_CONFLUENCE_URL" \
   --confluence-username="$ATLASSIAN_CONFLUENCE_USERNAME" \
   --confluence-token="$ATLASSIAN_CONFLUENCE_API_TOKEN" \

--- a/mcp/brave-search-mcp-wrapper.sh
+++ b/mcp/brave-search-mcp-wrapper.sh
@@ -32,7 +32,7 @@ mcp_check_env_var "BRAVE" "BRAVE_API_KEY" "Add: export BRAVE_API_KEY=\"your_api_
 mcp_check_docker "BRAVE"
 
 # Run the Brave Search MCP server with credentials from environment variables
-exec docker run -i --rm \
+mcp_exec_with_logging "BRAVE" docker run -i --rm \
   -e BRAVE_API_KEY="$BRAVE_API_KEY" \
   --network=host \
   mcp/brave-search

--- a/mcp/filesystem-mcp-wrapper.sh
+++ b/mcp/filesystem-mcp-wrapper.sh
@@ -25,7 +25,7 @@ if [[ -f "$BUILT_SERVER_PATH" ]]; then
     echo "Using locally built custom Filesystem MCP server..."
     # Pass all arguments to the built server
     # The $HOME argument allows access to the home directory
-    node "$BUILT_SERVER_PATH" "$HOME" "$@"
+    mcp_exec_with_logging "FILESYSTEM" node "$BUILT_SERVER_PATH" "$HOME" "$@"
 else
     echo "Built server not found, falling back to npx..."
     echo "Warning: This will use the standard version without custom tool descriptions"
@@ -37,5 +37,5 @@ else
     fi
     
     # Fall back to npx if the built server doesn't exist
-    npx @modelcontextprotocol/filesystem-server "$HOME" "$@"
+    mcp_exec_with_logging "FILESYSTEM" npx @modelcontextprotocol/filesystem-server "$HOME" "$@"
 fi

--- a/mcp/gdrive-mcp-wrapper.sh
+++ b/mcp/gdrive-mcp-wrapper.sh
@@ -34,7 +34,7 @@ if ! docker volume ls --format "table {{.Name}}" | grep -q "mcp-gdrive"; then
 fi
 
 # Run the Google Drive MCP server using Docker
-exec docker run -i --rm \
+mcp_exec_with_logging "GDRIVE" docker run -i --rm \
   -v mcp-gdrive:/gdrive-server \
   -e GDRIVE_CREDENTIALS_PATH=/gdrive-server/credentials.json \
   mcp/gdrive

--- a/mcp/git-mcp-wrapper.sh
+++ b/mcp/git-mcp-wrapper.sh
@@ -34,4 +34,4 @@ mcp_check_command "GIT" "git" "Install Git: brew install git"
 
 # Activate the virtual environment and run the Python module
 source "$SERVER_DIR/.venv/bin/activate"
-exec python -m mcp_server_git "$@"
+mcp_exec_with_logging "GIT" python -m mcp_server_git "$@"

--- a/mcp/github-mcp-wrapper.sh
+++ b/mcp/github-mcp-wrapper.sh
@@ -39,4 +39,4 @@ if [[ ! -x "$GITHUB_BINARY_PATH" ]]; then
 fi
 
 # Run the GitHub MCP server with the token
-exec "$GITHUB_BINARY_PATH" stdio
+mcp_exec_with_logging "GITHUB" "$GITHUB_BINARY_PATH" stdio


### PR DESCRIPTION
## Problem
MCP wrapper scripts only logged pre-flight check failures but couldn't capture runtime errors from actual server processes. The `exec` command replaced the shell process, making Python/Node.js server crashes, asyncio errors, and network failures invisible to the logging framework.

## Root Cause
All wrapper scripts used the `exec` pattern which:
- Replaces the shell process entirely
- Prevents capturing stderr or exit codes from server processes  
- Makes runtime failures (asyncio/stdio issues, crashes) invisible
- Breaks the error logging framework for the most critical failures

## Solution
- **New `mcp_exec_with_logging` function** replaces `exec` pattern
- **Captures stderr** from server processes while preserving stdout for MCP protocol
- **Logs runtime failures** with exit codes and error messages to `~/mcp-errors.log`
- **Maintains same exit behavior** as original server processes
- **Updated all 6 wrapper scripts** to use the new logging function

## Changes Made
- `mcp/utils/mcp-logging.sh`: Add `mcp_exec_with_logging` function
- `mcp/atlassian-mcp-wrapper.sh`: Capture uvx/Python server errors
- `mcp/brave-search-mcp-wrapper.sh`: Capture Docker container errors  
- `mcp/filesystem-mcp-wrapper.sh`: Capture Node.js server errors
- `mcp/gdrive-mcp-wrapper.sh`: Capture Docker container errors
- `mcp/git-mcp-wrapper.sh`: Capture Python server errors
- `mcp/github-mcp-wrapper.sh`: Capture binary server errors

## Testing
Validated with temporary test script that simulates:
- Commands with non-zero exit codes
- Non-existent commands  
- Python scripts with runtime exceptions

All scenarios now properly log to `~/mcp-errors.log` and are visible via `check-mcp-errors`.

## Impact
Runtime errors like asyncio/stdio failures, network timeouts, and server crashes are now visible instead of being silently lost. This addresses the fundamental gap where the most critical MCP server failures were invisible to users.

Fixes #442