### PR TITLE
fix(mcp): use personal-token params for self-hosted Atlassian

### DIFF
--- a/mcp/atlassian-mcp-wrapper.sh
+++ b/mcp/atlassian-mcp-wrapper.sh
@@ -45,7 +45,7 @@ mcp_check_env_var "ATLASSIAN" "ATLASSIAN_JIRA_API_TOKEN" "Add: export ATLASSIAN_
 mcp_exec_with_logging "ATLASSIAN" uvx mcp-atlassian \
   --confluence-url="$ATLASSIAN_CONFLUENCE_URL" \
   --confluence-username="$ATLASSIAN_CONFLUENCE_USERNAME" \
-  --confluence-token="$ATLASSIAN_CONFLUENCE_API_TOKEN" \
+  --confluence-personal-token="$ATLASSIAN_CONFLUENCE_API_TOKEN" \
   --jira-url="$ATLASSIAN_JIRA_URL" \
   --jira-username="$ATLASSIAN_JIRA_USERNAME" \
-  --jira-token="$ATLASSIAN_JIRA_API_TOKEN"
+  --jira-personal-token="$ATLASSIAN_JIRA_API_TOKEN"


### PR DESCRIPTION
## Summary
- Changed Atlassian MCP wrapper to use `--confluence-personal-token` and `--jira-personal-token`
- These are the correct parameters for self-hosted Atlassian instances (Server/Data Center)
- Previous parameters (`--confluence-token`, `--jira-token`) are for Cloud instances only

## Details
The mcp-atlassian tool supports different authentication parameters for Cloud vs self-hosted instances:
- Cloud: Uses `--confluence-token` and `--jira-token` with API tokens from Atlassian Cloud
- Self-hosted: Uses `--confluence-personal-token` and `--jira-personal-token` with Personal Access Tokens generated from within the instance

Our wrapper was using Cloud parameters, causing 401 authentication errors even with valid Personal Access Tokens from self-hosted instances.

## Test plan
- [x] Verified help output shows both parameter sets with correct descriptions
- [x] Checked syntax validity with `bash -n`
- [x] Confirmed the personal-token parameters are now in the wrapper script
- [x] The environment variable names remain unchanged for backward compatibility

Closes #672

🤖 Generated with [Claude Code](https://claude.ai/code)