### PR TITLE
feat(github-mcp): implement auto-approval for private repo operations

### DIFF
--- a/mcp/github-mcp-auto-wrapper.sh
+++ b/mcp/github-mcp-auto-wrapper.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# =========================================================
+# GITHUB MCP AUTO-APPROVAL WRAPPER SCRIPT
+# =========================================================
+# PURPOSE: Runtime wrapper that executes the GitHub MCP server with auto-approval enabled
+# This script enables auto-approval for operations on private repos owned by the authenticated user
+# =========================================================
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source MCP logging utilities
+source "$SCRIPT_DIR/utils/mcp-logging.sh"
+
+# Check if GitHub CLI is available
+mcp_check_command "GITHUB-AUTO" "gh" "Install GitHub CLI: brew install gh"
+
+# Get GitHub token from GitHub CLI
+TOKEN=$(gh auth token 2>/dev/null)
+
+# Check if token was retrieved successfully
+if [[ -z "$TOKEN" ]]; then
+  mcp_log_error "GITHUB-AUTO" "Failed to retrieve GitHub token" "Make sure you're logged in with: gh auth login"
+  exit 1
+fi
+
+# Export the token as an environment variable
+export GITHUB_PERSONAL_ACCESS_TOKEN="$TOKEN"
+
+# Path to the GitHub MCP server binary
+GITHUB_BINARY_PATH="$SCRIPT_DIR/servers/github"
+
+# Check if the binary exists and is executable
+if [[ ! -x "$GITHUB_BINARY_PATH" ]]; then
+  mcp_log_error "GITHUB-AUTO" "GitHub MCP server binary not found or not executable at $GITHUB_BINARY_PATH" "Run setup-github-mcp.sh to build the binary"
+  exit 1
+fi
+
+# Run the GitHub MCP server with auto-approval enabled
+mcp_exec_with_logging "GITHUB-AUTO" "$GITHUB_BINARY_PATH" stdio --auto-approval

--- a/mcp/github-mcp-server/cmd/github-mcp-server/generate_docs.go
+++ b/mcp/github-mcp-server/cmd/github-mcp-server/generate_docs.go
@@ -64,7 +64,7 @@ func generateReadmeDocs(readmePath string) error {
 	t, _ := translations.TranslationHelper()
 
 	// Create toolset group with mock clients
-	tsg := github.DefaultToolsetGroup(false, false, mockGetClient, mockGetGQLClient, mockGetRawClient, t)
+	tsg := github.DefaultToolsetGroup(false, false, mockGetClient, mockGetGQLClient, mockGetRawClient, t, nil)
 
 	// Generate toolsets documentation
 	toolsetsDoc := generateToolsetsDoc(tsg)
@@ -302,7 +302,7 @@ func generateRemoteToolsetsDoc() string {
 	t, _ := translations.TranslationHelper()
 
 	// Create toolset group with mock clients
-	tsg := github.DefaultToolsetGroup(false, false, mockGetClient, mockGetGQLClient, mockGetRawClient, t)
+	tsg := github.DefaultToolsetGroup(false, false, mockGetClient, mockGetGQLClient, mockGetRawClient, t, nil)
 
 	// Generate table header
 	buf.WriteString("| Name           | Description                                      | API URL                                               | 1-Click Install (VS Code)                                                                                                                                                                                                 | Read-only Link                                                                                                 | 1-Click Read-only Install (VS Code)                                                                                                                                                                                                 |\n")

--- a/mcp/github-mcp-server/cmd/github-mcp-server/main.go
+++ b/mcp/github-mcp-server/cmd/github-mcp-server/main.go
@@ -64,6 +64,7 @@ var (
 				ExportTranslations:   viper.GetBool("export-translations"),
 				EnableCommandLogging: viper.GetBool("enable-command-logging"),
 				LogFilePath:          viper.GetString("log-file"),
+				AutoApproval:         viper.GetBool("auto-approval"),
 			}
 			return ghmcp.RunStdioServer(stdioServerConfig)
 		},
@@ -85,6 +86,7 @@ func init() {
 	rootCmd.PersistentFlags().Bool("enable-command-logging", false, "When enabled, the server will log all command requests and responses to the log file")
 	rootCmd.PersistentFlags().Bool("export-translations", false, "Save translations to a JSON file")
 	rootCmd.PersistentFlags().String("gh-host", "", "Specify the GitHub hostname (for GitHub Enterprise etc.)")
+	rootCmd.PersistentFlags().Bool("auto-approval", false, "Enable auto-approval for operations on private repos owned by authenticated user")
 
 	// Bind flag to viper
 	_ = viper.BindPFlag("toolsets", rootCmd.PersistentFlags().Lookup("toolsets"))
@@ -95,6 +97,7 @@ func init() {
 	_ = viper.BindPFlag("enable-command-logging", rootCmd.PersistentFlags().Lookup("enable-command-logging"))
 	_ = viper.BindPFlag("export-translations", rootCmd.PersistentFlags().Lookup("export-translations"))
 	_ = viper.BindPFlag("host", rootCmd.PersistentFlags().Lookup("gh-host"))
+	_ = viper.BindPFlag("auto-approval", rootCmd.PersistentFlags().Lookup("auto-approval"))
 
 	// Add subcommands
 	rootCmd.AddCommand(stdioCmd)

--- a/mcp/github-mcp-server/pkg/github/auto_approval.go
+++ b/mcp/github-mcp-server/pkg/github/auto_approval.go
@@ -1,0 +1,144 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// AutoApprovalChecker manages auto-approval logic for GitHub operations
+type AutoApprovalChecker struct {
+	enabled           bool
+	authenticatedUser string
+	getClient         GetClientFn
+	mu                sync.RWMutex
+	initialized       bool
+}
+
+// NewAutoApprovalChecker creates a new auto-approval checker
+func NewAutoApprovalChecker(enabled bool, getClient GetClientFn) *AutoApprovalChecker {
+	return &AutoApprovalChecker{
+		enabled:   enabled,
+		getClient: getClient,
+	}
+}
+
+// Initialize fetches and caches the authenticated user
+func (a *AutoApprovalChecker) Initialize(ctx context.Context) error {
+	if !a.enabled {
+		return nil
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.initialized {
+		return nil
+	}
+
+	client, err := a.getClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get GitHub client: %w", err)
+	}
+
+	user, _, err := client.Users.Get(ctx, "")
+	if err != nil {
+		return fmt.Errorf("failed to get authenticated user: %w", err)
+	}
+
+	if user.Login == nil {
+		return fmt.Errorf("authenticated user has no login")
+	}
+
+	a.authenticatedUser = *user.Login
+	a.initialized = true
+	return nil
+}
+
+// CheckOperation checks if an operation should be auto-approved
+func (a *AutoApprovalChecker) CheckOperation(ctx context.Context, owner, repo string, operationType string) error {
+	if !a.enabled {
+		// Auto-approval is disabled, allow all operations
+		return nil
+	}
+
+	a.mu.RLock()
+	if !a.initialized {
+		a.mu.RUnlock()
+		// Initialize if not already done
+		if err := a.Initialize(ctx); err != nil {
+			return fmt.Errorf("failed to initialize auto-approval: %w", err)
+		}
+		a.mu.RLock()
+	}
+	authenticatedUser := a.authenticatedUser
+	a.mu.RUnlock()
+
+	// Check if the owner matches the authenticated user
+	if owner != authenticatedUser {
+		return fmt.Errorf("operation on repository not owned by authenticated user (%s) requires manual approval", authenticatedUser)
+	}
+
+	// Get repository details to check if it's private
+	client, err := a.getClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get GitHub client: %w", err)
+	}
+
+	repoDetails, _, err := client.Repositories.Get(ctx, owner, repo)
+	if err != nil {
+		return fmt.Errorf("failed to get repository details: %w", err)
+	}
+
+	// Check if repository is private
+	if repoDetails.Private == nil || !*repoDetails.Private {
+		return fmt.Errorf("operation on public repository requires manual approval for safety")
+	}
+
+	// Check for dangerous operations that always require approval
+	dangerousOps := map[string]bool{
+		"delete_repository":     true,
+		"make_public":          true,
+		"transfer_ownership":   true,
+		"force_push_main":      true,
+	}
+
+	if dangerousOps[operationType] {
+		return fmt.Errorf("operation '%s' always requires manual approval", operationType)
+	}
+
+	// All checks passed
+	return nil
+}
+
+// IsEnabled returns whether auto-approval is enabled
+func (a *AutoApprovalChecker) IsEnabled() bool {
+	return a.enabled
+}
+
+// WrapHandler wraps a tool handler with auto-approval checks
+func (a *AutoApprovalChecker) WrapHandler(operationType string, handler server.ToolHandlerFunc) server.ToolHandlerFunc {
+	if !a.enabled {
+		// Auto-approval is disabled, return the original handler
+		return handler
+	}
+
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		// Extract owner and repo from the request if available
+		owner, _ := RequiredParam[string](request, "owner")
+		repo, _ := RequiredParam[string](request, "repo")
+
+		// If we have owner and repo, check the operation
+		if owner != "" && repo != "" {
+			if err := a.CheckOperation(ctx, owner, repo, operationType); err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("Auto-approval check failed: %v", err)), nil
+			}
+		}
+
+		// All checks passed, execute the original handler
+		return handler(ctx, request)
+	}
+}

--- a/mcp/mcp.json
+++ b/mcp/mcp.json
@@ -17,6 +17,11 @@
       "args": [],
       "env": {}
     },
+    "github-auto": {
+      "command": "github-mcp-auto-wrapper.sh",
+      "args": [],
+      "env": {}
+    },
     "gitlab": {
       "command": "gitlab-mcp-wrapper.sh",
       "args": [],


### PR DESCRIPTION
## Problem & Solution
**Problem**: Agents request approval for every GitHub operation, creating friction and preventing focus on higher-level decisions (helicopter approval pattern).
**Solution**: Implement contextual auto-approval logic in GitHub MCP server that auto-approves operations on private repos owned by the authenticated user.
**Keywords**: auto-approval, OSE perspective, github mcp, private repo, authenticated user

## Related Issues
Closes #710

## Technical Details
**Files changed**: 
- `mcp/github-mcp-server/pkg/github/auto_approval.go` - New auto-approval checker
- `mcp/github-mcp-server/cmd/github-mcp-server/main.go` - Added --auto-approval flag
- `mcp/github-mcp-server/internal/ghmcp/server.go` - Initialize auto-approval checker
- `mcp/github-mcp-server/pkg/github/tools.go` - Wrap write tools with approval checks
- `mcp/github-mcp-auto-wrapper.sh` - New wrapper script for auto-approval mode
- `mcp/mcp.json` - Added github-auto server configuration

**Key modifications**: 
- Cache authenticated user with get_me() on startup
- Check repo ownership and privacy before operations
- Maintain manual approval for dangerous operations (delete repo, make public, etc.)
- Only wrap tools when --auto-approval flag is enabled

**Alternative approaches considered**: 
- Creating duplicate tools (rejected as too complex)
- Modifying MCP protocol (not possible from server side)

## Testing
- Built server successfully with new flag
- Verified --auto-approval flag appears in help
- Created test wrapper script
- Ready for integration testing with MCP client

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added/updated tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have updated the documentation accordingly (if applicable)