### PR TITLE
Replace claude-desktop-debian with our fork

### DIFF
--- a/mcp/setup-claude-desktop.sh.optional
+++ b/mcp/setup-claude-desktop.sh.optional
@@ -10,7 +10,7 @@
 set -e
 
 # Clone this repository
-git clone https://github.com/aaddrick/claude-desktop-debian.git
+git clone https://github.com/atxtechbro/claude-desktop-debian.git
 cd claude-desktop-debian
 
 # Build the package (Defaults to .deb and cleans build files)


### PR DESCRIPTION
Replaces the upstream claude-desktop-debian repository with our fork for better control and maintenance.

Closes #491

## Changes
- Updated `mcp/setup-claude-desktop.sh.optional` to clone from `atxtechbro/claude-desktop-debian` instead of `aaddrick/claude-desktop-debian`

## Context
- Original repository is no longer maintained
- Using our fork provides better control and maintenance
- This is still an optional setup since Claude Desktop isn't officially supported on Linux