### PR TITLE
feat[slash-commands]: add issue comments retrieval step to /close-issue

### DIFF
--- a/.claude/command-templates/close-issue.md
+++ b/.claude/command-templates/close-issue.md
@@ -10,6 +10,9 @@ Use `mcp__github__get_issue` to read issue #{{ ISSUE_NUMBER }} and determine:
 - Is this invalid/duplicate? → Close with explanation
 - Check recent merged PRs for similar patterns → `mcp__github__list_pull_requests` (state: "closed")
 
+## Step 2: Get Issue Comments
+Use `mcp__github__get_issue_comments` to enrich understanding of issue #{{ ISSUE_NUMBER }}.
+
 ## Quick Close Path
 If the issue is already resolved, invalid, or duplicate:
 1. Add explanatory comment with `mcp__github__add_issue_comment`
@@ -19,14 +22,14 @@ If the issue is already resolved, invalid, or duplicate:
 ## Full Implementation Path
 If the issue needs implementation:
 
-### 1. Set Up Development
+### 3. Set Up Development
 {{ INJECT:procedures/worktree-workflow.md }}
 
 Apply to issue #{{ ISSUE_NUMBER }}:
 - Replace <NUMBER> with {{ ISSUE_NUMBER }}
 - Replace <description> with issue title slug
 
-### 2. Implement Solution
+### 4. Implement Solution
 - Use TodoWrite to track implementation tasks
 - Follow existing patterns in codebase
 - Test changes as you go
@@ -34,13 +37,13 @@ Apply to issue #{{ ISSUE_NUMBER }}:
 
 {{ INJECT:procedures/git-workflow.md }}
 
-### 3. Create Pull Request
+### 5. Create Pull Request
 - Push the feature branch to remote
 - Create PR with `mcp__github__create_pull_request` following the PR template at `.github/PULL_REQUEST_TEMPLATE.md`
 - Reference "Closes #{{ ISSUE_NUMBER }}" in PR body
 - Add "Conduct post-PR mini retro" to your todo list
 
-### 4. Cleanup
+### 6. Cleanup
 Remove worktree after PR is created.
 
 ## REQUIRED: Post-PR Mini Retro (if PR was created)


### PR DESCRIPTION
## Problem & Solution
**Problem**: /close-issue command doesn't review issue comments before deciding implementation path, potentially missing important context
**Solution**: Add Step 2 to retrieve issue comments after analyzing the issue
**Keywords**: close-issue, issue comments, GitHub API, slash commands, mcp__github__get_issue_comments

## Related Issues
Closes #639

## Technical Details
**Files changed**: `.claude/command-templates/close-issue.md`
**Key modifications**: 
- Added new Step 2 using `mcp__github__get_issue_comments` to enrich understanding
- Renumbered subsequent steps (3-6) to maintain logical flow
**Alternative approaches considered**: Could have made it part of Step 1, but separate step is clearer

## Testing
1. Run `/close-issue` command on an issue with comments
2. Verify it fetches comments before creating worktree
3. Confirm step numbering flows correctly

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added/updated tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have updated the documentation accordingly (if applicable)