### PR TITLE
feat[mcp]: add command chaining tools to git MCP server

### DIFF
--- a/docs/git-mcp-chaining-logging.md
+++ b/docs/git-mcp-chaining-logging.md
@@ -1,5 +1,7 @@
 # Git MCP Command Chaining and Logging Behavior
 
+This document explains how the [MCP tool-level logging framework](../mcp/README.md#adding-tool-level-logging-to-mcp-servers) handles chained git commands.
+
 ## How Logging Works with Chained Commands
 
 ### git_stage_commit_push
@@ -38,3 +40,7 @@ git_stage_commit_push | STATUS: SUCCESS | Stage-commit-push completed
 ```
 
 This design follows the principle of abstraction - log at the level of user intent, not implementation details.
+
+## Log Location
+
+All tool calls are logged to `~/mcp-tool-calls.log` as configured in the [logging framework](../mcp/README.md#tool-level-logging-guidelines). Use `check-mcp-logs -t` to view recent tool calls.

--- a/docs/git-mcp-chaining-logging.md
+++ b/docs/git-mcp-chaining-logging.md
@@ -1,0 +1,40 @@
+# Git MCP Command Chaining and Logging Behavior
+
+## How Logging Works with Chained Commands
+
+### git_stage_commit_push
+When you use `git_stage_commit_push`, it creates **ONE log entry** for the entire operation:
+- Tool name: `git_stage_commit_push`
+- Details: "Stage-commit-push completed"
+- The individual add/commit/push operations are NOT logged separately
+- This provides a cleaner log focused on the high-level operation
+
+### git_batch
+When you use `git_batch`, it also creates **ONE log entry** for the batch:
+- Tool name: `git_batch`
+- Details: "Batch executed: X/Y succeeded"
+- Individual commands within the batch are NOT logged separately
+- The formatted results show success/failure for each command in the response
+
+## Why This Design?
+
+1. **Cleaner Logs**: Avoids cluttering logs with implementation details
+2. **Atomic Operations**: Treats chained operations as single logical units
+3. **Better Analytics**: Easier to track usage patterns of workflows vs individual commands
+4. **Performance**: Reduces log write operations
+
+## Example Log Output
+
+Instead of:
+```
+git_add | STATUS: SUCCESS | Added files: ["file.py"]
+git_commit | STATUS: SUCCESS | Committed: abc123
+git_push | STATUS: SUCCESS | Pushed main to origin
+```
+
+You get:
+```
+git_stage_commit_push | STATUS: SUCCESS | Stage-commit-push completed
+```
+
+This design follows the principle of abstraction - log at the level of user intent, not implementation details.

--- a/knowledge/procedures/git-workflow.md
+++ b/knowledge/procedures/git-workflow.md
@@ -1,5 +1,18 @@
 # Git Workflow Rules
 
+## MCP Git Tools Usage
+**IMPORTANT**: Use the git MCP server tools instead of bash commands:
+- `mcp__git__git_status` - Check repository status
+- `mcp__git__git_add` - Stage files
+- `mcp__git__git_commit` - Commit changes
+- `mcp__git__git_create_branch` - Create new branches
+- `mcp__git__git_checkout` - Switch branches
+- `mcp__git__git_push` - Push with upstream tracking
+- `mcp__git__git_log` - View commit history
+- `mcp__git__git_diff*` - View changes
+
+These tools provide structured logging and better error handling than raw bash commands.
+
 ## Commit Standards
 - Always use conventional commit syntax: `<type>[scope]: description` (scope optional but encouraged; use separate `-m` for trailers)
 - Good scope choices add context about what component is being modified (e.g., api, ui, auth, config, docs)

--- a/knowledge/procedures/git-workflow.md
+++ b/knowledge/procedures/git-workflow.md
@@ -1,17 +1,7 @@
 # Git Workflow Rules
 
 ## MCP Git Tools Usage
-**IMPORTANT**: Use the git MCP server tools instead of bash commands:
-- `mcp__git__git_status` - Check repository status
-- `mcp__git__git_add` - Stage files
-- `mcp__git__git_commit` - Commit changes
-- `mcp__git__git_create_branch` - Create new branches
-- `mcp__git__git_checkout` - Switch branches
-- `mcp__git__git_push` - Push with upstream tracking
-- `mcp__git__git_log` - View commit history
-- `mcp__git__git_diff*` - View changes
-
-These tools provide structured logging and better error handling than raw bash commands.
+**IMPORTANT**: Use `mcp__git__*` tools instead of bash commands.
 
 ## Commit Standards
 - Always use conventional commit syntax: `<type>[scope]: description` (scope optional but encouraged; use separate `-m` for trailers)

--- a/knowledge/procedures/git-workflow.md
+++ b/knowledge/procedures/git-workflow.md
@@ -2,6 +2,8 @@
 
 ## MCP Git Tools Usage
 **IMPORTANT**: Use `mcp__git__*` tools instead of bash commands.
+- **Time Saver**: Use `mcp__git__git_stage_commit_push` for the common add→commit→push workflow
+- **Complex Workflows**: Use `mcp__git__git_batch` to chain multiple git operations
 
 ## Commit Standards
 - Always use conventional commit syntax: `<type>[scope]: description` (scope optional but encouraged; use separate `-m` for trailers)

--- a/knowledge/procedures/git-workflow.md
+++ b/knowledge/procedures/git-workflow.md
@@ -14,6 +14,7 @@
 - If there's a related issue, suffix with issue number: `type/description-123` (e.g., `feature/add-authentication-512`)
 - Use short-lived branches for complex tasks
 - Keep changes small and frequent
+- Never push directly to main - always use feature branches
 
 ## Common Errors to Avoid
 - Don't thank self when closing your own PRs

--- a/knowledge/procedures/worktree-workflow.md
+++ b/knowledge/procedures/worktree-workflow.md
@@ -2,11 +2,13 @@
 
 Suppose you need to work on multiple tasks simultaneously with complete code isolation between Claude Code instances. Git worktrees provide this isolation.
 
+**IMPORTANT**: Use git MCP tools instead of bash commands when possible. The `repo_path` parameter acts like `git -C` for worktrees.
+
 1. `mkdir -p ~/ppv/pillars/dotfiles/worktrees`
 2. Create worktree:
-   - **New branch**: `git worktree add ~/ppv/pillars/dotfiles/worktrees/<worktree-name> -b <branch-name>`
-   - **Existing branch**: `git worktree add ~/ppv/pillars/dotfiles/worktrees/<worktree-name> <branch-name>`
-3. Work in worktree: `cd ~/ppv/pillars/dotfiles/worktrees/<worktree-name>`
+   - **New branch**: Use `mcp__git__git_worktree_add` with `create_branch: true`
+   - **Existing branch**: Use `mcp__git__git_worktree_add` with branch name
+3. Work in worktree: Pass worktree path as `repo_path` to MCP tools (no `cd` needed!)
 4. Commit, push, create PR as normal
 5. Ask for any pr feedback and address if any
-6. Cleanup: `cd ~/ppv/pillars/dotfiles && git worktree remove ~/ppv/pillars/dotfiles/worktrees/<worktree-name> --force`
+6. Cleanup: Use `mcp__git__git_worktree_remove` with `force: true`

--- a/mcp/servers/git-mcp-server/src/mcp_server_git/server.py
+++ b/mcp/servers/git-mcp-server/src/mcp_server_git/server.py
@@ -245,7 +245,7 @@ def git_push(repo: git.Repo, remote: str = "origin", branch: str | None = None, 
     # Use the git command directly through repo.git
     output = repo.git.push(*cmd_parts)
     
-    return f"Pushed to {remote}" + (f" (tracking {remote}/{branch or repo.active_branch.name})" if set_upstream else "")
+    return f"Pushed {branch or repo.active_branch.name} to {remote}" + (f" (tracking)" if set_upstream else "")
 
 def git_remote(repo: git.Repo, action: str, name: str | None = None, url: str | None = None) -> str:
     """Manage remote repositories"""


### PR DESCRIPTION
## Summary
- Added `git_stage_commit_push` for the common add→commit→push workflow
- Added `git_batch` for arbitrary command sequences  
- Updated documentation to encourage using these time-saving tools

## Key Features

### git_stage_commit_push
- Combines add, commit, and push in one operation
- Returns clean output: `Staged X file(s) → Committed: sha → Pushed branch to remote`
- Creates single log entry for the entire operation

### git_batch
- Execute multiple git commands in sequence
- Stops on first error
- Returns formatted results with ✓/✗ indicators

## Documentation
- Created git-mcp-chaining-logging.md explaining logging behavior
- Updated git-workflow.md to highlight these time-saving tools
- Linked to MCP logging framework documentation

## Test Results
Successfully tested `git_stage_commit_push` - it created one log entry and completed the full workflow efficiently.

Principle: developer-experience

🤖 Generated with [Claude Code](https://claude.ai/code)