### PR TITLE
fix[github-mcp]: reduce default pagination for pull requests to avoid token limits

### DIFF
--- a/mcp/github-mcp-server/pkg/github/pullrequests.go
+++ b/mcp/github-mcp-server/pkg/github/pullrequests.go
@@ -392,7 +392,7 @@ func ListPullRequests(getClient GetClientFn, t translations.TranslationHelperFun
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
-			pagination, err := OptionalPaginationParams(request)
+			pagination, err := OptionalPaginationParamsForPullRequests(request)
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}

--- a/mcp/github-mcp-server/pkg/github/server.go
+++ b/mcp/github-mcp-server/pkg/github/server.go
@@ -216,6 +216,25 @@ func OptionalPaginationParams(r mcp.CallToolRequest) (PaginationParams, error) {
 	}, nil
 }
 
+// OptionalPaginationParamsForPullRequests returns pagination parameters with a smaller
+// default perPage value (3) to avoid token limit issues with large pull request data.
+// Pull requests include substantial data (descriptions, comments, diff info) that can
+// easily exceed token limits even with small result sets.
+func OptionalPaginationParamsForPullRequests(r mcp.CallToolRequest) (PaginationParams, error) {
+	page, err := OptionalIntParamWithDefault(r, "page", 1)
+	if err != nil {
+		return PaginationParams{}, err
+	}
+	perPage, err := OptionalIntParamWithDefault(r, "perPage", 3)
+	if err != nil {
+		return PaginationParams{}, err
+	}
+	return PaginationParams{
+		page:    page,
+		perPage: perPage,
+	}, nil
+}
+
 func MarshalledTextResult(v any) *mcp.CallToolResult {
 	data, err := json.Marshal(v)
 	if err != nil {

--- a/mcp/github-mcp-server/pkg/github/server_test.go
+++ b/mcp/github-mcp-server/pkg/github/server_test.go
@@ -560,3 +560,86 @@ func TestOptionalPaginationParams(t *testing.T) {
 		})
 	}
 }
+
+func TestOptionalPaginationParamsForPullRequests(t *testing.T) {
+	tests := []struct {
+		name        string
+		params      map[string]any
+		expected    PaginationParams
+		expectError bool
+	}{
+		{
+			name:   "no pagination parameters, default values",
+			params: map[string]any{},
+			expected: PaginationParams{
+				page:    1,
+				perPage: 3, // Different default for pull requests
+			},
+			expectError: false,
+		},
+		{
+			name: "page parameter, default perPage",
+			params: map[string]any{
+				"page": float64(2),
+			},
+			expected: PaginationParams{
+				page:    2,
+				perPage: 3, // Different default for pull requests
+			},
+			expectError: false,
+		},
+		{
+			name: "perPage parameter, default page",
+			params: map[string]any{
+				"perPage": float64(5),
+			},
+			expected: PaginationParams{
+				page:    1,
+				perPage: 5,
+			},
+			expectError: false,
+		},
+		{
+			name: "page and perPage parameters",
+			params: map[string]any{
+				"page":    float64(2),
+				"perPage": float64(5),
+			},
+			expected: PaginationParams{
+				page:    2,
+				perPage: 5,
+			},
+			expectError: false,
+		},
+		{
+			name: "invalid page parameter",
+			params: map[string]any{
+				"page": "not-a-number",
+			},
+			expected:    PaginationParams{},
+			expectError: true,
+		},
+		{
+			name: "invalid perPage parameter",
+			params: map[string]any{
+				"perPage": "not-a-number",
+			},
+			expected:    PaginationParams{},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			request := createMCPRequest(tc.params)
+			result, err := OptionalPaginationParamsForPullRequests(request)
+
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Created `OptionalPaginationParamsForPullRequests` function with default perPage of 3 (down from 30)
- Updated `list_pull_requests` to use the new pagination function
- Added comprehensive tests for the new pagination behavior

## Problem
Pull request data includes substantial content (descriptions, comments, diff info) that can easily exceed the 25k token limit even with small result sets. Users were experiencing frequent token limit errors when trying to list pull requests.

## Solution
This change reduces the default pagination for pull requests specifically, while keeping other resources at their original defaults. The new default of 3 prevents common token limit errors while still allowing users to override with a higher value if needed.

## Test Plan
- [x] Added unit tests for `OptionalPaginationParamsForPullRequests`
- [x] Verified tests pass
- [x] Manual testing would show list_pull_requests now defaults to 3 results

Closes #623

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>