### PR TITLE
fix(mcp): update GitLab env var to GITLAB_PERSONAL_ACCESS_TOKEN

### DIFF
--- a/.bash_secrets.example
+++ b/.bash_secrets.example
@@ -41,6 +41,11 @@
 # export ATLASSIAN_JIRA_USERNAME="your.email@domain.com"
 # export ATLASSIAN_JIRA_API_TOKEN="your_api_token"
 
+# ==== GITLAB CREDENTIALS ====
+# For GitLab MCP server integration
+# export GITLAB_URL="https://gitlab.example.com"
+# export GITLAB_PERSONAL_ACCESS_TOKEN="your_personal_access_token"
+
 # ==== GOOGLE MAPS API CREDENTIALS ====
 # Get API key from: https://developers.google.com/maps/documentation/javascript/get-api-key
 # export GOOGLE_MAPS_API_KEY="your_api_key"

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -23,7 +23,7 @@ This standardized approach makes it easy to add more MCP servers in the future f
 |-------------|-------------|----------------------|---------------------|---------------|-------------------|-------------------|
 | AWS Documentation | AWS documentation search | None required | PyPI packages via UVX | - | No | No |
 | GitHub | GitHub API integration | Uses GitHub CLI token | Custom setup script | [Our Fork](https://github.com/atxtechbro/github-mcp-server?tab=readme-ov-file#github-mcp-server) | No | Yes |
-| GitLab | GitLab API integration | PAT from `.bash_secrets` | Direct npx (no wrapper needed) | https://github.com/zereight/gitlab-mcp | No | No |
+| GitLab | GitLab API integration | `GITLAB_PERSONAL_ACCESS_TOKEN` from `.bash_secrets` | Direct npx (no wrapper needed) | https://github.com/zereight/gitlab-mcp | No | No |
 | Atlassian | Jira and Confluence integration | API tokens from `.bash_secrets` | Custom setup script | - | No | Yes |
 | Brave Search | Web search via Brave | API key from `.bash_secrets` | Docker container | - | No | Yes |
 | Filesystem | Local filesystem operations | None required | Built from source | [Our Fork](https://github.com/atxtechbro/mcp-servers/tree/main/src/filesystem#filesystem-mcp-server) | No | Yes |

--- a/mcp/gitlab-mcp-wrapper.sh
+++ b/mcp/gitlab-mcp-wrapper.sh
@@ -31,7 +31,7 @@ mcp_source_secrets "GITLAB"
 
 # Check if required GitLab environment variables are set
 mcp_check_env_var "GITLAB" "GITLAB_URL" "Add: export GITLAB_URL=\"https://gitlab.example.com\""
-mcp_check_env_var "GITLAB" "GITLAB_PAT" "Add: export GITLAB_PAT=\"your_personal_access_token\""
+mcp_check_env_var "GITLAB" "GITLAB_PERSONAL_ACCESS_TOKEN" "Add: export GITLAB_PERSONAL_ACCESS_TOKEN=\"your_personal_access_token\""
 
 # Pass through any environment variables from the MCP config
 export GITLAB_READ_ONLY_MODE="${GITLAB_READ_ONLY_MODE:-false}"


### PR DESCRIPTION
## Summary
- Update wrapper to check for GITLAB_PERSONAL_ACCESS_TOKEN instead of GITLAB_PAT
- Add GitLab section to .bash_secrets.example with correct var name  
- Update MCP README to specify exact env var name in table

## Details
This PR fixes the GitLab MCP environment variable mismatch where the wrapper expected `GITLAB_PAT` but the actual gitlab-mcp server requires `GITLAB_PERSONAL_ACCESS_TOKEN`. This caused confusion during setup when users would set the variable as instructed by the wrapper's error message, but the server would still fail.

### Changes made:
1. **gitlab-mcp-wrapper.sh**: Updated to check for `GITLAB_PERSONAL_ACCESS_TOKEN`
2. **.bash_secrets.example**: Added GitLab section with the correct variable names
3. **mcp/README.md**: Updated the table to specify the exact env var name

This ensures consistency between what the wrapper expects and what the gitlab-mcp server actually requires.

## Test plan
- [x] Updated wrapper script to check for correct env var
- [x] Tested that wrapper starts without env var errors when GITLAB_PERSONAL_ACCESS_TOKEN is set
- [x] Verified documentation is consistent across all files

Closes #670

🤖 Generated with [Claude Code](https://claude.ai/code)