### PR TITLE
fix(mcp): remove invalid --write-only flag from github-write wrapper

### DIFF
--- a/mcp/github-mcp-write-wrapper.sh
+++ b/mcp/github-mcp-write-wrapper.sh
@@ -44,5 +44,6 @@ elif [[ -n "$GITHUB_TOKEN" ]] && [[ -z "$GITHUB_PERSONAL_ACCESS_TOKEN" ]]; then
   export GITHUB_PERSONAL_ACCESS_TOKEN="$GITHUB_TOKEN"
 fi
 
-# Run the server with write-only flag (only write operations)
-mcp_exec_with_logging "GITHUB-WRITE" "$SERVER_BIN" stdio --write-only "$@"
+# Run the server (full access - both read and write operations)
+# Note: The GitHub server doesn't have a --write-only flag, only --read-only
+mcp_exec_with_logging "GITHUB-WRITE" "$SERVER_BIN" stdio "$@"


### PR DESCRIPTION
## Summary
- Fixed github-write MCP server startup failure by removing unsupported `--write-only` flag
- The GitHub MCP server only supports `--read-only` flag, not `--write-only`
- Server now starts with full read/write access as intended

## Test plan
- [x] Verified github-write server starts successfully without the flag
- [x] Checked that GitHub MCP server help confirms no `--write-only` flag exists
- [x] Tested that github-write wrapper now executes without errors

Closes #668

🤖 Generated with [Claude Code](https://claude.ai/code)