### PR TITLE
feat(amazonq): add chat.enableNotifications setting defaulted to false

### DIFF
--- a/utils/install-amazon-q.sh
+++ b/utils/install-amazon-q.sh
@@ -191,6 +191,7 @@ configure_amazon_q() {
     q settings chat.editMode vi >/dev/null 2>&1 || echo -e "${YELLOW}Could not set chat.editMode to vi${NC}"
     q settings chat.defaultModel claude-4-sonnet >/dev/null 2>&1 || echo -e "${YELLOW}Could not set default model${NC}"
     q settings mcp.noInteractiveTimeout 5000 >/dev/null 2>&1 || echo -e "${YELLOW}Could not set mcp.noInteractiveTimeout${NC}"
+    q settings chat.enableNotifications false >/dev/null 2>&1 || echo -e "${YELLOW}Could not set chat.enableNotifications${NC}"
 
     echo -e "${GREEN}✓ Amazon Q configuration complete${NC}"
 }


### PR DESCRIPTION
Add `chat.enableNotifications false` to Amazon Q CLI setup script for testing the new notification feature.

Setting defaults to false - can be enabled manually with `q settings chat.enableNotifications true`.