### PR TITLE
feat(claude-code): configure terminal bell notifications via setup

### DIFF
--- a/.claude/settings/claude-code-defaults.json
+++ b/.claude/settings/claude-code-defaults.json
@@ -1,0 +1,3 @@
+{
+  "preferredNotifChannel": "terminal_bell"
+}

--- a/utils/configure-claude-code-settings.sh
+++ b/utils/configure-claude-code-settings.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Configure Claude Code settings from source-controlled defaults
+# Applies settings defined in .claude/settings/claude-code-defaults.json
+
+set -euo pipefail
+
+# Colors for output
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+configure_claude_code_settings() {
+    echo "Configuring Claude Code settings..."
+    
+    # Get the directory where this script is located
+    SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+    DOT_DEN="$(dirname "$SCRIPT_DIR")"
+    
+    # Path to source settings
+    SETTINGS_SOURCE="$DOT_DEN/.claude/settings/claude-code-defaults.json"
+    
+    # Check if Claude Code is installed
+    if ! command -v claude &> /dev/null; then
+        echo -e "${YELLOW}Claude Code is not installed. Skipping configuration.${NC}"
+        return 0
+    fi
+    
+    # Check if settings file exists
+    if [ ! -f "$SETTINGS_SOURCE" ]; then
+        echo -e "${YELLOW}No Claude Code settings found at $SETTINGS_SOURCE${NC}"
+        return 0
+    fi
+    
+    # Check if jq is available for JSON parsing
+    if ! command -v jq &> /dev/null; then
+        echo -e "${RED}jq is not installed. Cannot parse JSON settings.${NC}"
+        return 1
+    fi
+    
+    # Apply each setting from the JSON file
+    echo "Applying Claude Code settings from source control..."
+    
+    # Read each key-value pair from the JSON file
+    while IFS= read -r key && IFS= read -r value; do
+        # Skip empty keys
+        if [ -z "$key" ]; then
+            continue
+        fi
+        
+        # Apply the setting globally
+        if claude config set --global "$key" "$value" 2>/dev/null; then
+            echo -e "  ${GREEN}✓${NC} Set $key to: $value"
+        else
+            echo -e "  ${RED}✗${NC} Failed to set $key"
+        fi
+    done < <(jq -r 'to_entries[] | .key, .value' "$SETTINGS_SOURCE")
+    
+    echo -e "${GREEN}✓ Claude Code settings configured${NC}"
+    
+    # Show current configuration
+    echo -e "\nCurrent Claude Code global settings:"
+    claude config list --global 2>/dev/null | grep -E "(preferredNotifChannel|messageIdleNotifThresholdMs)" || true
+    
+    # Platform-specific notes
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        echo -e "\n${YELLOW}macOS Note:${NC}"
+        echo "For terminal bell notifications to work in iTerm2:"
+        echo "  1. Go to System Settings → Notifications → iTerm2"
+        echo "  2. Enable 'Allow Notifications'"
+        echo "  3. In iTerm2: Preferences → Profiles → Terminal → Check 'Enable bell'"
+    fi
+    
+    return 0
+}
+
+# Run configuration if script is executed directly
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    configure_claude_code_settings
+fi

--- a/utils/install-claude-code.sh
+++ b/utils/install-claude-code.sh
@@ -79,6 +79,9 @@ setup_claude_code() {
     # Configure MCP servers for Claude Code
     configure_claude_mcp
     
+    # Configure Claude Code settings from source control
+    configure_claude_code_settings
+    
     return 0
 }
 
@@ -154,6 +157,17 @@ configure_claude_mcp() {
     else
         echo -e "${YELLOW}Warning: MCP configuration not found at $MCP_CONFIG_SOURCE${NC}"
         echo "MCP servers will need to be configured manually."
+    fi
+}
+
+configure_claude_code_settings() {
+    # Get the directory where this script is located
+    SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+    
+    # Source the configuration script
+    if [ -f "$SCRIPT_DIR/configure-claude-code-settings.sh" ]; then
+        source "$SCRIPT_DIR/configure-claude-code-settings.sh"
+        configure_claude_code_settings
     fi
 }
 


### PR DESCRIPTION
## Summary
- Add source-controlled Claude Code settings configuration following the spilled-coffee-principle
- Configure `preferredNotifChannel` to `terminal_bell` via setup.sh instead of manual commands
- Fix worktree workflow to work within Claude Code's cd constraints

## Implementation
- Created `.claude/settings/claude-code-defaults.json` with terminal bell preference
- Added `utils/configure-claude-code-settings.sh` to apply settings globally
- Integrated into existing Claude Code installation flow
- Updated worktree workflow documentation for Claude Code compatibility

## macOS Note
For terminal bell notifications to work in iTerm2:
1. System Settings → Notifications → iTerm2 → Enable 'Allow Notifications'
2. iTerm2 Preferences → Profiles → Terminal → Check 'Enable bell'

Closes #501