### PR TITLE
fix[mcp]: correct git command execution in worktree and push tools

### DIFF
--- a/mcp/servers/git-mcp-server/src/mcp_server_git/server.py
+++ b/mcp/servers/git-mcp-server/src/mcp_server_git/server.py
@@ -231,20 +231,20 @@ def git_worktree_list(repo: git.Repo) -> str:
 
 def git_push(repo: git.Repo, remote: str = "origin", branch: str | None = None, set_upstream: bool = False, force: bool = False) -> str:
     """Push changes to remote repository"""
-    args = [remote]
-    
-    if set_upstream:
-        args = ["-u", remote]
-    
-    if branch:
-        args.append(branch)
-    else:
-        args.append(repo.active_branch.name)
+    # Build command as a list
+    cmd_parts = []
     
     if force:
-        args.insert(0, "--force")
+        cmd_parts.append("--force")
     
-    output = repo.git.push(*args)
+    if set_upstream:
+        cmd_parts.extend(["-u", remote, branch or repo.active_branch.name])
+    else:
+        cmd_parts.extend([remote, branch or repo.active_branch.name])
+    
+    # Use the git command directly through repo.git
+    output = repo.git.push(*cmd_parts)
+    
     return f"Pushed to {remote}" + (f" (tracking {remote}/{branch or repo.active_branch.name})" if set_upstream else "")
 
 def git_remote(repo: git.Repo, action: str, name: str | None = None, url: str | None = None) -> str:

--- a/mcp/servers/git-mcp-server/src/mcp_server_git/server.py
+++ b/mcp/servers/git-mcp-server/src/mcp_server_git/server.py
@@ -178,23 +178,22 @@ def git_show(repo: git.Repo, revision: str) -> str:
 
 def git_worktree_add(repo: git.Repo, worktree_path: str, branch_name: str | None = None, create_branch: bool = False) -> str:
     """Add a new worktree"""
-    args = ["worktree", "add", worktree_path]
-    
     if create_branch and branch_name:
-        args.extend(["-b", branch_name])
+        output = repo.git.worktree("add", "-b", branch_name, worktree_path)
     elif branch_name:
-        args.append(branch_name)
+        output = repo.git.worktree("add", worktree_path, branch_name)
+    else:
+        output = repo.git.worktree("add", worktree_path)
     
-    output = repo.git.execute(args)
     return f"Worktree added at {worktree_path}" + (f" on new branch {branch_name}" if create_branch else "")
 
 def git_worktree_remove(repo: git.Repo, worktree_path: str, force: bool = False) -> str:
     """Remove a worktree"""
-    args = ["worktree", "remove", worktree_path]
     if force:
-        args.append("--force")
+        output = repo.git.worktree("remove", "--force", worktree_path)
+    else:
+        output = repo.git.worktree("remove", worktree_path)
     
-    output = repo.git.execute(args)
     return f"Worktree at {worktree_path} removed"
 
 def git_worktree_list(repo: git.Repo) -> str:
@@ -232,18 +231,20 @@ def git_worktree_list(repo: git.Repo) -> str:
 
 def git_push(repo: git.Repo, remote: str = "origin", branch: str | None = None, set_upstream: bool = False, force: bool = False) -> str:
     """Push changes to remote repository"""
-    args = ["push", remote]
+    args = [remote]
+    
+    if set_upstream:
+        args = ["-u", remote]
     
     if branch:
         args.append(branch)
-    
-    if set_upstream:
-        args.extend(["-u", remote, branch or repo.active_branch.name])
+    else:
+        args.append(repo.active_branch.name)
     
     if force:
-        args.append("--force")
+        args.insert(0, "--force")
     
-    output = repo.git.execute(args)
+    output = repo.git.push(*args)
     return f"Pushed to {remote}" + (f" (tracking {remote}/{branch or repo.active_branch.name})" if set_upstream else "")
 
 def git_remote(repo: git.Repo, action: str, name: str | None = None, url: str | None = None) -> str:


### PR DESCRIPTION
## Summary
- Fixed git_worktree_add, git_worktree_remove, and git_push to use correct GitPython API methods
- Resolved FileNotFoundError issues when executing git commands
- Improved argument handling for git push with upstream and force options

## Changes
- `git_worktree_add`: Now uses `repo.git.worktree()` instead of `repo.git.execute()`
- `git_worktree_remove`: Now uses `repo.git.worktree()` for consistent API usage
- `git_push`: Rebuilt command argument construction for proper flag ordering

## Test plan
- [x] Test git_worktree_list - working
- [ ] Test git_worktree_add with new branch creation
- [ ] Test git_worktree_remove 
- [ ] Test git_push with upstream tracking
- [x] Verify tool call logging is working for all new tools

Principle: tracer-bullets

🤖 Generated with [Claude Code](https://claude.ai/code)