### PR TITLE
feat[slash-commands]: add PR pattern check to close-issue workflow

### DIFF
--- a/.claude/command-templates/close-issue.md
+++ b/.claude/command-templates/close-issue.md
@@ -8,6 +8,7 @@ Use `mcp__github__get_issue` to read issue #{{ ISSUE_NUMBER }} and determine:
 - Is this already resolved? → Quick close
 - Does this need implementation? → Full workflow
 - Is this invalid/duplicate? → Close with explanation
+- Check recent merged PRs for similar patterns → `mcp__github__list_pull_requests` (state: "closed")
 
 ## Quick Close Path
 If the issue is already resolved, invalid, or duplicate:


### PR DESCRIPTION
## Summary
- Adds a single line to check recent merged PRs for similar patterns before starting work on an issue
- Helps maintain consistency across similar changes and learn from recent implementations
- Minimal addition to the existing workflow

## Changes
Added one line to the "Analyze the Issue" section:
```
- Check recent merged PRs for similar patterns → `mcp__github__list_pull_requests` (state: "closed")
```

## Benefits
- Learn from recent successful implementations
- Maintain consistency across similar changes  
- Reduce reinventing patterns
- Minimal addition (one line)

Closes #604

Principle: versioning-mindset