### PR TITLE
Fix MCP server compatibility with git worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,22 @@ The setup script automatically handles:
 
 Following the "Spilled Coffee Principle" - the setup script ensures you can be fully operational after running it once.
 
+### Parallel Development with Worktrees
+
+For working on multiple features simultaneously, we support git worktrees:
+
+```bash
+# Create a new worktree for your feature
+cd ~/ppv/pillars/dotfiles
+git worktree add -b feature/my-feature worktrees/feature/my-feature
+
+# Set up the worktree environment
+cd worktrees/feature/my-feature
+source setup.sh
+```
+
+Each worktree is self-contained with its own MCP servers, binaries, and dependencies. See [docs/worktree-development.md](docs/worktree-development.md) for detailed instructions.
+
 ## AI Provider Agnostic Context
 
 This repository automatically configures global context for multiple AI coding assistants from a single source of truth:

--- a/docs/worktree-development.md
+++ b/docs/worktree-development.md
@@ -1,0 +1,111 @@
+# Worktree Development Guide
+
+This guide explains how to use git worktrees for parallel development in the dotfiles repository.
+
+## Why Use Worktrees?
+
+Git worktrees allow you to have multiple branches checked out simultaneously in different directories. This is perfect for:
+- Working on multiple features in parallel
+- Testing changes in isolation
+- Keeping your main repo clean while experimenting
+
+## Creating a Worktree
+
+```bash
+# From the main dotfiles directory
+cd ~/ppv/pillars/dotfiles
+
+# Create a new worktree with a new branch
+git worktree add -b feature/my-feature worktrees/feature/my-feature
+
+# Or use an existing branch
+git worktree add worktrees/fix/existing-fix fix/existing-fix
+```
+
+## Setting Up the Worktree Environment
+
+**IMPORTANT**: Each worktree needs its own environment setup to work properly.
+
+```bash
+# Navigate to your worktree
+cd ~/ppv/pillars/dotfiles/worktrees/feature/my-feature
+
+# Source setup.sh from the worktree directory
+source setup.sh
+```
+
+This will:
+- Set `DOT_DEN` to the worktree directory
+- Add the worktree's MCP directories to PATH
+- Install all MCP server dependencies locally in the worktree
+- Build/copy all necessary binaries to the worktree
+
+## MCP Servers in Worktrees
+
+The setup process ensures all MCP servers work correctly in worktrees by:
+
+1. **Building binaries locally**: GitHub MCP server binary is built in `worktree/mcp/servers/github`
+2. **Creating Python venvs**: Git MCP server venv is created at `worktree/mcp/servers/git-mcp-server/.venv`
+3. **Installing npm packages**: Filesystem MCP dependencies installed in `worktree/mcp/servers/filesystem-mcp-server/node_modules`
+4. **Generating configs**: MCP configurations are generated for the worktree path
+
+## Working with MCP in Worktrees
+
+After setup, all MCP servers should work normally:
+
+```bash
+# Test GitHub MCP server
+echo '{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2024-11-05", "capabilities": {}, "clientInfo": {"name": "test", "version": "1.0"}}}' | github-mcp-wrapper.sh
+
+# The wrapper scripts use relative paths, so they find the worktree's binaries
+```
+
+## Common Issues and Solutions
+
+### Issue: MCP servers fail with "binary not found"
+**Solution**: Run `source setup.sh` from the worktree directory to build/install dependencies
+
+### Issue: Python venv not found for git-mcp-server
+**Solution**: The setup script should create it. If not, run:
+```bash
+cd mcp/servers/git-mcp-server
+python -m venv .venv
+.venv/bin/pip install -e .
+```
+
+### Issue: npm packages not found
+**Solution**: The setup script should install them. If not, run:
+```bash
+cd mcp/servers/filesystem-mcp-server
+npm install
+```
+
+## Cleaning Up Worktrees
+
+When you're done with a worktree:
+
+```bash
+# From anywhere
+git worktree remove ~/ppv/pillars/dotfiles/worktrees/feature/my-feature
+
+# Or force remove if there are uncommitted changes
+git worktree remove -f ~/ppv/pillars/dotfiles/worktrees/feature/my-feature
+```
+
+## Best Practices
+
+1. **Always source setup.sh** from the worktree directory after creating it
+2. **Keep worktrees organized** in the `worktrees/` subdirectory
+3. **Name worktrees after their branch** for easy identification
+4. **Clean up worktrees** when done to save disk space
+5. **Don't share binaries** between worktrees - each should be self-contained
+
+## Technical Details
+
+The setup works because:
+- `DOT_DEN` is set to the directory where setup.sh is sourced from
+- All scripts use `$DOT_DEN` or relative paths from their location
+- MCP wrapper scripts resolve paths relative to their own location
+- Each worktree gets its own complete set of dependencies
+
+This follows the "Spilled Coffee Principle" - if your laptop dies, you can recreate any worktree by just running `source setup.sh` from it.

--- a/mcp/setup-all-mcp-servers.sh
+++ b/mcp/setup-all-mcp-servers.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# Setup all MCP servers with worktree support
+# This script ensures all MCP servers are properly initialized
+# whether running from main repo or a worktree
+
+set -euo pipefail
+
+# Colors for output
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+# Get script directory (works in worktrees)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MCP_DIR="$SCRIPT_DIR"
+REPO_ROOT="$(dirname "$MCP_DIR")"
+
+echo -e "${GREEN}Setting up all MCP servers...${NC}"
+echo "Working directory: $REPO_ROOT"
+
+# Detect if we're in a worktree
+if git rev-parse --git-common-dir >/dev/null 2>&1; then
+    GIT_COMMON_DIR=$(git rev-parse --git-common-dir)
+    GIT_DIR=$(git rev-parse --git-dir)
+    if [ "$GIT_COMMON_DIR" != "$GIT_DIR" ]; then
+        echo -e "${YELLOW}Detected git worktree - ensuring local setup${NC}"
+        IS_WORKTREE=true
+    else
+        IS_WORKTREE=false
+    fi
+else
+    IS_WORKTREE=false
+fi
+
+# Run individual setup scripts
+setup_scripts=(
+    "setup-github-mcp.sh"
+    "setup-git-mcp.sh"
+    "setup-filesystem-mcp.sh"
+    "setup-brave-search-mcp.sh"
+    "setup-gdrive-mcp.sh"
+)
+
+failed_setups=()
+
+for script in "${setup_scripts[@]}"; do
+    if [ -f "$MCP_DIR/$script" ]; then
+        echo -e "\n${GREEN}Running $script...${NC}"
+        if ! "$MCP_DIR/$script"; then
+            echo -e "${RED}Failed to run $script${NC}"
+            failed_setups+=("$script")
+        fi
+    else
+        echo -e "${YELLOW}Warning: $script not found${NC}"
+    fi
+done
+
+# Generate MCP configuration for all clients
+if [ -f "$MCP_DIR/generate-mcp-config.sh" ]; then
+    echo -e "\n${GREEN}Generating MCP configurations...${NC}"
+    "$MCP_DIR/generate-mcp-config.sh"
+else
+    echo -e "${YELLOW}Warning: generate-mcp-config.sh not found${NC}"
+fi
+
+# Create servers directory if it doesn't exist
+mkdir -p "$MCP_DIR/servers"
+
+# Summary
+echo -e "\n${GREEN}MCP Server Setup Summary:${NC}"
+echo "- Working directory: $REPO_ROOT"
+echo "- Is worktree: $IS_WORKTREE"
+echo "- MCP directory: $MCP_DIR"
+echo "- Servers directory: $MCP_DIR/servers"
+
+if [ ${#failed_setups[@]} -gt 0 ]; then
+    echo -e "\n${RED}Failed setups:${NC}"
+    for failed in "${failed_setups[@]}"; do
+        echo "  - $failed"
+    done
+    echo -e "\n${YELLOW}Some servers may not work properly. Please check the errors above.${NC}"
+else
+    echo -e "\n${GREEN}All MCP servers set up successfully!${NC}"
+fi
+
+# Verify critical binaries exist
+echo -e "\n${GREEN}Verifying server binaries:${NC}"
+binaries=(
+    "servers/github"
+    "servers/git-mcp-server/.venv/bin/python"
+    "servers/filesystem-mcp-server/node_modules/.bin/filesystem-server"
+)
+
+for binary in "${binaries[@]}"; do
+    if [ -e "$MCP_DIR/$binary" ]; then
+        echo -e "  ✓ $binary"
+    else
+        echo -e "  ${RED}✗ $binary${NC}"
+    fi
+done

--- a/setup.sh
+++ b/setup.sh
@@ -246,6 +246,15 @@ else
   echo -e "${YELLOW}Vendor-agnostic MCP setup script not found. Skipping MCP configuration setup.${NC}"
 fi
 
+# Set up all MCP servers (works in worktrees)
+if [[ -f "$DOT_DEN/mcp/setup-all-mcp-servers.sh" ]]; then
+  echo -e "${DIVIDER}"
+  echo "Setting up MCP servers..."
+  "$DOT_DEN/mcp/setup-all-mcp-servers.sh"
+else
+  echo -e "${YELLOW}MCP server setup script not found. Skipping MCP server setup.${NC}"
+fi
+
 # Generate AI provider commands from templates
 if [[ -f "$DOT_DEN/utils/generate-commands.sh" ]]; then
   echo "Generating AI provider commands from templates..."


### PR DESCRIPTION
## Summary
- Add comprehensive worktree support for MCP servers
- Ensure all dependencies are installed locally in each worktree
- Document proper worktree setup procedures

## Problem
MCP servers were failing in git worktrees with various errors:
- GitHub MCP: Segmentation faults
- Git MCP: Python venv not found
- Filesystem MCP: npm packages missing

Root cause: The setup process wasn't being run in worktrees, leaving them without proper dependencies.

## Solution
1. Created `setup-all-mcp-servers.sh` to handle all MCP server initialization
2. Integrated it into `setup.sh` so it runs automatically
3. Added comprehensive documentation for worktree usage
4. Each worktree now gets its own complete environment

## Test Plan
- [x] Create a new worktree
- [x] Run `source setup.sh` from the worktree
- [x] Verify all MCP servers work correctly
- [x] Test that binaries are built locally
- [x] Confirm Python venvs are created
- [x] Check npm packages are installed

Fixes #717

🤖 Generated with [Claude Code](https://claude.ai/code)