### PR TITLE
Fix zsh compdef error when sourcing setup.sh

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -127,7 +127,10 @@ parse_git_branch() {
 
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
-[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+# Only load bash completion in bash, not zsh (prevents compdef errors)
+if [ -n "$BASH_VERSION" ]; then
+    [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+fi
 
 export PYTHONPATH=$PYTHONPATH:$(pwd)
 

--- a/setup.sh
+++ b/setup.sh
@@ -362,7 +362,8 @@ if [ ! -d "$NVM_DIR" ]; then
       # shellcheck source=/dev/null
       . "$NVM_DIR/nvm.sh"
     fi
-    if [ -s "$NVM_DIR/bash_completion" ]; then
+    # Only load bash completion in bash shells to avoid zsh errors
+    if [ -n "$BASH_VERSION" ] && [ -s "$NVM_DIR/bash_completion" ]; then
       # shellcheck source=/dev/null
       . "$NVM_DIR/bash_completion"
     fi
@@ -382,7 +383,8 @@ else
       # shellcheck source=/dev/null
       . "$NVM_DIR/nvm.sh"
     fi
-    if [ -s "$NVM_DIR/bash_completion" ]; then
+    # Only load bash completion in bash shells to avoid zsh errors
+    if [ -n "$BASH_VERSION" ] && [ -s "$NVM_DIR/bash_completion" ]; then
       # shellcheck source=/dev/null
       . "$NVM_DIR/bash_completion"
     fi
@@ -417,7 +419,8 @@ else
         # shellcheck source=/dev/null
         . "$NVM_DIR/nvm.sh"
       fi
-      if [ -s "$NVM_DIR/bash_completion" ]; then
+      # Only load bash completion in bash shells to avoid zsh errors
+      if [ -n "$BASH_VERSION" ] && [ -s "$NVM_DIR/bash_completion" ]; then
         # shellcheck source=/dev/null
         . "$NVM_DIR/bash_completion"
       fi


### PR DESCRIPTION
## Summary
- Added shell type detection before loading NVM bash completions
- Prevents `compdef:153: _comps: assignment to invalid subscript range` error in zsh
- Only loads bash completion when `$BASH_VERSION` is set

## Problem
When sourcing `setup.sh` in a zsh shell, users encounter a compdef error because the script attempts to load bash-specific completions that are incompatible with zsh.

## Solution
Added a check for `$BASH_VERSION` before sourcing NVM's bash_completion file. This ensures bash completions are only loaded in bash shells, preventing the error in zsh while maintaining functionality in bash.

## Test Plan
- [x] Tested `source setup.sh` in zsh - no compdef errors
- [x] Tested `source setup.sh` in bash - works as before
- [x] Verified NVM still functions correctly in both shells

Closes #566

🤖 Generated with [Claude Code](https://claude.ai/code)