### PR TITLE
docs: add git worktree workflow documentation

### DIFF
--- a/docs/git-worktree-workflow.md
+++ b/docs/git-worktree-workflow.md
@@ -1,0 +1,20 @@
+# Git Worktree Workflow (Beta - Imperfect System)
+
+We know very little about worktrees. This is an admittedly imperfect system to be improved upon later per Versioning Mindset.
+
+## Steps
+
+1. `mkdir -p ~/ppv/pillars/worktrees/dotfiles`
+2. `cd ~/ppv/pillars/dotfiles && git worktree add ~/ppv/pillars/worktrees/dotfiles/issue-<NUMBER> -b feature/<description>-<NUMBER>`
+3. Work in worktree: `cd ~/ppv/pillars/worktrees/dotfiles/issue-<NUMBER>`
+4. Commit, push, create PR as normal
+5. Cleanup: `cd ~/ppv/pillars/dotfiles && git worktree remove ~/ppv/pillars/worktrees/dotfiles/issue-<NUMBER> --force`
+
+## Quirks Found
+
+- Must use full paths
+- Cleanup requires returning to main repo directory
+
+---
+
+*First edition - will improve with experience*


### PR DESCRIPTION
## Summary
Moves git worktree workflow documentation from Amazon Q rules to main repository for better accessibility and systems stewardship.

## Changes
- Added `docs/git-worktree-workflow.md` with current beta workflow
- Preserved existing documentation with known quirks and limitations
- Made institutional knowledge available to all dotfiles users

## Dogfooding
This PR was created using the worktree workflow it documents, demonstrating the process in practice.

## Philosophy Alignment
- **Systems Stewardship**: Preserving and sharing institutional knowledge
- **Versioning Mindset**: First edition that will improve with experience

Closes #446