### PR TITLE
fix(mcp): implement write-only mode for github-write server

### DIFF
--- a/mcp/github-mcp-server/README-SPLIT.md
+++ b/mcp/github-mcp-server/README-SPLIT.md
@@ -1,15 +1,16 @@
 # GitHub MCP Server - Read/Write Split
 
 ## Overview
-The GitHub MCP server has been split into two modes using the existing `--read-only` flag:
+The GitHub MCP server has been split into two distinct modes:
 - `github-read`: Read-only operations (runs with `--read-only` flag)
-- `github-write`: Full operations (runs without restrictions)
+- `github-write`: Write-only operations (runs with `--write-only` flag)
 
 ## Architecture
-Unlike the Git server split, the GitHub server uses the same binary with different flags:
+The GitHub server uses the same binary with different flags:
 - Both wrappers execute the same `github-mcp-server` binary
 - The read wrapper adds `--read-only` flag
-- The write wrapper runs without restrictions
+- The write wrapper adds `--write-only` flag
+- This ensures no overlap between read and write operations
 
 ## Read-Only Operations (github-read)
 When running with `--read-only`, the server restricts to:
@@ -19,19 +20,20 @@ When running with `--read-only`, the server restricts to:
 - Notification viewing (but not dismissing/marking as read in strict mode)
 
 ## Write Operations (github-write)
-Full access includes:
+When running with `--write-only`, the server restricts to write operations only:
 - All create_* operations
 - All update_* operations
 - All delete_* operations
 - merge_pull_request, push_files
 - Workflow runs and management
-- Notification management
+- Notification management (dismissing, marking as read)
+- Note: Read operations are NOT available in this mode
 
 ## Security Notes
-- The GitHub server already has built-in read-only mode support
-- The `--read-only` flag is enforced at the toolset level
+- The GitHub server has built-in read-only and write-only mode support
+- The `--read-only` and `--write-only` flags are enforced at the toolset level
 - Each toolset separates read and write tools internally
-- No code changes needed - just different launch flags
+- Clear separation prevents accidental exposure of read operations in write mode
 
 ## Migration
 Users need to:

--- a/mcp/github-mcp-server/cmd/github-mcp-server/generate_docs.go
+++ b/mcp/github-mcp-server/cmd/github-mcp-server/generate_docs.go
@@ -64,7 +64,7 @@ func generateReadmeDocs(readmePath string) error {
 	t, _ := translations.TranslationHelper()
 
 	// Create toolset group with mock clients
-	tsg := github.DefaultToolsetGroup(false, mockGetClient, mockGetGQLClient, mockGetRawClient, t)
+	tsg := github.DefaultToolsetGroup(false, false, mockGetClient, mockGetGQLClient, mockGetRawClient, t)
 
 	// Generate toolsets documentation
 	toolsetsDoc := generateToolsetsDoc(tsg)
@@ -302,7 +302,7 @@ func generateRemoteToolsetsDoc() string {
 	t, _ := translations.TranslationHelper()
 
 	// Create toolset group with mock clients
-	tsg := github.DefaultToolsetGroup(false, mockGetClient, mockGetGQLClient, mockGetRawClient, t)
+	tsg := github.DefaultToolsetGroup(false, false, mockGetClient, mockGetGQLClient, mockGetRawClient, t)
 
 	// Generate table header
 	buf.WriteString("| Name           | Description                                      | API URL                                               | 1-Click Install (VS Code)                                                                                                                                                                                                 | Read-only Link                                                                                                 | 1-Click Read-only Install (VS Code)                                                                                                                                                                                                 |\n")

--- a/mcp/github-mcp-server/cmd/github-mcp-server/main.go
+++ b/mcp/github-mcp-server/cmd/github-mcp-server/main.go
@@ -45,13 +45,22 @@ var (
 				return fmt.Errorf("failed to unmarshal toolsets: %w", err)
 			}
 
+			readOnly := viper.GetBool("read-only")
+			writeOnly := viper.GetBool("write-only")
+			
+			// Validate that both flags are not set
+			if readOnly && writeOnly {
+				return errors.New("cannot set both --read-only and --write-only flags")
+			}
+			
 			stdioServerConfig := ghmcp.StdioServerConfig{
 				Version:              version,
 				Host:                 viper.GetString("host"),
 				Token:                token,
 				EnabledToolsets:      enabledToolsets,
 				DynamicToolsets:      viper.GetBool("dynamic_toolsets"),
-				ReadOnly:             viper.GetBool("read-only"),
+				ReadOnly:             readOnly,
+				WriteOnly:            writeOnly,
 				ExportTranslations:   viper.GetBool("export-translations"),
 				EnableCommandLogging: viper.GetBool("enable-command-logging"),
 				LogFilePath:          viper.GetString("log-file"),
@@ -71,6 +80,7 @@ func init() {
 	rootCmd.PersistentFlags().StringSlice("toolsets", github.DefaultTools, "An optional comma separated list of groups of tools to allow, defaults to enabling all")
 	rootCmd.PersistentFlags().Bool("dynamic-toolsets", false, "Enable dynamic toolsets")
 	rootCmd.PersistentFlags().Bool("read-only", false, "Restrict the server to read-only operations")
+	rootCmd.PersistentFlags().Bool("write-only", false, "Restrict the server to write-only operations (excludes read tools)")
 	rootCmd.PersistentFlags().String("log-file", "", "Path to log file")
 	rootCmd.PersistentFlags().Bool("enable-command-logging", false, "When enabled, the server will log all command requests and responses to the log file")
 	rootCmd.PersistentFlags().Bool("export-translations", false, "Save translations to a JSON file")
@@ -80,6 +90,7 @@ func init() {
 	_ = viper.BindPFlag("toolsets", rootCmd.PersistentFlags().Lookup("toolsets"))
 	_ = viper.BindPFlag("dynamic_toolsets", rootCmd.PersistentFlags().Lookup("dynamic-toolsets"))
 	_ = viper.BindPFlag("read-only", rootCmd.PersistentFlags().Lookup("read-only"))
+	_ = viper.BindPFlag("write-only", rootCmd.PersistentFlags().Lookup("write-only"))
 	_ = viper.BindPFlag("log-file", rootCmd.PersistentFlags().Lookup("log-file"))
 	_ = viper.BindPFlag("enable-command-logging", rootCmd.PersistentFlags().Lookup("enable-command-logging"))
 	_ = viper.BindPFlag("export-translations", rootCmd.PersistentFlags().Lookup("export-translations"))

--- a/mcp/github-mcp-server/internal/ghmcp/server.go
+++ b/mcp/github-mcp-server/internal/ghmcp/server.go
@@ -46,6 +46,9 @@ type MCPServerConfig struct {
 	// ReadOnly indicates if we should only offer read-only tools
 	ReadOnly bool
 
+	// WriteOnly indicates if we should only offer write-only tools (excluding read tools)
+	WriteOnly bool
+
 	// Translator provides translated text for the server tooling
 	Translator translations.TranslationHelperFunc
 }
@@ -134,7 +137,7 @@ func NewMCPServer(cfg MCPServerConfig) (*server.MCPServer, error) {
 	toolsets.SetToolHandlerRegistrar(github.RegisterToolHandler)
 
 	// Create default toolsets
-	tsg := github.DefaultToolsetGroup(cfg.ReadOnly, getClient, getGQLClient, getRawClient, cfg.Translator)
+	tsg := github.DefaultToolsetGroup(cfg.ReadOnly, cfg.WriteOnly, getClient, getGQLClient, getRawClient, cfg.Translator)
 	err = tsg.EnableToolsets(enabledToolsets)
 
 	if err != nil {
@@ -173,6 +176,9 @@ type StdioServerConfig struct {
 	// ReadOnly indicates if we should only register read-only tools
 	ReadOnly bool
 
+	// WriteOnly indicates if we should only register write-only tools (excluding read tools)
+	WriteOnly bool
+
 	// ExportTranslations indicates if we should export translations
 	// See: https://github.com/github/github-mcp-server?tab=readme-ov-file#i18n--overriding-descriptions
 	ExportTranslations bool
@@ -199,6 +205,7 @@ func RunStdioServer(cfg StdioServerConfig) error {
 		EnabledToolsets: cfg.EnabledToolsets,
 		DynamicToolsets: cfg.DynamicToolsets,
 		ReadOnly:        cfg.ReadOnly,
+		WriteOnly:       cfg.WriteOnly,
 		Translator:      t,
 	})
 	if err != nil {

--- a/mcp/github-mcp-server/pkg/github/tools.go
+++ b/mcp/github-mcp-server/pkg/github/tools.go
@@ -16,8 +16,8 @@ type GetGQLClientFn func(context.Context) (*githubv4.Client, error)
 
 var DefaultTools = []string{"all"}
 
-func DefaultToolsetGroup(readOnly bool, getClient GetClientFn, getGQLClient GetGQLClientFn, getRawClient raw.GetRawClientFn, t translations.TranslationHelperFunc) *toolsets.ToolsetGroup {
-	tsg := toolsets.NewToolsetGroup(readOnly)
+func DefaultToolsetGroup(readOnly bool, writeOnly bool, getClient GetClientFn, getGQLClient GetGQLClientFn, getRawClient raw.GetRawClientFn, t translations.TranslationHelperFunc) *toolsets.ToolsetGroup {
+	tsg := toolsets.NewToolsetGroup(readOnly, writeOnly)
 
 	// Define all available features with their default state (disabled)
 	// Create toolsets

--- a/mcp/github-mcp-write-wrapper.sh
+++ b/mcp/github-mcp-write-wrapper.sh
@@ -3,9 +3,9 @@
 # =========================================================
 # GITHUB MCP WRITE WRAPPER SCRIPT
 # =========================================================
-# PURPOSE: Runtime wrapper that executes the GitHub MCP server with full write access
+# PURPOSE: Runtime wrapper that executes the GitHub MCP server with write-only access
 # This script is called by the MCP system during normal operation
-# Runs without --read-only flag to enable all operations
+# Uses the --write-only flag to restrict to write operations only
 # =========================================================
 
 # Get the directory where this script is located
@@ -44,5 +44,5 @@ elif [[ -n "$GITHUB_TOKEN" ]] && [[ -z "$GITHUB_PERSONAL_ACCESS_TOKEN" ]]; then
   export GITHUB_PERSONAL_ACCESS_TOKEN="$GITHUB_TOKEN"
 fi
 
-# Run the server without read-only flag (full access)
-mcp_exec_with_logging "GITHUB-WRITE" "$SERVER_BIN" stdio "$@"
+# Run the server with write-only flag (only write operations)
+mcp_exec_with_logging "GITHUB-WRITE" "$SERVER_BIN" stdio --write-only "$@"


### PR DESCRIPTION
## Problem & Solution
**Problem**: Both `mcp__github-read` and `mcp__github-write` MCP servers expose the same read-only tools (like `get_issue`), causing confusion and redundancy
**Solution**: Implement a `--write-only` flag that restricts the github-write server to only expose write operations
**Keywords**: MCP duplicate tools, github-write read-only, tool separation, write-only mode

## Related Issues
Closes #665

## Technical Details
**Files changed**: 
- `mcp/github-mcp-server/cmd/github-mcp-server/main.go` - Added --write-only flag
- `mcp/github-mcp-server/internal/ghmcp/server.go` - Pass writeOnly through config
- `mcp/github-mcp-server/pkg/github/tools.go` - Accept writeOnly parameter
- `mcp/github-mcp-server/pkg/toolsets/toolsets.go` - Implement write-only logic in toolsets
- `mcp/github-mcp-write-wrapper.sh` - Use --write-only flag
- `mcp/github-mcp-server/README-SPLIT.md` - Document the new behavior

**Key modifications**: 
- Added `writeOnly` field to toolset configuration
- Modified `RegisterTools()` to skip read tools when in write-only mode
- Updated wrapper script to use the new flag
- Validation to prevent both --read-only and --write-only flags

**Alternative approaches considered**: 
- Removing specific tools manually (more brittle)
- Creating separate binaries (more complex)
- Configuration file approach (less explicit)

## Testing
Verified that:
- Server builds successfully with new flag
- `--write-only` flag appears in help output
- Cannot set both `--read-only` and `--write-only` flags simultaneously

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added/updated tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have updated the documentation accordingly (if applicable)