### PR TITLE
fix(worktree): make setup.sh location-aware for MCP isolation

### DIFF
--- a/knowledge/procedures/worktree-workflow.md
+++ b/knowledge/procedures/worktree-workflow.md
@@ -8,7 +8,9 @@ Suppose you need to work on multiple tasks simultaneously with complete code iso
 2. Create worktree:
    - **New branch**: Use `mcp__git__git_worktree_add` with `create_branch: true`
    - **Existing branch**: Use `mcp__git__git_worktree_add` with branch name
-3. Work in worktree: Pass worktree path as `repo_path` to MCP tools (no `cd` needed!)
-4. Commit, push, create PR as normal
-5. Ask for any pr feedback and address if any
-6. Cleanup: Use `mcp__git__git_worktree_remove`
+3. Initialize worktree environment: `cd` into worktree and run `source setup.sh`
+   - This ensures PATH and environment are configured for the worktree context
+4. Work in worktree: Pass worktree path as `repo_path` to MCP tools (no `cd` needed!)
+5. Commit, push, create PR as normal
+6. Ask for any pr feedback and address if any
+7. Cleanup: Use `mcp__git__git_worktree_remove`

--- a/setup.sh
+++ b/setup.sh
@@ -35,15 +35,10 @@ fi
 # Add debug logging
 echo "Debug: Starting setup script in sourced mode"
 
-# Define the dotfiles directory - worktree aware
-# Check if we're in a git repository (including worktrees)
-if git rev-parse --git-common-dir >/dev/null 2>&1; then
-    # We're in a git repo, use its root
-    DOT_DEN="$(git rev-parse --show-toplevel)"
-else
-    # Fall back to known location
-    DOT_DEN="$HOME/ppv/pillars/dotfiles"
-fi
+# Determine dotfiles root relative to this script's location
+# Works from main repo OR worktrees - everything is relative to where you source from
+# This makes the system self-documenting: source from where you want to work
+DOT_DEN="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Export DOT_DEN as a global variable for other scripts to use
 export DOT_DEN
 


### PR DESCRIPTION
## Problem & Solution
**Problem**: MCP servers were always executed from the main dotfiles directory instead of worktree versions, breaking worktree isolation. When developing in worktrees, wrapper scripts were resolved via PATH which pointed to main repo.
**Solution**: Made setup.sh location-aware by dynamically resolving DOT_DEN from script location instead of hardcoded/git-based paths
**Keywords**: worktree, MCP, PATH resolution, DOT_DEN, wrapper scripts, isolation

## Related Issues
Closes #676

## Technical Details
**Files changed**: 
- `setup.sh` - Dynamic DOT_DEN resolution
- `knowledge/procedures/worktree-workflow.md` - Added source setup.sh step

**Key modifications**: 
- Replaced complex git-based DOT_DEN detection with simple script location resolution
- Added clear comment explaining the self-documenting approach
- Updated workflow to explicitly source setup.sh after creating worktree

**Alternative approaches considered**: 
- Git worktree detection (too complex)
- Wrapper script intelligence (would require updating all wrappers)
- Absolute paths in .mcp.json (less portable)

## Testing
Verified in fresh shell that:
1. DOT_DEN correctly resolves to worktree path
2. Worktree MCP directory is first in PATH
3. MCP wrappers will execute from worktree context

```bash
bash -c 'cd ~/ppv/pillars/dotfiles/worktrees/worktree-mcp-isolation-676 && source setup.sh > /dev/null 2>&1 && echo "DOT_DEN: $DOT_DEN"'
# Output: DOT_DEN: /Users/morgan.joyce/ppv/pillars/dotfiles/worktrees/worktree-mcp-isolation-676
```

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the documentation accordingly