### PR TITLE
fix[setup]: add symlink for Claude Code settings

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -338,6 +338,19 @@ else
   echo -e "${RED}Claude Code installation script not found at $DOT_DEN/utils/install-claude-code.sh${NC}"
 fi
 
+# Symlink Claude Code settings to correct location
+# Claude Code reads from ~/.claude/settings.json, not from .claude/settings.local.json
+if [[ -f "$DOT_DEN/.claude/settings.local.json" ]]; then
+  echo "Creating symlink for Claude Code settings..."
+  # Create ~/.claude directory if it doesn't exist
+  mkdir -p "$HOME/.claude"
+  # Create symlink (force to overwrite if exists)
+  ln -sf "$DOT_DEN/.claude/settings.local.json" "$HOME/.claude/settings.json"
+  echo -e "${GREEN}✓ Claude Code settings symlinked to ~/.claude/settings.json${NC}"
+else
+  echo -e "${YELLOW}Warning: .claude/settings.local.json not found. Skipping settings symlink.${NC}"
+fi
+
 
 # Node.js setup with NVM
 echo -e "${DIVIDER}"


### PR DESCRIPTION
## Summary
- Adds symlink creation to setup.sh to fix Claude Code settings location mismatch
- Claude Code reads from `~/.claude/settings.json` but our settings are in `.claude/settings.local.json`
- This symlink ensures Claude Code uses the correct settings file

## Problem Fixed
Claude Code was prompting for permissions on already-allowed MCP tools because it wasn't reading our settings file. It kept modifying and corrupting the settings because it didn't recognize `.local` suffix.

## Solution
Added a symlink section after Claude Code installation that:
- Creates `~/.claude` directory if needed
- Symlinks our `.claude/settings.local.json` to `~/.claude/settings.json`
- Uses `-f` flag to force overwrite any existing file
- Includes error handling for missing settings file

## Test Results
Tested the setup script section - symlink creates successfully and Claude Code now reads the correct settings.

Closes #626

🤖 Generated with [Claude Code](https://claude.ai/code)