### PR TITLE
chore[mcp]: add git server location quick reference

### DIFF
--- a/knowledge/principles/README.md
+++ b/knowledge/principles/README.md
@@ -2,7 +2,7 @@
 
 Foundational truths that guide development across all projects.
 
-- `do-dont-explain.md` - Act like an agent, not a chatbot (with retro exception)
+- `do-dont-explain.md` - Act like an agent, not a chatbot
 - `invent-and-simplify.md` - Constant reinvention and simplifying assumptions
 - `subtraction-creates-value.md` - Strategic removal often creates more value than addition
 - `tracer-bullets.md` - Rapid feedback-driven development with ground truth

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -13,6 +13,10 @@ Current servers from this source:
 
 This standardized approach makes it easy to add more MCP servers in the future from this abundant collection.
 
+## Server Locations Quick Reference
+
+- Git MCP Server: `mcp/servers/git-mcp-server/src/mcp_server_git/server.py`
+
 ## Available MCP Integrations
 
 | Integration | Description | Authentication Method | Installation Method | Documentation | Tool-Level Logging | Init-Level Logging |


### PR DESCRIPTION
## Summary
- Add quick reference section in MCP README for server implementation locations
- Remove outdated retro exception reference from principles index

## Context
During our retro, we identified that discovery time for finding the git MCP server implementation was longer than necessary. This small addition will save future discovery time.

## Changes
- Added "Server Locations Quick Reference" section to `mcp/README.md`
- Listed git MCP server location: `mcp/servers/git-mcp-server/src/mcp_server_git/server.py`
- Cleaned up outdated reference to retro exception in principles index

Principle: systems-stewardship

🤖 Generated with [Claude Code](https://claude.ai/code)