### PR TITLE
Add Systems-Stewardship commit trailer for tracking meta-development work

### DIFF
--- a/.amazonq/rules/procedures/git-workflow.md
+++ b/.amazonq/rules/procedures/git-workflow.md
@@ -4,6 +4,7 @@
 - **IMPORTANT: NEVER commit directly to the main branch**
 - Always use conventional commit syntax: `<type>[scope]: description` (scope optional but encouraged; use separate `-m` for trailers)
 - Good scope choices add context about what component is being modified (e.g., api, ui, auth, config, docs)
+- Use `Systems-Stewardship: true` trailer for systems improvement work
 - Commit early and often with meaningful changes
 
 ## Branch Management


### PR DESCRIPTION
## Summary
Adds `Systems-Stewardship: true` commit trailer to git workflow rules for tracking systems improvement work vs direct feature development.

## Changes
- Updated `.amazonq/rules/procedures/git-workflow.md` to include Systems-Stewardship trailer guidance
- Enables measurement of 80/20 balance between systems work and feature work

## Systems Stewardship
This commit itself demonstrates the principle - improving our development workflow rather than just building features.

## Testing
- [x] Trailer added to git workflow documentation
- [x] This commit uses the trailer: `Systems-Stewardship: true`