### PR TITLE
docs: add vendor-neutral knowledge taxonomy win to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ A living log of notable changes, decisions, and modifications to the dotfiles se
 
 ## 2025-06-19
 
+- Restructured Amazon Q rules to vendor-neutral knowledge taxonomy (#487) - enables tool-agnostic knowledge organization (Invent and Simplify, Systems Stewardship)
 - Added CHANGELOG.md for documenting notable changes and decisions (Snowball Method)
 - Commented out Claude Desktop setups - no longer using, made reintegration seamless (Subtraction Creates Value)
 


### PR DESCRIPTION
## Summary
Documents the successful vendor-neutral knowledge taxonomy restructuring in the changelog.

## Changes
- Added entry for restructuring Amazon Q rules to `knowledge/` directory (#487)
- Positioned as top changelog entry for 2025-06-19
- Referenced GitHub issue for traceability
- Highlighted tool-agnostic knowledge organization benefit
- Noted alignment with Invent and Simplify + Systems Stewardship principles

## Key Insight Captured
The `$DOT_DEN` variable insight was crucial - worktree testing initially didn't work because setup scripts reference the main dotfiles directory, not the worktree location. This required merging the changes first before the symlink update would take effect.

## Philosophy Alignment
- **Snowball Method**: Documenting wins and insights for future reference
- **Systems Stewardship**: Preserving institutional knowledge about the refactoring