### PR TITLE
Consolidate git-read and git-write MCP servers into single git server

### DIFF
--- a/mcp/git-mcp-read-wrapper.sh
+++ b/mcp/git-mcp-read-wrapper.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 # =========================================================
-# GIT MCP READ-ONLY WRAPPER SCRIPT
+# GIT MCP READ-ONLY WRAPPER SCRIPT [DEPRECATED]
 # =========================================================
-# PURPOSE: Runtime wrapper that executes the Git MCP server in read-only mode
-# This script is called by the MCP system during normal operation
-# Uses the --read-only flag to restrict to safe operations
+# PURPOSE: This script is deprecated. Use git-mcp-wrapper.sh instead.
+# The git-read/git-write split has been consolidated into a single git server
+# that relies on Git's built-in authentication for security.
 # =========================================================
 
 # Get the directory where this script is located

--- a/mcp/git-mcp-write-wrapper.sh
+++ b/mcp/git-mcp-write-wrapper.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 # =========================================================
-# GIT MCP WRITE WRAPPER SCRIPT
+# GIT MCP WRITE WRAPPER SCRIPT [DEPRECATED]
 # =========================================================
-# PURPOSE: Runtime wrapper that executes the Git MCP server with full write access
-# This script is called by the MCP system during normal operation
-# Runs without --read-only flag to enable all operations
+# PURPOSE: This script is deprecated. Use git-mcp-wrapper.sh instead.
+# The git-read/git-write split has been consolidated into a single git server
+# that relies on Git's built-in authentication for security.
 # =========================================================
 
 # Get the directory where this script is located

--- a/mcp/mcp.template.json
+++ b/mcp/mcp.template.json
@@ -7,15 +7,8 @@
         "FASTMCP_LOG_LEVEL": "ERROR"
       }
     },
-    "git-read": {
-      "command": "git-mcp-read-wrapper.sh",
-      "args": [],
-      "env": {
-        "FASTMCP_LOG_LEVEL": "ERROR"
-      }
-    },
-    "git-write": {
-      "command": "git-mcp-write-wrapper.sh",
+    "git": {
+      "command": "git-mcp-wrapper.sh",
       "args": [],
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"

--- a/mcp/servers/git-mcp-server/README-FLAG.md
+++ b/mcp/servers/git-mcp-server/README-FLAG.md
@@ -1,15 +1,12 @@
-# Git MCP Server - Flag-Based Read/Write Split
+# Git MCP Server - Unified Server with Optional Read-Only Mode
 
 ## Overview
-The Git MCP server now supports a `--read-only` flag to restrict operations:
-- `git-read`: Safe read-only operations (runs with `--read-only` flag)
-- `git-write`: Full operations (runs without restrictions)
+The Git MCP server is now consolidated into a single server that provides full functionality by default, with an optional `--read-only` flag for restricted operations if needed.
 
 ## Architecture
-This implementation follows the same pattern as the GitHub MCP server:
-- Single Python codebase with conditional behavior
-- Flag passed through wrapper scripts
-- Tool filtering based on mode at runtime
+- Single Python codebase with all Git operations
+- Relies on Git's built-in authentication for security
+- Optional `--read-only` flag available but not used by default
 
 ## Implementation Details
 
@@ -45,11 +42,11 @@ Tools are categorized into READ_ONLY_TOOLS and WRITE_TOOLS sets. The server:
 - git_rebase, git_stash, git_cherry_pick
 - git_revert, git_reset_hard, git_clean, git_bisect
 
-## Migration
-Users need to:
-1. Update their MCP client config to use new server names
-2. Replace `git` with `git-read` for safe operations
-3. Manually enable `git-write` when needed
+## Migration from Split Servers
+Users who were using `git-read` and `git-write` should:
+1. Update their MCP client config to use the single `git` server
+2. Remove references to `git-read` and `git-write`
+3. Trust Git's built-in authentication for security
 
 ## Benefits
 - Consistent with GitHub server approach


### PR DESCRIPTION
## Summary
This PR consolidates the separate `git-read` and `git-write` MCP servers into a single unified `git` server.

## Why
- The split was unnecessary since Git already requires SSH authentication for pushes
- GitHub enforces repository permissions server-side  
- The MCP server cannot bypass authentication requirements
- This reduces cognitive overhead without compromising security

## Changes
- Update `mcp.template.json` to use single `git` server
- Add deprecation notices to old wrapper scripts
- Update documentation to reflect consolidation
- Rely on Git's built-in authentication instead of artificial split

## Testing
- Ran `generate-mcp-config.sh` to verify template generates correctly
- Confirmed single `git` server appears in generated `.mcp.json`

Closes #657