### PR TITLE
feat[git-mcp-server]: Add safety rule to prevent main branch deletion

### DIFF
--- a/mcp/servers/git-mcp-server/src/mcp_server_git/server.py
+++ b/mcp/servers/git-mcp-server/src/mcp_server_git/server.py
@@ -934,6 +934,11 @@ def git_branch_delete(repo: git.Repo, branch_name: str, force: bool = False, rem
     try:
         results = []
         
+        # Safety check: prevent deletion of main/master branches
+        protected_branches = {"main", "master"}
+        if branch_name.lower() in protected_branches:
+            return f"Cannot delete protected branch '{branch_name}'. Direct deletion of main/master branches is not allowed for safety reasons."
+        
         # Check if we're trying to delete the current branch
         try:
             current_branch = repo.active_branch.name


### PR DESCRIPTION
## Summary
- Adds protection against accidentally deleting main/master branches
- Checks branch name (case-insensitive) before deletion
- Returns clear error message when attempting to delete protected branches

## Motivation
This safety rule prevents catastrophic accidents when AI agents use the git branch delete command. By blocking deletion of main/master branches, we can more confidently trust AI with git operations.

## Changes
- Added safety check in `git_branch_delete()` function
- Protected branches: "main", "master" (case-insensitive)
- Clear error message explaining why deletion was blocked

## Testing
The change is straightforward enough to review directly. The logic simply:
1. Checks if branch name (lowercased) is in the protected set
2. Returns error message before any deletion occurs
3. Existing functionality remains unchanged for other branches

Closes #584

Principle: systems-stewardship