### PR TITLE
fix(permissions): add specific patterns for find command to auto-approve

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,9 @@
   "permissions": {
     "allow": [
       "Bash(find:*)",
+      "Bash(find * | *)",
+      "Bash(find * -name * | *)",
+      "Bash(find * -type * | *)",
       "Bash(grep:*)",
       "Bash(locate:*)",
       "Bash(ls:*)",
@@ -46,6 +49,7 @@
       "Bash(./utils/configure-claude-code-settings.sh:*)",
       "Bash(check-mcp-logs:*)",
       "Bash(python:*)",
+      "Bash(find /home/linuxmint-lp/*)",
       
       "WebFetch(domain:docs.anthropic.com)"
     ]


### PR DESCRIPTION
<!-- 
AUDIENCE: Future AI agents searching for solutions to similar problems
FORMAT: Use keywords, exact error messages, and technical details they'll search for
-->

## Problem & Solution
**Problem**: Getting prompted for `find` command even though we have `"Bash(find:*)` in permissions. Exact prompt:
```
Bash command
  find /home/linuxmint-lp/ppv/pillars/dotfiles -name ".claude" -type d | head -20
  Find .claude directories in dotfiles repo

Do you want to proceed?
```

**Solution**: Added more specific patterns to handle find commands with options and piped commands
**Keywords**: find command, bash permissions, Claude Code, auto-approve, piped commands, permission prompts

## Related Issues
Closes #606

## Technical Details
**Files changed**: `.claude/settings.json`
**Key modifications**: 
- Added `"Bash(find * | *)"` - for piped find commands
- Added `"Bash(find * -name * | *)"` - for name searches with pipes
- Added `"Bash(find * -type * | *)"` - for type searches with pipes  
- Added `"Bash(find /home/linuxmint-lp/*)"` - for Linux-specific paths

**Alternative approaches considered**: 
- Initially had just `"Bash(find:*)"` but it wasn't matching piped commands
- Similar pattern as mkdir where we have both generic and specific patterns

## Testing
- The fix addresses the exact command shown in the issue
- Patterns follow the same approach as the working mkdir patterns
- Multiple specific patterns ensure various find command variations are covered

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added/updated tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have updated the documentation accordingly (if applicable)