### PR TITLE
experiment[mcp]: temporarily disable filesystem MCP server

### DIFF
--- a/mcp/mcp.json
+++ b/mcp/mcp.json
@@ -39,7 +39,8 @@
       "args": [],
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"
-      }
+      },
+      "disabled": true
     },
     "gdrive": {
       "command": "gdrive-mcp-wrapper.sh",


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Temporarily disables the filesystem MCP server to evaluate the development experience
- Sets `disabled: true` in the mcp.json configuration
- This is an experimental change to test using only native file tools

## Test Plan
- [x] Updated mcp.json to disable filesystem server
- [ ] Test Claude Code with native file tools only
- [ ] Test Amazon Q with native file tools only
- [ ] Evaluate if this improves the development experience

Closes #513

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)