### PR TITLE
feat[mcp]: add git_rebase tool to MCP server

### DIFF
--- a/mcp/servers/git-mcp-server/README.md
+++ b/mcp/servers/git-mcp-server/README.md
@@ -28,6 +28,35 @@ This is a customized version of the git-mcp-server that has been migrated into t
 | `git_create_branch` | Creates new branch | ✅ |
 | `git_checkout` | Switches branches | ✅ |
 | `git_show` | Shows commit contents | ✅ |
+| `git_worktree_add` | Add a new worktree for parallel development | ✅ |
+| `git_worktree_remove` | Remove a worktree | ✅ |
+| `git_worktree_list` | List all worktrees | ✅ |
+| `git_push` | Push commits to remote repository | ✅ |
+| `git_pull` | Pull changes from remote repository | ✅ |
+| `git_merge` | Merge branches with support for different strategies | ✅ |
+| `git_remote` | Manage remote repositories | ✅ |
+| `git_batch` | Execute multiple git commands in sequence | ✅ |
+| `git_rebase` | Rebase current branch onto another branch | ✅ |
+
+### Git Rebase Tool
+
+The `git_rebase` tool supports maintaining linear history and reorganizing commits:
+
+**Parameters:**
+- `repo_path`: Path to the git repository (required)
+- `onto`: Branch to rebase onto (required for new rebase)
+- `interactive`: Enable interactive rebase (limited support)
+- `continue_rebase`: Continue an in-progress rebase
+- `skip`: Skip current commit during rebase
+- `abort`: Abort an in-progress rebase
+
+**Usage Examples:**
+- Start rebase: `{"repo_path": ".", "onto": "main"}`
+- Continue after resolving conflicts: `{"repo_path": ".", "continue_rebase": true}`
+- Skip problematic commit: `{"repo_path": ".", "skip": true}`
+- Abort rebase: `{"repo_path": ".", "abort": true}`
+
+**Note:** Interactive rebase is not fully supported in MCP environment due to editor limitations.
 
 ## Logging Implementation
 

--- a/mcp/servers/git-mcp-server/git_mcp_server.py
+++ b/mcp/servers/git-mcp-server/git_mcp_server.py
@@ -1,1 +1,1 @@
-/home/linuxmint-lp/ppv/pillars/dotfiles/mcp/servers/git-mcp-server/src/mcp_server_git/__main__.py
+src/mcp_server_git/__main__.py


### PR DESCRIPTION
## Summary
- Adds `git_rebase` tool to the MCP server for maintaining linear history and reorganizing commits
- Supports standard rebase operations including --continue, --skip, and --abort
- Enables cleaner git history management through MCP tools

## Changes
- Added `GitRebase` model with parameters for onto branch, interactive mode, and control operations
- Implemented `git_rebase()` function with comprehensive error handling and conflict detection
- Registered tool in the MCP server's tool list and call handler
- Added support for git_rebase in batch operations
- Updated README with tool documentation and usage examples
- Fixed git_mcp_server.py symlink to use relative path for better worktree support

## Test plan
- [x] Python syntax validation passed
- [x] MCP protocol test confirmed git_rebase tool is properly registered
- [x] Setup script successfully installs the updated server

Closes #538

🤖 Generated with [Claude Code](https://claude.ai/code)