### PR TITLE
feat(mcp): disable/enable git MCP server to test client recognition of disabled value

### DIFF
--- a/mcp/mcp.json
+++ b/mcp/mcp.json
@@ -13,7 +13,7 @@
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"
       },
-      "disabled": true
+      "disabled": false
     },
     "github": {
       "command": "github-mcp-wrapper.sh",

--- a/mcp/mcp.json
+++ b/mcp/mcp.json
@@ -12,7 +12,8 @@
       "args": [],
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"
-      }
+      },
+      "disabled": true
     },
     "github": {
       "command": "github-mcp-wrapper.sh",


### PR DESCRIPTION
## Theory to Test

Git is so fundamentally well understood and documented that AI models are already extremely proficient with git commands without needing a specialized MCP server. The git MCP server may be unnecessary overhead rather than adding meaningful value.

## What This Changes

- Adds `"disabled": true` to the git MCP server configuration
- Tests whether Amazon Q CLI can handle git operations just as effectively using built-in knowledge vs MCP tools
- Potentially improves performance by removing one MCP server from the stack

## Rationale

**Subtraction Creates Value**: Git commands are:
- Standardized and well-documented
- Extensively covered in AI model training data
- Fundamental enough that specialized tooling may be redundant
- Simple enough that direct command execution is often clearer than abstraction

## Expected Outcomes

If the theory is correct:
- ✅ Git operations continue to work seamlessly
- ✅ Reduced MCP server overhead and startup time
- ✅ Simpler configuration with one less moving part

If the theory is wrong:
- ❌ Git operations become less reliable or intuitive
- ❌ Loss of git-specific context or capabilities

## Testing Approach

1. Merge this change
2. Use Amazon Q CLI for typical git workflows
3. Monitor for any degradation in git operation quality
4. Compare performance with one fewer MCP server running

## Philosophy Alignment

- **Subtraction Creates Value**: Remove complexity that doesn't add meaningful capability
- **Systems Stewardship**: Test assumptions about tool necessity
- **Tracer Bullets**: Quick experiment to validate or invalidate the theory

Related to #461 - leveraging the new `disabled=true` field support to test MCP server necessity.

Let's see if AI's native git proficiency makes the git MCP server redundant.