### PR TITLE
fix[git-mcp]: remove duplicate code causing syntax error

### DIFF
--- a/mcp/servers/git-mcp-server/src/mcp_server_git/server.py
+++ b/mcp/servers/git-mcp-server/src/mcp_server_git/server.py
@@ -610,17 +610,8 @@ def git_stash_pop(repo: git.Repo, stash_ref: str | None = None, index: bool = Fa
             
         output = repo.git.execute(cmd_parts)
         
-output = repo.git.execute(cmd_parts)
-        
         stash = stash_ref or "stash@{0}"
         return output if output else f"Successfully applied and removed {stash}"
-            
-    except git.GitCommandError as e:
-        if "CONFLICT" in str(e):
-            return output
-        else:
-            stash = stash_ref or "stash@{0}"
-            return f"Successfully applied and removed {stash}"
             
     except git.GitCommandError as e:
         if "CONFLICT" in str(e):


### PR DESCRIPTION
Fixed SyntaxError at line 613 in git MCP server by removing duplicate execute() call and duplicate except blocks in git_stash_pop function.

The server was failing to start with:
```
SyntaxError: expected 'except' or 'finally' block
```

This was caused by duplicate code that appeared to be a merge/edit error.