### PR TITLE
fix/close issue retro prominence 544

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,21 @@ This repository automatically configures global context for multiple AI coding a
 
 All context is sourced from the `knowledge/` directory and automatically configured by the setup script. See [AI Provider Agnostic Context](docs/ai-provider-agnostic-context.md) for details.
 
+### Slash Commands
+
+Custom slash commands for Claude Code are defined as templates in `.claude/command-templates/`:
+
+- **Templates**: Stored in `.claude/command-templates/` (e.g., `close-issue.md`, `retro.md`)
+- **Generation**: Run `utils/generate-claude-commands.sh` to process templates
+- **Output**: Generated commands appear in `~/.claude/commands/`
+- **Injection**: Templates use `{{ INJECT:path }}` to pull content from `knowledge/` directory
+- **Variables**: Templates support variables like `{{ ISSUE_NUMBER }}` for dynamic content
+
+To modify a slash command:
+1. Edit the template in `.claude/command-templates/`
+2. Run `utils/generate-claude-commands.sh` (automatically run by `source setup.sh`)
+3. The updated command is now available in Claude Code
+
 ## Secret Management
 
 Sensitive information like API tokens are stored in `~/.bash_secrets` (not tracked in git).


### PR DESCRIPTION
- **feat[mcp]: add git_merge tool to MCP server**
  - Add GitMerge model with support for branch, message, strategy (ff-only, no-ff, squash), and abort
  - Implement git_merge function with comprehensive merge strategy support
  - Handle merge conflicts gracefully with clear error messages
  - Add tool registration and case handling in server
  - Include git_merge in batch command support
  
  Closes #537
  
  Principle: developer-experience

- **fix[commands]: make post-PR mini retro more prominent in close-issue workflow**
  - Move post-PR retro to top-level section with REQUIRED label
  - Add clear trigger condition: "If you created a pull request, you MUST complete this step"
  - Add reminder to include retro in todo list when creating PR
  - Renumber cleanup step to maintain logical flow
  
  Closes #544
  
  Principle: systems-stewardship

- **docs: add slash commands documentation to README**
  - Document where slash command templates live (.claude/command-templates/)
  - Explain the generation process and INJECT system
  - Provide clear steps for modifying slash commands
  - Capture tribal knowledge to prevent future search-and-discovery cycles
  
  This addresses the retro finding that agents had to search far and wide to find where slash commands were defined.
  
  Principle: systems-stewardship