### PR TITLE
fix[slash-commands]: consolidate issue comments retrieval into Step 1

### DIFF
--- a/.claude/command-templates/close-issue.md
+++ b/.claude/command-templates/close-issue.md
@@ -9,6 +9,7 @@ Use `mcp__github__get_issue` to read issue #{{ ISSUE_NUMBER }} and determine:
 - Does this need implementation? → Full workflow
 - Is this invalid/duplicate? → Close with explanation
 - Check recent merged PRs for similar patterns → `mcp__github__list_pull_requests` (state: "closed")
+- Get issue comments with `mcp__github__get_issue_comments` to enrich understanding
 
 ## Quick Close Path
 If the issue is already resolved, invalid, or duplicate:


### PR DESCRIPTION
## Problem & Solution
**Problem**: PR #641 added issue comments as a separate Step 2, but it logically belongs in Step 1's analysis phase
**Solution**: Consolidate into Step 1 as another bullet point
**Keywords**: close-issue, slash commands, simplification

## Related Issues
Improves upon #641

## Technical Details
**Files changed**: `.claude/command-templates/close-issue.md`
**Key modifications**: Added comments retrieval as final bullet in Step 1
**Alternative approaches considered**: Keeping as separate step (too granular)

## Testing
Run `/close-issue` - verify comments are fetched during initial analysis

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added/updated tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have updated the documentation accordingly (if applicable)