### PR TITLE
fix(procedures): correct worktree paths to be inside dotfiles directory

### DIFF
--- a/knowledge/procedures/worktree-workflow.md
+++ b/knowledge/procedures/worktree-workflow.md
@@ -1,6 +1,6 @@
-# Git Worktree Workflow (Beta - Imperfect System)
+# Git Worktree Workflow
 
-We know very little about worktrees. This is an admittedly imperfect system to be improved upon later per Versioning Mindset.
+Suppose you need to work on multiple tasks simultaneously with complete code isolation between Claude Code instances. Git worktrees provide this isolation.
 
 1. `mkdir -p ~/ppv/pillars/dotfiles/worktrees`
 2. `cd ~/ppv/pillars/dotfiles && git worktree add ~/ppv/pillars/dotfiles/worktrees/issue-<NUMBER> -b feature/<description>-<NUMBER>`

--- a/knowledge/procedures/worktree-workflow.md
+++ b/knowledge/procedures/worktree-workflow.md
@@ -2,10 +2,10 @@
 
 We know very little about worktrees. This is an admittedly imperfect system to be improved upon later per Versioning Mindset.
 
-1. `mkdir -p ~/ppv/pillars/worktrees/dotfiles`
-2. `cd ~/ppv/pillars/dotfiles && git worktree add ~/ppv/pillars/worktrees/dotfiles/issue-<NUMBER> -b feature/<description>-<NUMBER>`
-3. Work in worktree: `cd ~/ppv/pillars/worktrees/dotfiles/issue-<NUMBER>`
+1. `mkdir -p ~/ppv/pillars/dotfiles/worktrees`
+2. `cd ~/ppv/pillars/dotfiles && git worktree add ~/ppv/pillars/dotfiles/worktrees/issue-<NUMBER> -b feature/<description>-<NUMBER>`
+3. Work in worktree: `cd ~/ppv/pillars/dotfiles/worktrees/issue-<NUMBER>`
 4. Commit, push, create PR as normal
-5. Cleanup: `cd ~/ppv/pillars/dotfiles && git worktree remove ~/ppv/pillars/worktrees/dotfiles/issue-<NUMBER> --force`
+5. Cleanup: `cd ~/ppv/pillars/dotfiles && git worktree remove ~/ppv/pillars/dotfiles/worktrees/issue-<NUMBER> --force`
 
 **Quirks found**: Must use full paths, cleanup requires returning to main repo directory.

--- a/knowledge/procedures/worktree-workflow.md
+++ b/knowledge/procedures/worktree-workflow.md
@@ -9,5 +9,3 @@ Suppose you need to work on multiple tasks simultaneously with complete code iso
 3. Work in worktree: `cd ~/ppv/pillars/dotfiles/worktrees/<worktree-name>`
 4. Commit, push, create PR as normal
 5. Cleanup: `cd ~/ppv/pillars/dotfiles && git worktree remove ~/ppv/pillars/dotfiles/worktrees/<worktree-name> --force`
-
-**Quirks found**: Must use full paths, cleanup requires returning to main repo directory.

--- a/knowledge/procedures/worktree-workflow.md
+++ b/knowledge/procedures/worktree-workflow.md
@@ -3,7 +3,9 @@
 Suppose you need to work on multiple tasks simultaneously with complete code isolation between Claude Code instances. Git worktrees provide this isolation.
 
 1. `mkdir -p ~/ppv/pillars/dotfiles/worktrees`
-2. `cd ~/ppv/pillars/dotfiles && git worktree add ~/ppv/pillars/dotfiles/worktrees/issue-<NUMBER> -b feature/<description>-<NUMBER>`
+2. Create worktree:
+   - **New branch**: `git worktree add ~/ppv/pillars/dotfiles/worktrees/issue-<NUMBER> -b <type>/<description>-<NUMBER>`
+   - **Existing branch**: `git worktree add ~/ppv/pillars/dotfiles/worktrees/issue-<NUMBER> <existing-branch-name>`
 3. Work in worktree: `cd ~/ppv/pillars/dotfiles/worktrees/issue-<NUMBER>`
 4. Commit, push, create PR as normal
 5. Cleanup: `cd ~/ppv/pillars/dotfiles && git worktree remove ~/ppv/pillars/dotfiles/worktrees/issue-<NUMBER> --force`

--- a/knowledge/procedures/worktree-workflow.md
+++ b/knowledge/procedures/worktree-workflow.md
@@ -4,10 +4,10 @@ Suppose you need to work on multiple tasks simultaneously with complete code iso
 
 1. `mkdir -p ~/ppv/pillars/dotfiles/worktrees`
 2. Create worktree:
-   - **New branch**: `git worktree add ~/ppv/pillars/dotfiles/worktrees/issue-<NUMBER> -b <type>/<description>-<NUMBER>`
-   - **Existing branch**: `git worktree add ~/ppv/pillars/dotfiles/worktrees/issue-<NUMBER> <existing-branch-name>`
-3. Work in worktree: `cd ~/ppv/pillars/dotfiles/worktrees/issue-<NUMBER>`
+   - **New branch**: `git worktree add ~/ppv/pillars/dotfiles/worktrees/<worktree-name> -b <branch-name>`
+   - **Existing branch**: `git worktree add ~/ppv/pillars/dotfiles/worktrees/<worktree-name> <branch-name>`
+3. Work in worktree: `cd ~/ppv/pillars/dotfiles/worktrees/<worktree-name>`
 4. Commit, push, create PR as normal
-5. Cleanup: `cd ~/ppv/pillars/dotfiles && git worktree remove ~/ppv/pillars/dotfiles/worktrees/issue-<NUMBER> --force`
+5. Cleanup: `cd ~/ppv/pillars/dotfiles && git worktree remove ~/ppv/pillars/dotfiles/worktrees/<worktree-name> --force`
 
 **Quirks found**: Must use full paths, cleanup requires returning to main repo directory.


### PR DESCRIPTION
## Summary
- Corrects worktree directory structure from `~/ppv/pillars/worktrees/dotfiles/` to `~/ppv/pillars/dotfiles/worktrees/`
- Keeps worktrees as a subdirectory within the dotfiles repository

## Why this change?
The previous path structure placed worktrees outside the dotfiles directory, which is less logical and harder to manage. This change:
- Keeps all dotfiles-related content within the dotfiles directory
- Makes cleanup easier (everything is contained)
- Follows common git worktree patterns where worktrees are subdirectories of the main repo