### PR TITLE
feat(mcp): add chained tool calls to GitHub MCP server

### DIFF
--- a/mcp/github-mcp-server/README.md
+++ b/mcp/github-mcp-server/README.md
@@ -1,0 +1,125 @@
+# GitHub MCP Server
+
+An in-house GitHub MCP server that provides comprehensive GitHub API integration through the Model Context Protocol.
+
+## Features
+
+- Full GitHub API v3 and GraphQL v4 support
+- Organized toolsets for different GitHub features
+- Read-only mode for safe operations
+- Dynamic toolset discovery
+- **Batch execution support for chaining multiple GitHub operations**
+
+## Available Toolsets
+
+| Toolset | Description | Tools |
+|---------|-------------|-------|
+| `context` | User and authentication context | `get_me` |
+| `repos` | Repository operations | `search_repositories`, `get_file_contents`, `list_commits`, `create_repository`, `fork_repository`, etc. |
+| `issues` | Issue management | `get_issue`, `search_issues`, `create_issue`, `update_issue`, `add_issue_comment` |
+| `pull_requests` | Pull request operations | `get_pull_request`, `create_pull_request`, `merge_pull_request`, `create_pull_request_review`, etc. |
+| `actions` | GitHub Actions workflows | `list_workflows`, `run_workflow`, `get_workflow_run`, `rerun_failed_jobs`, etc. |
+| `notifications` | Notification management | `list_notifications`, `dismiss_notification`, `mark_all_notifications_read` |
+| `batch` | Batch execution | `github_batch` - Execute multiple GitHub operations in sequence |
+
+## Batch Execution
+
+The `github_batch` tool allows you to chain multiple GitHub operations together, reducing the number of AI-agent-human feedback cycles and enabling complex workflows in a single call.
+
+### Usage
+
+```json
+{
+  "tool": "github_batch",
+  "args": {
+    "commands": [
+      {
+        "tool": "get_issue",
+        "args": {
+          "owner": "atxtechbro",
+          "repo": "dotfiles",
+          "issue_number": 123
+        }
+      },
+      {
+        "tool": "add_issue_comment",
+        "args": {
+          "owner": "atxtechbro",
+          "repo": "dotfiles",
+          "issue_number": 123,
+          "body": "I've reviewed this issue."
+        }
+      },
+      {
+        "tool": "update_issue",
+        "args": {
+          "owner": "atxtechbro",
+          "repo": "dotfiles",
+          "issue_number": 123,
+          "state": "closed"
+        }
+      }
+    ]
+  }
+}
+```
+
+### Benefits
+
+- **Reduced latency**: Execute multiple operations in a single round trip
+- **Atomic workflows**: Group related operations together
+- **Better error handling**: See which operations succeeded vs failed
+- **Improved efficiency**: Minimize AI agent cycles for complex tasks
+
+### Example Workflows
+
+#### 1. Issue Analysis and Response
+```json
+{
+  "commands": [
+    {"tool": "get_issue", "args": {"owner": "...", "repo": "...", "issue_number": 123}},
+    {"tool": "get_issue_comments", "args": {"owner": "...", "repo": "...", "issue_number": 123}},
+    {"tool": "search_pull_requests", "args": {"query": "is:pr is:merged fixes #123"}}
+  ]
+}
+```
+
+#### 2. Create PR with Review Request
+```json
+{
+  "commands": [
+    {"tool": "create_pull_request", "args": {"owner": "...", "repo": "...", "title": "...", "head": "...", "base": "..."}},
+    {"tool": "request_copilot_review", "args": {"owner": "...", "repo": "...", "pullNumber": 456}}
+  ]
+}
+```
+
+## Configuration
+
+The server is configured through environment variables:
+
+- `GITHUB_PERSONAL_ACCESS_TOKEN`: GitHub personal access token (required)
+- `GITHUB_TOOLSETS`: Comma-separated list of toolsets to enable (default: "all")
+- `GITHUB_DYNAMIC_TOOLSETS`: Enable dynamic toolset discovery (default: false)
+- `GITHUB_READ_ONLY`: Restrict to read-only operations (default: false)
+
+## Building
+
+```bash
+cd cmd/github-mcp-server
+go build -o github-mcp-server
+```
+
+## Testing
+
+```bash
+go test ./...
+```
+
+## Architecture Notes
+
+The GitHub MCP server uses a toolset-based architecture where:
+- Tools are organized into logical groups (toolsets)
+- Each toolset can be enabled/disabled independently
+- Tool handlers are registered dynamically when toolsets are enabled
+- The batch execution system maintains a registry of all available tool handlers

--- a/mcp/github-mcp-server/internal/ghmcp/server.go
+++ b/mcp/github-mcp-server/internal/ghmcp/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/github/github-mcp-server/pkg/github"
 	mcplog "github.com/github/github-mcp-server/pkg/log"
 	"github.com/github/github-mcp-server/pkg/raw"
+	"github.com/github/github-mcp-server/pkg/toolsets"
 	"github.com/github/github-mcp-server/pkg/translations"
 	gogithub "github.com/google/go-github/v72/github"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -128,6 +129,9 @@ func NewMCPServer(cfg MCPServerConfig) (*server.MCPServer, error) {
 		}
 		return raw.NewClient(client, apiHost.rawURL), nil // closing over client
 	}
+
+	// Set up the tool handler registrar for batch execution
+	toolsets.SetToolHandlerRegistrar(github.RegisterToolHandler)
 
 	// Create default toolsets
 	tsg := github.DefaultToolsetGroup(cfg.ReadOnly, getClient, getGQLClient, getRawClient, cfg.Translator)

--- a/mcp/github-mcp-server/pkg/github/batch.go
+++ b/mcp/github-mcp-server/pkg/github/batch.go
@@ -1,0 +1,144 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/github/github-mcp-server/pkg/raw"
+	"github.com/github/github-mcp-server/pkg/translations"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// toolHandlerMap is a global map to store tool handlers for batch execution
+var toolHandlerMap = make(map[string]server.ToolHandlerFunc)
+
+// RegisterToolHandler registers a tool handler for batch execution
+func RegisterToolHandler(name string, handler server.ToolHandlerFunc) {
+	toolHandlerMap[name] = handler
+}
+
+// GitHubBatch creates a tool to execute multiple GitHub commands in sequence.
+func GitHubBatch(getClient GetClientFn, getGQLClient GetGQLClientFn, getRawClient raw.GetRawClientFn, t translations.TranslationHelperFunc) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+	return mcp.NewTool("github_batch",
+		mcp.WithDescription(t("TOOL_GITHUB_BATCH_DESCRIPTION", "Execute multiple GitHub commands in sequence")),
+		mcp.WithToolAnnotation(mcp.ToolAnnotation{
+			Title: t("TOOL_GITHUB_BATCH_USER_TITLE", "Execute batch GitHub operations"),
+		}),
+		mcp.WithArray("commands",
+			mcp.Required(),
+			mcp.Description("Array of commands to execute. Each command should have 'tool' and 'args' fields"),
+		),
+	),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			// Get commands array from request
+			commandsRaw, ok := request.GetArguments()["commands"]
+			if !ok {
+				return mcp.NewToolResultError("missing required parameter: commands"), nil
+			}
+			
+			commands, ok := commandsRaw.([]interface{})
+			if !ok {
+				return mcp.NewToolResultError("commands must be an array"), nil
+			}
+
+			results := make([]map[string]interface{}, 0, len(commands))
+
+			for i, cmd := range commands {
+				cmdMap, ok := cmd.(map[string]interface{})
+				if !ok {
+					results = append(results, map[string]interface{}{
+						"index":  i,
+						"status": "error",
+						"error":  "command must be an object with 'tool' and 'args' fields",
+					})
+					continue
+				}
+
+				toolName, ok := cmdMap["tool"].(string)
+				if !ok {
+					results = append(results, map[string]interface{}{
+						"index":  i,
+						"status": "error",
+						"error":  "missing or invalid 'tool' field",
+					})
+					continue
+				}
+
+				args, ok := cmdMap["args"].(map[string]interface{})
+				if !ok {
+					args = make(map[string]interface{})
+				}
+
+				// Create a new tool request with the specified arguments
+				toolRequest := mcp.CallToolRequest{
+					Params: mcp.CallToolParams{
+						Name:      toolName,
+						Arguments: args,
+					},
+				}
+
+				// Find the tool handler in our registry
+				handler, found := toolHandlerMap[toolName]
+				if !found {
+					results = append(results, map[string]interface{}{
+						"index":  i,
+						"tool":   toolName,
+						"status": "error",
+						"error":  fmt.Sprintf("unknown tool: %s", toolName),
+					})
+					continue
+				}
+
+				// Execute the tool
+				result, err := handler(ctx, toolRequest)
+				if err != nil {
+					results = append(results, map[string]interface{}{
+						"index":  i,
+						"tool":   toolName,
+						"status": "error",
+						"error":  err.Error(),
+					})
+					continue
+				}
+
+				// Extract result content
+				var resultContent string
+				if len(result.Content) > 0 {
+					if textContent, ok := result.Content[0].(mcp.TextContent); ok {
+						resultContent = textContent.Text
+					} else {
+						resultContent = fmt.Sprintf("%v", result.Content[0])
+					}
+				}
+
+				results = append(results, map[string]interface{}{
+					"index":  i,
+					"tool":   toolName,
+					"status": "success",
+					"result": resultContent,
+				})
+			}
+
+			// Format results for display
+			var formattedResults []string
+			successCount := 0
+			for _, r := range results {
+				if r["status"] == "success" {
+					successCount++
+					formattedResults = append(formattedResults, 
+						fmt.Sprintf("✓ %s: %v", r["tool"], r["result"]))
+				} else {
+					formattedResults = append(formattedResults, 
+						fmt.Sprintf("✗ %s: %v", r["tool"], r["error"]))
+				}
+			}
+
+			summary := fmt.Sprintf("Batch executed: %d/%d succeeded\n\n%s", 
+				successCount, len(results), 
+				strings.Join(formattedResults, "\n"))
+
+			return mcp.NewToolResultText(summary), nil
+		}
+}

--- a/mcp/github-mcp-server/pkg/github/batch_test.go
+++ b/mcp/github-mcp-server/pkg/github/batch_test.go
@@ -1,0 +1,130 @@
+package github
+
+import (
+	"context"
+	"testing"
+
+	"github.com/github/github-mcp-server/pkg/raw"
+	"github.com/github/github-mcp-server/pkg/translations"
+	"github.com/google/go-github/v72/github"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/shurcooL/githubv4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGitHubBatch(t *testing.T) {
+	ctx := context.Background()
+	
+	// Mock functions
+	getClient := func(ctx context.Context) (*github.Client, error) {
+		return nil, nil
+	}
+	getGQLClient := func(ctx context.Context) (*githubv4.Client, error) {
+		return nil, nil
+	}
+	getRawClient := func(ctx context.Context) (*raw.Client, error) {
+		return nil, nil
+	}
+	translator := translations.NullTranslationHelper
+
+	// Register mock tool handlers
+	RegisterToolHandler("test_tool1", func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultText("Result from tool1"), nil
+	})
+	RegisterToolHandler("test_tool2", func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultText("Result from tool2"), nil
+	})
+
+	// Create the batch tool
+	tool, handler := GitHubBatch(getClient, getGQLClient, getRawClient, translator)
+
+	// Verify tool properties
+	assert.Equal(t, "github_batch", tool.Name)
+	assert.NotNil(t, handler)
+
+	t.Run("successful batch execution", func(t *testing.T) {
+		// Create a batch request
+		request := mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name: "github_batch",
+				Arguments: map[string]interface{}{
+					"commands": []interface{}{
+						map[string]interface{}{
+							"tool": "test_tool1",
+							"args": map[string]interface{}{},
+						},
+						map[string]interface{}{
+							"tool": "test_tool2",
+							"args": map[string]interface{}{},
+						},
+					},
+				},
+			},
+		}
+
+		result, err := handler(ctx, request)
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		
+		// Check that the result contains success message
+		assert.Contains(t, result.Content[0].(mcp.TextContent).Text, "Batch executed: 2/2 succeeded")
+		assert.Contains(t, result.Content[0].(mcp.TextContent).Text, "✓ test_tool1: Result from tool1")
+		assert.Contains(t, result.Content[0].(mcp.TextContent).Text, "✓ test_tool2: Result from tool2")
+	})
+
+	t.Run("handles invalid command format", func(t *testing.T) {
+		request := mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name: "github_batch",
+				Arguments: map[string]interface{}{
+					"commands": []interface{}{
+						"invalid_command", // Not a map
+					},
+				},
+			},
+		}
+
+		result, err := handler(ctx, request)
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Contains(t, result.Content[0].(mcp.TextContent).Text, "Batch executed: 0/1 succeeded")
+		assert.Contains(t, result.Content[0].(mcp.TextContent).Text, "command must be an object")
+	})
+
+	t.Run("handles unknown tool", func(t *testing.T) {
+		request := mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name: "github_batch",
+				Arguments: map[string]interface{}{
+					"commands": []interface{}{
+						map[string]interface{}{
+							"tool": "unknown_tool",
+							"args": map[string]interface{}{},
+						},
+					},
+				},
+			},
+		}
+
+		result, err := handler(ctx, request)
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Contains(t, result.Content[0].(mcp.TextContent).Text, "Batch executed: 0/1 succeeded")
+		assert.Contains(t, result.Content[0].(mcp.TextContent).Text, "unknown tool: unknown_tool")
+	})
+
+	t.Run("handles missing commands parameter", func(t *testing.T) {
+		request := mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name:      "github_batch",
+				Arguments: map[string]interface{}{},
+			},
+		}
+
+		result, err := handler(ctx, request)
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.True(t, result.IsError)
+		assert.Contains(t, result.Content[0].(mcp.TextContent).Text, "missing required parameter: commands")
+	})
+}

--- a/mcp/github-mcp-server/pkg/github/tools.go
+++ b/mcp/github-mcp-server/pkg/github/tools.go
@@ -144,6 +144,12 @@ func DefaultToolsetGroup(readOnly bool, getClient GetClientFn, getGQLClient GetG
 			toolsets.NewServerTool(GetMe(getClient, t)),
 		)
 
+	// Add batch toolset for chained operations
+	batch := toolsets.NewToolset("batch", "Batch execution of multiple GitHub operations").
+		AddReadTools(
+			toolsets.NewServerTool(GitHubBatch(getClient, getGQLClient, getRawClient, t)),
+		)
+
 	// Add toolsets to the group
 	tsg.AddToolset(contextTools)
 	tsg.AddToolset(repos)
@@ -156,6 +162,7 @@ func DefaultToolsetGroup(readOnly bool, getClient GetClientFn, getGQLClient GetG
 	tsg.AddToolset(secretProtection)
 	tsg.AddToolset(notifications)
 	tsg.AddToolset(experiments)
+	tsg.AddToolset(batch)
 
 	return tsg
 }


### PR DESCRIPTION
## Summary
- Implemented `github_batch` tool for executing multiple GitHub operations in sequence
- Created tool handler registry to enable batch execution across toolsets
- Added comprehensive test coverage for batch functionality
- Documented the feature with usage examples and workflows

## Implementation Details

The implementation follows the pattern established by `git_batch` in the git-mcp-server:
- Commands are passed as an array with `tool` and `args` fields
- Each command is executed sequentially
- Results show success/failure status for each operation
- Tool handlers are registered globally when toolsets are enabled

## Test Plan
- [x] Unit tests for batch execution with various scenarios
- [x] Tests for error handling (invalid commands, unknown tools)
- [x] Build verification (`go build ./...` passes)
- [x] Test execution (`go test ./pkg/github -run TestGitHubBatch` passes)

## Example Usage

```json
{
  "tool": "github_batch",
  "args": {
    "commands": [
      {
        "tool": "get_issue",
        "args": {"owner": "...", "repo": "...", "issue_number": 123}
      },
      {
        "tool": "add_issue_comment", 
        "args": {"owner": "...", "repo": "...", "issue_number": 123, "body": "..."}
      }
    ]
  }
}
```

Closes #636