### PR TITLE
feat[tmux]: add urlview integration for URL extraction

### DIFF
--- a/.tmux/bindings.conf
+++ b/.tmux/bindings.conf
@@ -36,3 +36,7 @@ bind v copy-mode
 
 # Create new windows in the same directory
 bind c new-window -c "#{pane_current_path}"
+
+# URL extraction with urlview (prefix + u)
+# Captures the current pane, saves to temp file, and opens urlview in a new window
+bind-key u capture-pane -J \; save-buffer /tmp/tmux-buffer \; delete-buffer \; new-window -n urlview 'urlview /tmp/tmux-buffer'

--- a/setup.sh
+++ b/setup.sh
@@ -516,6 +516,18 @@ else
 fi
 echo -e "${DIVIDER}"
 
+# urlview setup (for tmux URL extraction)
+echo "Setting up urlview (tmux URL extraction utility)..."
+if [[ -f "$DOT_DEN/utils/install-urlview.sh" ]]; then
+    source "$DOT_DEN/utils/install-urlview.sh"
+    install_or_update_urlview || {
+        echo -e "${YELLOW}Failed to setup urlview. tmux URL extraction may not work.${NC}"
+        echo "You can install it manually: apt install urlview (Linux) or brew install urlview (macOS)"
+    }
+else
+    echo -e "${RED}urlview installation script not found at $DOT_DEN/utils/install-urlview.sh${NC}"
+fi
+
 # Check if user is in docker group (Linux only)
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   if groups | grep -q docker; then

--- a/utils/install-urlview.sh
+++ b/utils/install-urlview.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# urlview Installation Utility
+# URL extraction tool for tmux - implements "stand on the shoulders of giants" principle
+# Provides cross-platform solution for extracting URLs from terminal output
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No Color
+
+install_or_update_urlview() {
+    echo "Checking urlview installation (URL extraction utility for tmux)..."
+    
+    # Check if urlview is installed
+    if command -v urlview &> /dev/null; then
+        echo -e "${GREEN}✓ urlview is already installed${NC}"
+        return 0
+    else
+        echo "urlview not installed. Installing now..."
+        
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            # macOS with Homebrew
+            if command -v brew &> /dev/null; then
+                brew install urlview
+                if command -v urlview &> /dev/null; then
+                    echo -e "${GREEN}✓ urlview installed successfully${NC}"
+                    echo "Use 'prefix + u' in tmux to extract URLs from current pane"
+                else
+                    echo -e "${RED}urlview installation failed${NC}"
+                    return 1
+                fi
+            else
+                echo -e "${RED}Homebrew not available, cannot install urlview${NC}"
+                echo "Please install Homebrew first: https://brew.sh"
+                return 1
+            fi
+        elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+            # Linux - detect package manager
+            if command -v apt &> /dev/null; then
+                sudo apt update && sudo apt install -y urlview
+            elif command -v pacman &> /dev/null; then
+                sudo pacman -Sy --noconfirm urlview
+            elif command -v dnf &> /dev/null; then
+                sudo dnf install -y urlview
+            elif command -v yum &> /dev/null; then
+                sudo yum install -y urlview
+            else
+                echo -e "${RED}No supported package manager found for urlview installation${NC}"
+                return 1
+            fi
+            
+            if command -v urlview &> /dev/null; then
+                echo -e "${GREEN}✓ urlview installed successfully${NC}"
+                echo "Use 'prefix + u' in tmux to extract URLs from current pane"
+            else
+                echo -e "${RED}urlview installation failed${NC}"
+                return 1
+            fi
+        else
+            echo -e "${YELLOW}Unsupported OS: $OSTYPE. Cannot install urlview automatically.${NC}"
+            echo "Please install urlview manually for your system."
+            return 1
+        fi
+    fi
+    
+    return 0
+}
+
+# Main execution
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    install_or_update_urlview
+fi


### PR DESCRIPTION
## Summary
- Implements urlview integration to solve tmux URL wrapping issue
- Embodies "stand on the shoulders of giants" principle by using mature, battle-tested tool
- Provides cross-platform solution that works on both Linux and macOS

## Changes
1. **Created `utils/install-urlview.sh`** - Modular installation script following existing patterns
2. **Updated `setup.sh`** - Added urlview installation after tmux setup
3. **Updated `.tmux/bindings.conf`** - Added `prefix + u` keybinding for URL extraction

## How it Works
- Press `Ctrl+a u` (or your tmux prefix + u) in any tmux pane
- urlview opens in a new window showing all URLs from the current pane
- Select a URL to open it in your default browser
- No more broken URLs from line wrapping!

## Test plan
- [x] Install script detects OS and uses appropriate package manager
- [x] Script is executable and follows existing patterns
- [x] Keybinding added to tmux configuration
- [ ] Test on Linux system with apt
- [ ] Test on macOS with Homebrew
- [ ] Verify `prefix + u` extracts URLs correctly

Closes #588

🤖 Generated with [Claude Code](https://claude.ai/code)