### PR TITLE
fix: make setup.sh and utility scripts compatible with zsh

### DIFF
--- a/.claude/command-templates/close-issue.md
+++ b/.claude/command-templates/close-issue.md
@@ -1,7 +1,6 @@
 Close GitHub issue #{{ ISSUE_NUMBER }} - determine if it needs implementation or just closure.
 
 ## Core Principles
-{{ INJECT:principles/do-dont-explain.md }}
 {{ INJECT:principles/tracer-bullets.md }}
 
 ## Step 1: Analyze the Issue

--- a/utils/clipboard.sh
+++ b/utils/clipboard.sh
@@ -43,7 +43,7 @@ clipboard_paste() {
 }
 
 # If script is executed directly, provide command-line interface
-if [[ -n "${BASH_SOURCE[0]}" && "${BASH_SOURCE[0]}" == "${0}" ]] || [[ -z "${BASH_SOURCE[0]}" && "$0" != "bash" && "$0" != "zsh" && "$0" != "-bash" && "$0" != "-zsh" ]]; then
+if [[ -n "${BASH_SOURCE[0]:-}" && "${BASH_SOURCE[0]:-}" == "${0}" ]] || [[ -z "${BASH_SOURCE[0]:-}" && "$0" != "bash" && "$0" != "zsh" && "$0" != "-bash" && "$0" != "-zsh" ]]; then
     case "${1:-}" in
         "copy"|"c")
             clipboard_copy

--- a/utils/clipboard.sh
+++ b/utils/clipboard.sh
@@ -43,7 +43,7 @@ clipboard_paste() {
 }
 
 # If script is executed directly, provide command-line interface
-if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+if [[ -n "${BASH_SOURCE[0]}" && "${BASH_SOURCE[0]}" == "${0}" ]] || [[ -z "${BASH_SOURCE[0]}" && "$0" != "bash" && "$0" != "zsh" && "$0" != "-bash" && "$0" != "-zsh" ]]; then
     case "${1:-}" in
         "copy"|"c")
             clipboard_copy

--- a/utils/clipboard.sh
+++ b/utils/clipboard.sh
@@ -43,7 +43,8 @@ clipboard_paste() {
 }
 
 # If script is executed directly, provide command-line interface
-if [[ -n "${BASH_SOURCE[0]:-}" && "${BASH_SOURCE[0]:-}" == "${0}" ]] || [[ -z "${BASH_SOURCE[0]:-}" && "$0" != "bash" && "$0" != "zsh" && "$0" != "-bash" && "$0" != "-zsh" ]]; then
+# Skip if being sourced or if $0 is a shell name
+if [[ "${BASH_SOURCE[0]:-}" == "${0}" ]] && [[ "$0" != *"/bash" ]] && [[ "$0" != *"/zsh" ]] && [[ "$0" != *"/sh" ]]; then
     case "${1:-}" in
         "copy"|"c")
             clipboard_copy

--- a/utils/install-claude-code.sh
+++ b/utils/install-claude-code.sh
@@ -172,6 +172,6 @@ configure_claude_code_settings() {
 }
 
 # Run setup if script is executed directly
-if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+if [[ -n "${BASH_SOURCE[0]}" && "${BASH_SOURCE[0]}" == "${0}" ]] || [[ -z "${BASH_SOURCE[0]}" && "$0" != "bash" && "$0" != "zsh" && "$0" != "-bash" && "$0" != "-zsh" ]]; then
     setup_claude_code
 fi

--- a/utils/install-claude-code.sh
+++ b/utils/install-claude-code.sh
@@ -172,6 +172,6 @@ configure_claude_code_settings() {
 }
 
 # Run setup if script is executed directly
-if [[ -n "${BASH_SOURCE[0]}" && "${BASH_SOURCE[0]}" == "${0}" ]] || [[ -z "${BASH_SOURCE[0]}" && "$0" != "bash" && "$0" != "zsh" && "$0" != "-bash" && "$0" != "-zsh" ]]; then
+if [[ -n "${BASH_SOURCE[0]:-}" && "${BASH_SOURCE[0]:-}" == "${0}" ]] || [[ -z "${BASH_SOURCE[0]:-}" && "$0" != "bash" && "$0" != "zsh" && "$0" != "-bash" && "$0" != "-zsh" ]]; then
     setup_claude_code
 fi

--- a/utils/install-gh-cli.sh
+++ b/utils/install-gh-cli.sh
@@ -2,7 +2,7 @@
 # GitHub CLI Installation and Update Utility
 
 # Source common logging functions
-if [[ -n "${BASH_SOURCE[0]}" ]]; then
+if [[ -n "${BASH_SOURCE[0]:-}" ]]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 else
     SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/utils/install-gh-cli.sh
+++ b/utils/install-gh-cli.sh
@@ -2,7 +2,11 @@
 # GitHub CLI Installation and Update Utility
 
 # Source common logging functions
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -n "${BASH_SOURCE[0]}" ]]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+else
+    SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+fi
 source "${SCRIPT_DIR}/logging.sh"
 
 install_or_update_gh_cli() {
@@ -122,6 +126,6 @@ setup_gh_cli() {
 }
 
 # Main execution
-if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+if [[ -n "${BASH_SOURCE[0]}" && "${BASH_SOURCE[0]}" == "${0}" ]] || [[ -z "${BASH_SOURCE[0]}" && "$0" != "bash" && "$0" != "zsh" && "$0" != "-bash" && "$0" != "-zsh" ]]; then
   setup_gh_cli
 fi

--- a/utils/install-gh-cli.sh
+++ b/utils/install-gh-cli.sh
@@ -126,6 +126,6 @@ setup_gh_cli() {
 }
 
 # Main execution
-if [[ -n "${BASH_SOURCE[0]}" && "${BASH_SOURCE[0]}" == "${0}" ]] || [[ -z "${BASH_SOURCE[0]}" && "$0" != "bash" && "$0" != "zsh" && "$0" != "-bash" && "$0" != "-zsh" ]]; then
+if [[ -n "${BASH_SOURCE[0]:-}" && "${BASH_SOURCE[0]:-}" == "${0}" ]] || [[ -z "${BASH_SOURCE[0]:-}" && "$0" != "bash" && "$0" != "zsh" && "$0" != "-bash" && "$0" != "-zsh" ]]; then
   setup_gh_cli
 fi

--- a/utils/install-neovim.sh
+++ b/utils/install-neovim.sh
@@ -3,7 +3,7 @@
 # Automated installation following the spilled coffee principle
 
 # Source common logging functions
-if [[ -n "${BASH_SOURCE[0]}" ]]; then
+if [[ -n "${BASH_SOURCE[0]:-}" ]]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 else
     SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/utils/install-neovim.sh
+++ b/utils/install-neovim.sh
@@ -3,7 +3,11 @@
 # Automated installation following the spilled coffee principle
 
 # Source common logging functions
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -n "${BASH_SOURCE[0]}" ]]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+else
+    SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+fi
 source "${SCRIPT_DIR}/logging.sh"
 
 install_neovim() {

--- a/utils/install-tmux.sh
+++ b/utils/install-tmux.sh
@@ -123,6 +123,6 @@ install_or_update_tmux() {
 }
 
 # Main execution
-if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+if [[ -n "${BASH_SOURCE[0]}" && "${BASH_SOURCE[0]}" == "${0}" ]] || [[ -z "${BASH_SOURCE[0]}" && "$0" != "bash" && "$0" != "zsh" && "$0" != "-bash" && "$0" != "-zsh" ]]; then
     install_or_update_tmux
 fi

--- a/utils/install-tmux.sh
+++ b/utils/install-tmux.sh
@@ -123,6 +123,6 @@ install_or_update_tmux() {
 }
 
 # Main execution
-if [[ -n "${BASH_SOURCE[0]}" && "${BASH_SOURCE[0]}" == "${0}" ]] || [[ -z "${BASH_SOURCE[0]}" && "$0" != "bash" && "$0" != "zsh" && "$0" != "-bash" && "$0" != "-zsh" ]]; then
+if [[ -n "${BASH_SOURCE[0]:-}" && "${BASH_SOURCE[0]:-}" == "${0}" ]] || [[ -z "${BASH_SOURCE[0]:-}" && "$0" != "bash" && "$0" != "zsh" && "$0" != "-bash" && "$0" != "-zsh" ]]; then
     install_or_update_tmux
 fi


### PR DESCRIPTION
## Summary
- Fixed zsh compatibility issues that were causing setup.sh to crash on macOS
- Made all utility scripts work properly in both bash and zsh environments
- Removed reference to moratorium principle in Claude templates

## Changes

### BASH_SOURCE Compatibility
- Added checks for `BASH_SOURCE[0]` existence before using it
- Provided fallback to `$0` when BASH_SOURCE is not available (zsh)
- Used default parameter expansion (`${BASH_SOURCE[0]:-}`) to prevent "parameter not set" errors

### Fixed Scripts
- `utils/install-neovim.sh` - Fixed SCRIPT_DIR assignment
- `utils/install-gh-cli.sh` - Fixed SCRIPT_DIR assignment and main execution check
- `utils/install-claude-code.sh` - Fixed main execution check
- `utils/install-tmux.sh` - Fixed main execution check
- `utils/clipboard.sh` - Improved sourcing detection to prevent usage message during setup
- `.bash_aliases.d/llama.sh` - Fixed LD_LIBRARY_PATH parameter expansion

### Other Fixes
- Removed reference to `do-dont-explain.md` from close-issue.md template (principle is in moratorium)

## Test Results
- ✅ setup.sh now completes successfully without errors
- ✅ All scripts work in both bash and zsh environments
- ✅ No more "parameter not set" errors
- ✅ Clean output with success message at the end

Principle: systems-stewardship

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>