### PR TITLE
Add Subtraction Creates Value principle and standardize git trailers

### DIFF
--- a/.amazonq/rules/principles/subtraction-creates-value.md
+++ b/.amazonq/rules/principles/subtraction-creates-value.md
@@ -1,0 +1,3 @@
+# Subtraction Creates Value
+
+The idea that strategically removing items, commitments, or complexity often creates more value than adding new things.

--- a/.amazonq/rules/procedures/git-workflow.md
+++ b/.amazonq/rules/procedures/git-workflow.md
@@ -1,10 +1,9 @@
 # Git Workflow Rules
 
 ## Commit Standards
-- **IMPORTANT: NEVER commit directly to the main branch**
 - Always use conventional commit syntax: `<type>[scope]: description` (scope optional but encouraged; use separate `-m` for trailers)
 - Good scope choices add context about what component is being modified (e.g., api, ui, auth, config, docs)
-- Use `Systems-Stewardship: true` trailer for systems improvement work
+- Use `Principle: <slug>` trailer when work resonates with a specific principle (e.g., `Principle: subtraction-creates-value`, `Principle: versioning-mindset`, `Principle: systems-stewardship`)
 - Commit early and often with meaningful changes
 
 ## Branch Management


### PR DESCRIPTION
## Changes

- **Add new global principle**: `subtraction-creates-value` - The idea that strategically removing items, commitments, or complexity often creates more value than adding new things
- **Standardize git workflow**: Update to use `Principle: <slug>` format for all principles (including systems-stewardship)
- **Remove blanket restriction**: Allow direct commits to main branch when appropriate

## Context

This adds a core principle to the global Amazon Q rules that will be available across all repositories. The principle emphasizes the value of strategic removal and simplification over accumulation of complexity.

The git workflow standardization provides a consistent way to tag commits that resonate with any of our core principles using the slug format.