### PR TITLE
refactor[mcp]: simplify git MCP to primitives + batch chaining

### DIFF
--- a/docs/git-mcp-chaining-logging.md
+++ b/docs/git-mcp-chaining-logging.md
@@ -2,17 +2,9 @@
 
 This document explains how the [MCP tool-level logging framework](../mcp/README.md#adding-tool-level-logging-to-mcp-servers) handles chained git commands.
 
-## How Logging Works with Chained Commands
+## How Logging Works with git_batch
 
-### git_stage_commit_push
-When you use `git_stage_commit_push`, it creates **ONE log entry** for the entire operation:
-- Tool name: `git_stage_commit_push`
-- Details: "Stage-commit-push completed"
-- The individual add/commit/push operations are NOT logged separately
-- This provides a cleaner log focused on the high-level operation
-
-### git_batch
-When you use `git_batch`, it also creates **ONE log entry** for the batch:
+When you use `git_batch`, it creates **ONE log entry** for the entire batch operation:
 - Tool name: `git_batch`
 - Details: "Batch executed: X/Y succeeded"
 - Individual commands within the batch are NOT logged separately
@@ -25,18 +17,31 @@ When you use `git_batch`, it also creates **ONE log entry** for the batch:
 3. **Better Analytics**: Easier to track usage patterns of workflows vs individual commands
 4. **Performance**: Reduces log write operations
 
+## Example Usage
+
+```python
+mcp__git__git_batch(
+  repo_path="/path/to/repo",
+  commands=[
+    {"tool": "git_add", "args": {"files": ["*.py"]}},
+    {"tool": "git_commit", "args": {"message": "feat: add feature"}},
+    {"tool": "git_push", "args": {"set_upstream": true}}
+  ]
+)
+```
+
 ## Example Log Output
 
-Instead of:
+Instead of three separate log entries:
 ```
 git_add | STATUS: SUCCESS | Added files: ["file.py"]
 git_commit | STATUS: SUCCESS | Committed: abc123
 git_push | STATUS: SUCCESS | Pushed main to origin
 ```
 
-You get:
+You get one consolidated entry:
 ```
-git_stage_commit_push | STATUS: SUCCESS | Stage-commit-push completed
+git_batch | STATUS: SUCCESS | Batch executed: 3/3 succeeded
 ```
 
 This design follows the principle of abstraction - log at the level of user intent, not implementation details.

--- a/knowledge/procedures/git-workflow.md
+++ b/knowledge/procedures/git-workflow.md
@@ -2,8 +2,7 @@
 
 ## MCP Git Tools Usage
 **IMPORTANT**: Use `mcp__git__*` tools instead of bash commands.
-- **Time Saver**: Use `mcp__git__git_stage_commit_push` for the common add→commit→push workflow
-- **Complex Workflows**: Use `mcp__git__git_batch` to chain multiple git operations
+- **Chain Commands**: Use `mcp__git__git_batch` to combine multiple git operations efficiently
 
 ## Commit Standards
 - Always use conventional commit syntax: `<type>[scope]: description` (scope optional but encouraged; use separate `-m` for trailers)


### PR DESCRIPTION
## Summary
Simplified git MCP server by removing prescriptive command chains in favor of primitives + generic batch tool.

## Changes
- ❌ Removed `GitStageCommitPush` class and implementation
- ❌ Removed `STAGE_COMMIT_PUSH` from `GitTools` enum  
- ❌ Removed from `list_tools()` and `call_tool()` handlers
- 📝 Updated documentation to focus on `git_batch`
- 📝 Simplified git-workflow.md to emphasize chaining
- 📝 Updated chaining docs to remove stage_commit_push references

## Rationale
Following principles of **invent-and-simplify** and **subtraction-creates-value**:
- LLMs are sophisticated enough to decide what to chain
- Prescriptive chains add complexity without necessity
- The `git_batch` tool provides all the flexibility needed

## Test Results
- ✅ Python syntax check passed
- ✅ Successfully used `git_batch` to chain add→commit→push for this PR

## Post-Implementation Note
During implementation, I misunderstood the intent when told to "close" the issue - I initially tried to close it without implementation. This highlights the importance of clarity in instructions. The actual implementation was straightforward once the intent was clear.

Closes #531

Principle: subtraction-creates-value
Principle: invent-and-simplify

🤖 Generated with [Claude Code](https://claude.ai/code)