### PR TITLE
feat[screenshots]: add dedicated screenshots folder with macOS integration

### DIFF
--- a/.bash_aliases.d/macos.sh
+++ b/.bash_aliases.d/macos.sh
@@ -4,3 +4,18 @@
 if [[ "$OSTYPE" == "darwin"* ]] && command -v gtimeout &> /dev/null && ! command -v timeout &> /dev/null; then
     alias timeout='gtimeout'
 fi
+
+# Screenshot management aliases
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # Quick access to screenshots folder
+    alias screenshots='cd ~/ppv/pillars/dotfiles/screenshots'
+    
+    # List recent screenshots
+    alias recent-screenshots='ls -lat ~/ppv/pillars/dotfiles/screenshots | head -20'
+    
+    # Reset screenshots to default Desktop location
+    alias reset-screenshots='defaults write com.apple.screencapture location ~/Desktop/ && killall SystemUIServer'
+    
+    # Set screenshots back to dotfiles location
+    alias dotfiles-screenshots='defaults write com.apple.screencapture location ~/ppv/pillars/dotfiles/screenshots/ && killall SystemUIServer'
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,8 @@ build/
 # MCP client directories
 mcp/clients/
 .nrepl-port
+
+# Screenshots directory
+# Keep the directory structure but ignore all screenshot files
+screenshots/*
+!screenshots/.gitkeep

--- a/screenshots/.gitkeep
+++ b/screenshots/.gitkeep
@@ -1,0 +1,2 @@
+# This file ensures the screenshots directory is tracked by git
+# while all actual screenshot files are ignored

--- a/setup.sh
+++ b/setup.sh
@@ -550,6 +550,17 @@ if command -v docker &> /dev/null; then
   fi
 fi
 
+# macOS Screenshots Configuration
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  echo -e "${DIVIDER}"
+  if [[ -f "$DOT_DEN/utils/configure-macos-screenshots.sh" ]]; then
+    source "$DOT_DEN/utils/configure-macos-screenshots.sh"
+    configure_screenshots || {
+      echo -e "${YELLOW}Screenshot configuration had issues but continuing...${NC}"
+    }
+  fi
+fi
+
 # Source bash aliases to make them immediately available
 echo "Loading bash aliases into current session..."
 if [[ -f ~/.bash_aliases ]]; then

--- a/utils/configure-macos-screenshots.sh
+++ b/utils/configure-macos-screenshots.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Configure macOS screenshot location to use dotfiles/screenshots directory
+
+# Source common functions and variables
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOT_DEN="${DOT_DEN:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+
+# Define colors
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+configure_screenshots() {
+    # Only run on macOS
+    if [[ "$OSTYPE" != "darwin"* ]]; then
+        echo -e "${YELLOW}This script only applies to macOS. Skipping...${NC}"
+        return 0
+    fi
+    
+    echo "Configuring macOS screenshot location..."
+    
+    # Create screenshots directory if it doesn't exist
+    SCREENSHOTS_DIR="$DOT_DEN/screenshots"
+    if [[ ! -d "$SCREENSHOTS_DIR" ]]; then
+        mkdir -p "$SCREENSHOTS_DIR"
+        echo -e "${GREEN}✓ Created screenshots directory at $SCREENSHOTS_DIR${NC}"
+    else
+        echo -e "${GREEN}✓ Screenshots directory already exists at $SCREENSHOTS_DIR${NC}"
+    fi
+    
+    # Set macOS default screenshot location
+    defaults write com.apple.screencapture location "$SCREENSHOTS_DIR"
+    
+    # Restart SystemUIServer to apply changes
+    killall SystemUIServer 2>/dev/null || true
+    
+    echo -e "${GREEN}✓ macOS screenshots will now be saved to: $SCREENSHOTS_DIR${NC}"
+    echo -e "${BLUE}Note: Screenshots are gitignored for privacy/security${NC}"
+    
+    return 0
+}
+
+# Run the configuration if this script is executed directly
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    configure_screenshots
+fi


### PR DESCRIPTION
## Summary
- Created dedicated `screenshots/` directory within dotfiles for macOS screenshot storage
- Configured automatic macOS screenshot redirection via `defaults write`
- Added privacy protection through .gitignore entries

## Implementation Details

### Directory Structure
- Added `screenshots/` directory with `.gitkeep` for git tracking
- Updated `.gitignore` to exclude all screenshot files while preserving directory structure

### macOS Integration
- Created `utils/configure-macos-screenshots.sh` following standard utility script pattern
- Integrated into main `setup.sh` workflow for automatic configuration on macOS
- Uses `defaults write com.apple.screencapture location` for persistent setting

### Convenience Features
Added aliases to `.bash_aliases.d/macos.sh`:
- `screenshots` - Quick navigation to screenshots folder
- `recent-screenshots` - List 20 most recent screenshots
- `reset-screenshots` - Restore default Desktop location
- `dotfiles-screenshots` - Re-enable dotfiles location

## Testing
- ✅ Script execution successful
- ✅ macOS screenshot location verified via `defaults read`
- ✅ Directory created with proper gitignore rules
- ✅ Aliases functional for easy management

Closes #571

Principle: systems-stewardship