### PR TITLE
fix[permissions]: add Write tool to auto-approve

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -9,7 +9,8 @@
       "Bash(source:*)",
       
       "LS",
-      "Read"
+      "Read",
+      "Write",
       
       "Bash(git add:*)",
       "Bash(git checkout:*)",


### PR DESCRIPTION
## Summary
- Add `Write` tool to auto-approve permissions list
- Enables autonomous file creation in /close-issue workflow
- Essential for implementing new features and scripts

## Changes
Added `"Write"` to the permissions allow list in `.claude/settings.local.json`

## Testing
- [x] Added Write to permissions list  
- [x] Fixed JSON syntax (added missing comma)
- [ ] Test that Write operations no longer prompt
- [ ] Verify can be disabled for "vibe coding" sessions

## Notes
As discussed in the issue, Write is more nuanced than read-only permissions since it modifies the filesystem. However, it's essential for autonomous operation. Can be temporarily commented out when manual control is desired.

Closes #614

Principle: tracer-bullets