### PR TITLE
refactor[claude]: organize permissions into logical groups

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,82 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(find:*)",
+      "Bash(grep:*)",
+      "Bash(locate:*)",
+      "Bash(ls:*)",
+      "Bash(mkdir:*)",
+      "Bash(source:*)",
+      
+      "Bash(git add:*)",
+      "Bash(git checkout:*)",
+      "Bash(git cherry-pick:*)",
+      "Bash(git commit:*)",
+      "Bash(git mv:*)",
+      "Bash(git rebase:*)",
+      "Bash(git rm:*)",
+      
+      "Bash(gh pr list:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh repo list:*)",
+      "Bash(gh search commits:*)",
+      
+      "Bash(claude config --help)",
+      "Bash(claude config get --global verbose)",
+      "Bash(claude config list --global)",
+      "Bash(claude config list)",
+      "Bash(claude config set --help)",
+      
+      "mcp__git__git_add",
+      "mcp__git__git_checkout",
+      "mcp__git__git_cherry_pick",
+      "mcp__git__git_commit",
+      "mcp__git__git_create_branch",
+      "mcp__git__git_diff",
+      "mcp__git__git_diff_staged",
+      "mcp__git__git_diff_unstaged",
+      "mcp__git__git_fetch",
+      "mcp__git__git_log",
+      "mcp__git__git_rebase",
+      "mcp__git__git_stash",
+      "mcp__git__git_status",
+      "mcp__git__git_worktree_add",
+      "mcp__git__git_worktree_remove",
+      
+      "mcp__github__create_issue",
+      "mcp__github__create_pull_request",
+      "mcp__github__get_file_contents",
+      "mcp__github__get_issue",
+      "mcp__github__get_job_logs",
+      "mcp__github__get_pull_request",
+      "mcp__github__get_pull_request_comments",
+      "mcp__github__get_pull_request_reviews",
+      "mcp__github__list_pull_requests",
+      "mcp__github__list_workflow_runs",
+      "mcp__github__search_code",
+      "mcp__github__search_issues",
+      "mcp__github__search_repositories",
+      
+      "mcp__brave-search__brave_web_search",
+      "mcp__filesystem__read_file",
+      
+      "Bash(/home/linuxmint-lp/ppv/pillars/dotfiles/utils/generate-claude-commands.sh:*)",
+      "Bash(./utils/configure-claude-code-settings.sh:*)",
+      "Bash(check-mcp-logs:*)",
+      "Bash(python:*)",
+      
+      "WebFetch(domain:docs.anthropic.com)"
+    ]
+  },
+  "enableAllProjectMcpServers": false,
+  "enabledMcpjsonServers": [
+    "awslabs.aws-documentation-mcp-server",
+    "git",
+    "github",
+    "atlassian",
+    "brave-search",
+    "filesystem",
+    "gdrive",
+    "gitlab"
+  ]
+}


### PR DESCRIPTION
## Summary
Quick refactor to organize Claude Code permissions into logical groups for better maintainability.

## Changes
- Grouped permissions by type (file ops, git, github cli, mcp tools, etc.)
- Alphabetized within each group
- Added spacing between groups for visual clarity
- No functional changes - just reorganization

## Benefits
- Easier to find specific permissions
- Clear categorization of allowed operations
- Simpler to add new permissions to the right group

🤖 Generated with [Claude Code](https://claude.ai/code)