### PR TITLE
feat(mcp): implement flag-based Git MCP server split

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,7 +34,7 @@
       "Bash(claude config set --help)",
       
       "mcp__git",
-      "mcp__github",
+      "mcp__github-read",
       "mcp__brave-search",
       "mcp__filesystem",
       "mcp__awslabs.aws-documentation-mcp-server",
@@ -75,7 +75,7 @@
   "enabledMcpjsonServers": [
     "awslabs.aws-documentation-mcp-server",
     "git",
-    "github",
+    "github-read",
     "atlassian",
     "brave-search",
     "filesystem",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,7 +33,7 @@
       "Bash(claude config list)",
       "Bash(claude config set --help)",
       
-      "mcp__git",
+      "mcp__git-read",
       "mcp__github-read",
       "mcp__brave-search",
       "mcp__filesystem",
@@ -74,7 +74,7 @@
   "enableAllProjectMcpServers": false,
   "enabledMcpjsonServers": [
     "awslabs.aws-documentation-mcp-server",
-    "git",
+    "git-read",
     "github-read",
     "atlassian",
     "brave-search",

--- a/mcp/git-mcp-read-wrapper.sh
+++ b/mcp/git-mcp-read-wrapper.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# =========================================================
+# GIT MCP READ-ONLY WRAPPER SCRIPT
+# =========================================================
+# PURPOSE: Runtime wrapper that executes the Git MCP server in read-only mode
+# This script is called by the MCP system during normal operation
+# Uses the --read-only flag to restrict to safe operations
+# =========================================================
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source MCP logging utilities
+source "$SCRIPT_DIR/utils/mcp-logging.sh"
+
+# Check if git command is available
+mcp_check_command "GIT-READ" "git" "Install Git: apt-get install git"
+
+# Use virtual environment's Python
+PYTHON_CMD="$SCRIPT_DIR/servers/git-mcp-server/.venv/bin/python"
+
+# Check if the virtual environment exists
+if [[ ! -f "$PYTHON_CMD" ]]; then
+  mcp_log_error "GIT-READ" "Virtual environment not found" "Run setup-git-mcp.sh to install the Git MCP server"
+  exit 1
+fi
+
+# Run the server with read-only flag
+mcp_exec_with_logging "GIT-READ" "$PYTHON_CMD" -m mcp_server_git --read-only "$@"

--- a/mcp/git-mcp-write-wrapper.sh
+++ b/mcp/git-mcp-write-wrapper.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# =========================================================
+# GIT MCP WRITE WRAPPER SCRIPT
+# =========================================================
+# PURPOSE: Runtime wrapper that executes the Git MCP server with full write access
+# This script is called by the MCP system during normal operation
+# Runs without --read-only flag to enable all operations
+# =========================================================
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source MCP logging utilities
+source "$SCRIPT_DIR/utils/mcp-logging.sh"
+
+# Check if git command is available
+mcp_check_command "GIT-WRITE" "git" "Install Git: apt-get install git"
+
+# Use virtual environment's Python
+PYTHON_CMD="$SCRIPT_DIR/servers/git-mcp-server/.venv/bin/python"
+
+# Check if the virtual environment exists
+if [[ ! -f "$PYTHON_CMD" ]]; then
+  mcp_log_error "GIT-WRITE" "Virtual environment not found" "Run setup-git-mcp.sh to install the Git MCP server"
+  exit 1
+fi
+
+# Run the server without read-only flag (full access)
+mcp_exec_with_logging "GIT-WRITE" "$PYTHON_CMD" -m mcp_server_git "$@"

--- a/mcp/github-mcp-read-wrapper.sh
+++ b/mcp/github-mcp-read-wrapper.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# =========================================================
+# GITHUB MCP READ-ONLY WRAPPER SCRIPT
+# =========================================================
+# PURPOSE: Runtime wrapper that executes the GitHub MCP server in read-only mode
+# This script is called by the MCP system during normal operation
+# Uses the --read-only flag to restrict to safe operations
+# =========================================================
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source MCP logging utilities
+source "$SCRIPT_DIR/utils/mcp-logging.sh"
+
+# Path to the GitHub MCP server binary
+SERVER_BIN="$SCRIPT_DIR/servers/github"
+
+# Check if server binary exists
+if [[ ! -f "$SERVER_BIN" ]]; then
+  mcp_log_error "GITHUB-READ" "Server binary not found: $SERVER_BIN" "Run setup-github-mcp.sh to install the GitHub MCP server"
+  exit 1
+fi
+
+# Check if git command is available (needed for GitHub operations)
+mcp_check_command "GITHUB-READ" "git" "Install Git: brew install git"
+
+# Check if GitHub token is set
+if [[ -z "$GITHUB_PERSONAL_ACCESS_TOKEN" ]] && [[ -z "$GITHUB_TOKEN" ]]; then
+  # Try to get token from gh CLI
+  if command -v gh &> /dev/null; then
+    export GITHUB_PERSONAL_ACCESS_TOKEN="$(gh auth token 2>/dev/null)"
+    if [[ -z "$GITHUB_PERSONAL_ACCESS_TOKEN" ]]; then
+      mcp_log_error "GITHUB-READ" "GitHub token not found" "Set GITHUB_TOKEN or authenticate with: gh auth login"
+      exit 1
+    fi
+  else
+    mcp_log_error "GITHUB-READ" "GitHub token not found" "Set GITHUB_TOKEN or install GitHub CLI and authenticate"
+    exit 1
+  fi
+elif [[ -n "$GITHUB_TOKEN" ]] && [[ -z "$GITHUB_PERSONAL_ACCESS_TOKEN" ]]; then
+  # If GITHUB_TOKEN is set but not GITHUB_PERSONAL_ACCESS_TOKEN, copy it
+  export GITHUB_PERSONAL_ACCESS_TOKEN="$GITHUB_TOKEN"
+fi
+
+# Run the server with read-only flag
+mcp_exec_with_logging "GITHUB-READ" "$SERVER_BIN" stdio --read-only "$@"

--- a/mcp/github-mcp-server/README-SPLIT.md
+++ b/mcp/github-mcp-server/README-SPLIT.md
@@ -1,0 +1,40 @@
+# GitHub MCP Server - Read/Write Split
+
+## Overview
+The GitHub MCP server has been split into two modes using the existing `--read-only` flag:
+- `github-read`: Read-only operations (runs with `--read-only` flag)
+- `github-write`: Full operations (runs without restrictions)
+
+## Architecture
+Unlike the Git server split, the GitHub server uses the same binary with different flags:
+- Both wrappers execute the same `github-mcp-server` binary
+- The read wrapper adds `--read-only` flag
+- The write wrapper runs without restrictions
+
+## Read-Only Operations (github-read)
+When running with `--read-only`, the server restricts to:
+- All get_* operations (issues, PRs, commits, etc.)
+- All list_* operations
+- All search_* operations
+- Notification viewing (but not dismissing/marking as read in strict mode)
+
+## Write Operations (github-write)
+Full access includes:
+- All create_* operations
+- All update_* operations
+- All delete_* operations
+- merge_pull_request, push_files
+- Workflow runs and management
+- Notification management
+
+## Security Notes
+- The GitHub server already has built-in read-only mode support
+- The `--read-only` flag is enforced at the toolset level
+- Each toolset separates read and write tools internally
+- No code changes needed - just different launch flags
+
+## Migration
+Users need to:
+1. Update their MCP client config to use new server names
+2. Replace `github` with `github-read` for safe operations
+3. Manually enable `github-write` when needed

--- a/mcp/github-mcp-write-wrapper.sh
+++ b/mcp/github-mcp-write-wrapper.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# =========================================================
+# GITHUB MCP WRITE WRAPPER SCRIPT
+# =========================================================
+# PURPOSE: Runtime wrapper that executes the GitHub MCP server with full write access
+# This script is called by the MCP system during normal operation
+# Runs without --read-only flag to enable all operations
+# =========================================================
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source MCP logging utilities
+source "$SCRIPT_DIR/utils/mcp-logging.sh"
+
+# Path to the GitHub MCP server binary
+SERVER_BIN="$SCRIPT_DIR/servers/github"
+
+# Check if server binary exists
+if [[ ! -f "$SERVER_BIN" ]]; then
+  mcp_log_error "GITHUB-WRITE" "Server binary not found: $SERVER_BIN" "Run setup-github-mcp.sh to install the GitHub MCP server"
+  exit 1
+fi
+
+# Check if git command is available (needed for GitHub operations)
+mcp_check_command "GITHUB-WRITE" "git" "Install Git: brew install git"
+
+# Check if GitHub token is set
+if [[ -z "$GITHUB_PERSONAL_ACCESS_TOKEN" ]] && [[ -z "$GITHUB_TOKEN" ]]; then
+  # Try to get token from gh CLI
+  if command -v gh &> /dev/null; then
+    export GITHUB_PERSONAL_ACCESS_TOKEN="$(gh auth token 2>/dev/null)"
+    if [[ -z "$GITHUB_PERSONAL_ACCESS_TOKEN" ]]; then
+      mcp_log_error "GITHUB-WRITE" "GitHub token not found" "Set GITHUB_TOKEN or authenticate with: gh auth login"
+      exit 1
+    fi
+  else
+    mcp_log_error "GITHUB-WRITE" "GitHub token not found" "Set GITHUB_TOKEN or install GitHub CLI and authenticate"
+    exit 1
+  fi
+elif [[ -n "$GITHUB_TOKEN" ]] && [[ -z "$GITHUB_PERSONAL_ACCESS_TOKEN" ]]; then
+  # If GITHUB_TOKEN is set but not GITHUB_PERSONAL_ACCESS_TOKEN, copy it
+  export GITHUB_PERSONAL_ACCESS_TOKEN="$GITHUB_TOKEN"
+fi
+
+# Run the server without read-only flag (full access)
+mcp_exec_with_logging "GITHUB-WRITE" "$SERVER_BIN" stdio "$@"

--- a/mcp/mcp.template.json
+++ b/mcp/mcp.template.json
@@ -7,8 +7,15 @@
         "FASTMCP_LOG_LEVEL": "ERROR"
       }
     },
-    "git": {
-      "command": "git-mcp-wrapper.sh",
+    "git-read": {
+      "command": "git-mcp-read-wrapper.sh",
+      "args": [],
+      "env": {
+        "FASTMCP_LOG_LEVEL": "ERROR"
+      }
+    },
+    "git-write": {
+      "command": "git-mcp-write-wrapper.sh",
       "args": [],
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"

--- a/mcp/mcp.template.json
+++ b/mcp/mcp.template.json
@@ -14,8 +14,13 @@
         "FASTMCP_LOG_LEVEL": "ERROR"
       }
     },
-    "github": {
-      "command": "github-mcp-wrapper.sh",
+    "github-read": {
+      "command": "github-mcp-read-wrapper.sh",
+      "args": [],
+      "env": {}
+    },
+    "github-write": {
+      "command": "github-mcp-write-wrapper.sh",
       "args": [],
       "env": {}
     },

--- a/mcp/servers/git-mcp-server/README-FLAG.md
+++ b/mcp/servers/git-mcp-server/README-FLAG.md
@@ -1,0 +1,58 @@
+# Git MCP Server - Flag-Based Read/Write Split
+
+## Overview
+The Git MCP server now supports a `--read-only` flag to restrict operations:
+- `git-read`: Safe read-only operations (runs with `--read-only` flag)
+- `git-write`: Full operations (runs without restrictions)
+
+## Architecture
+This implementation follows the same pattern as the GitHub MCP server:
+- Single Python codebase with conditional behavior
+- Flag passed through wrapper scripts
+- Tool filtering based on mode at runtime
+
+## Implementation Details
+
+### Entry Point
+The `__init__.py` accepts a `--read-only` flag:
+```python
+@click.option("--read-only", is_flag=True, help="Run in read-only mode (no write operations)")
+```
+
+### Tool Filtering
+Tools are categorized into READ_ONLY_TOOLS and WRITE_TOOLS sets. The server:
+1. Filters available tools in `list_tools()` based on mode
+2. Validates tool usage in `call_tool()` before execution
+3. Provides special handling for restricted tools
+
+### Special Cases
+- **git_remote**: Limited to "list" action in read-only mode
+- **git_branch_delete**: Blocks remote deletion in read-only mode  
+- **git_batch**: Validates all commands are read-only tools
+- **git_fetch**: Allowed in read-only (only downloads data)
+
+## Read-Only Tools
+- git_status, git_diff_*, git_log, git_show
+- git_worktree_list, git_reflog, git_blame
+- git_describe, git_shortlog
+- git_remote (list only), git_fetch
+- git_branch_delete (local only)
+
+## Write Tools
+- git_commit, git_add, git_reset
+- git_create_branch, git_checkout
+- git_push, git_pull, git_merge
+- git_rebase, git_stash, git_cherry_pick
+- git_revert, git_reset_hard, git_clean, git_bisect
+
+## Migration
+Users need to:
+1. Update their MCP client config to use new server names
+2. Replace `git` with `git-read` for safe operations
+3. Manually enable `git-write` when needed
+
+## Benefits
+- Consistent with GitHub server approach
+- Single codebase to maintain
+- Easy to extend with new tools
+- Clear security boundaries

--- a/mcp/servers/git-mcp-server/src/mcp_server_git/__init__.py
+++ b/mcp/servers/git-mcp-server/src/mcp_server_git/__init__.py
@@ -9,7 +9,8 @@ from .server import serve
 @click.command()
 @click.option("--repository", "-r", type=Path, help="Git repository path")
 @click.option("-v", "--verbose", count=True)
-def main(repository: Path | None, verbose: bool) -> None:
+@click.option("--read-only", is_flag=True, help="Run in read-only mode (no write operations)")
+def main(repository: Path | None, verbose: bool, read_only: bool) -> None:
     """MCP Git Server - Git functionality for MCP"""
     import asyncio
 
@@ -20,7 +21,7 @@ def main(repository: Path | None, verbose: bool) -> None:
         logging_level = logging.DEBUG
 
     logging.basicConfig(level=logging_level, stream=sys.stderr)
-    asyncio.run(serve(repository))
+    asyncio.run(serve(repository, read_only))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary

This PR implements a flag-based approach for the Git MCP server split, consistent with the GitHub server pattern.

### Key Changes
- Added `--read-only` flag to Git MCP server
- Single codebase with runtime tool filtering
- Wrapper scripts pass appropriate flags
- Special handling for edge cases (git_remote, git_branch_delete, git_batch)

### Implementation Details

**Core Changes:**
- `__init__.py`: Added `--read-only` flag option
- `server.py`: 
  - Define READ_ONLY_TOOLS and WRITE_TOOLS sets
  - Filter tools in `list_tools()` based on mode
  - Validate tool access in `call_tool()`
  - Special restrictions for git_remote (list only), git_branch_delete (no remote), git_batch (validate all commands)

**Wrapper Scripts:**
- `git-mcp-read-wrapper.sh`: Executes with `--read-only` flag
- `git-mcp-write-wrapper.sh`: Executes without flag (full access)

**Configuration:**
- Updated `mcp.template.json` to use `git-read` and `git-write`
- Updated `.claude/settings.json` to auto-trust `git-read`

### Benefits Over Previous Approach
- Consistent with GitHub server implementation
- Single codebase to maintain
- Cleaner separation of concerns
- Easy to modify tool categorization

Closes #648
Related to #647

🤖 Generated with [Claude Code](https://claude.ai/code)