### PR TITLE
fix[gitignore]: add worktrees/ directory to prevent tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ mcp_test_*
 *~
 tmp.txt
 
+# Git worktrees directory
+worktrees/
+
 # OS specific files
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
## Summary
- Added `worktrees/` to `.gitignore` to prevent Git worktree directories from appearing in git status
- Placed entry in logical position after temporary files section

## Context
The worktree workflow is documented in `knowledge/procedures/worktree-workflow.md` and provides isolated development environments for working on multiple features simultaneously. The `worktrees/` directory serves as a container for these temporary worktrees, which should not be tracked by version control.

## Test Plan
- [x] Verified `.gitignore` syntax is correct
- [x] Confirmed `worktrees/` directory is now ignored in git status

Closes #637