### PR TITLE
feat: unify TDD principles under enhanced tracer-bullets

### DIFF
--- a/commands/README.md
+++ b/commands/README.md
@@ -1,0 +1,43 @@
+# Provider-Agnostic Commands
+
+This directory contains command templates that work across multiple AI providers (Claude, Amazon Q, etc.) without duplication.
+
+## Structure
+
+```
+commands/
+├── README.md          # This file
+└── templates/         # Provider-agnostic command templates
+    ├── close-issue.md
+    ├── retro.md
+    └── ...
+```
+
+## How It Works
+
+1. **Templates live here**: All command templates are stored in `commands/templates/`
+2. **Providers symlink**: Each AI provider creates symlinks to these templates:
+   - Claude: `.claude/command-templates` → `commands/templates`
+   - Amazon Q: `.amazonq/commands` → `commands/templates` (if/when supported)
+3. **Single source of truth**: Edit files in `commands/templates/`, changes apply everywhere
+
+## Important Notes
+
+- **Always edit the actual template files** in `commands/templates/`
+- **Never edit via symlinks** (e.g., `.claude/command-templates/`)
+- Symlinks are created automatically by `setup.sh`
+
+## Adding New Commands
+
+1. Create your template in `commands/templates/your-command.md`
+2. Use the `{{ INJECT:path/to/file.md }}` syntax for dynamic content
+3. Run `utils/generate-claude-commands.sh` to generate provider-specific versions
+
+## Why This Architecture?
+
+- **DRY Principle**: Write once, use everywhere
+- **Provider flexibility**: Easy to add new AI providers
+- **Consistent experience**: Same commands work across all tools
+- **Maintainability**: Single place to update commands
+
+This approach follows our Versioning Mindset - evolve the system rather than duplicate it.

--- a/commands/templates/close-issue.md
+++ b/commands/templates/close-issue.md
@@ -1,6 +1,6 @@
 Complete and implement GitHub issue #{{ ISSUE_NUMBER }}.
 
-## Core Principles
+## Core Principle: Target-First Development
 {{ INJECT:principles/tracer-bullets.md }}
 
 ## Step 1: Analyze the Issue
@@ -28,10 +28,25 @@ Apply to issue #{{ ISSUE_NUMBER }}:
 - Replace <description> with issue title slug
 
 ### 2. Implement Solution
-- Use TodoWrite to track implementation tasks
-- Follow existing patterns in codebase
-- Test changes as you go
-- Run lint/typecheck if available
+Apply tracer bullets methodology:
+
+**First, establish your target:**
+- Define clear success criteria for the issue resolution
+- Understand what failure looks like (how to detect when it's NOT fixed)
+- Create verification methods (tests, checks, validations) that can detect hits/misses
+
+**Then iterate with tracer rounds:**
+- Fire and miss: See verifications fail (confirms target detection works)
+- Adjust aim: Modify implementation while keeping target stable
+- Fire again: Run verifications to check progress
+- Use TodoWrite to track verified hits on target
+- Each commit is a confirmed hit - only commit code that moves toward the target
+
+**Natural behaviors that emerge:**
+- Test-first development (you need a target before you can aim)
+- Incremental progress through verified steps
+- Progressive refinement from rough to precise shots
+- Clear trajectory visible through commit history
 
 {{ INJECT:procedures/git-workflow.md }}
 

--- a/knowledge/principles/tracer-bullets.md
+++ b/knowledge/principles/tracer-bullets.md
@@ -1,13 +1,34 @@
 # Tracer Bullets Development
 
-Like military tracer rounds that help soldiers adjust their aim in real-time, each iteration provides immediate feedback to guide the next action.
+Like military tracer rounds that help soldiers adjust their aim in real-time, each iteration provides immediate feedback to guide the next action. But first, you need a target.
 
+## Establishing the Target
+Before firing any rounds, define what you're aiming at:
+- **Clear success criteria**: What does "hitting the target" look like? (tests, expected outputs, acceptance criteria)
+- **Negative space mapping**: Understanding what failure looks like helps define the target's boundaries
+- **Measurable outcomes**: Targets must be observable - you need to know when you've hit or missed
+
+## Iterative Targeting
+Once you have a target, use tracer rounds to zero in:
 - **Ground truth at each step**: Gain concrete feedback from the environment (tool results, code execution, system responses)
 - **Progress assessment**: Each cycle/loop/iteration should feel like getting closer to the target
-- **Human checkpoint pauses**: Stop for feedback when encountering blockers or at natural decision points
+- **Adjust aim, not target**: Keep success criteria stable while refining your approach
+- **Walk fire onto target**: Start with rough attempts, progressively refine precision
+
+## Feedback Mechanisms
 - **Commit early and often**: Each commit is a tracer round showing trajectory
 - **Short feedback loops over long planning**: Rapid iteration beats extensive upfront design
-- **Stopping conditions**: Maintain control with maximum iterations or clear completion criteria
+- **Human checkpoint pauses**: Stop for feedback when encountering blockers or at natural decision points
 - **AI-human feedback loop**: Core to this approach - neither operates in isolation
+- **Stopping conditions**: Maintain control with maximum iterations or clear completion criteria
 
-This principle enables effective development in unfamiliar territory by providing constant course correction through environmental feedback.
+## Target-First Development
+This principle naturally leads to test-driven behaviors:
+1. Define the target (write the test/criteria)
+2. Fire and miss (see it fail - confirms target detection works)
+3. Adjust aim (modify implementation)
+4. Fire again (run test)
+5. Repeat until you hit (test passes)
+6. Confirm stability (multiple hits = reliable solution)
+
+This principle enables effective development in unfamiliar territory by providing constant course correction through environmental feedback - but it all starts with having a clear target to aim at.


### PR DESCRIPTION
## Summary
Unifies TDD principles under an enhanced tracer-bullets principle, following our Versioning Mindset to evolve existing systems rather than create parallel ones.

## Key Insight
The five TDD principles from PR #721 are actually aspects of effective "target acquisition" for our tracer bullets:
- **Verifiable Intent** = Set up a clear target
- **Failure-First** = Fire where target ISN'T to map boundaries
- **Incremental Certainty** = Each hit becomes a waypoint
- **Isolated Iteration** = Adjust aim, not target position
- **Progressive Refinement** = Walk fire onto precise targets

## Changes
1. **Enhanced `tracer-bullets.md`** with comprehensive target-first approach
2. **Updated `/close-issue`** command to use unified methodology
3. **Added `commands/README.md`** documenting provider-agnostic command structure

## Benefits
- **Cleaner mental model**: One metaphor covers the complete cycle
- **Natural TDD emergence**: Target-first naturally leads to test-first
- **Reduced complexity**: Fewer principles, more power
- **Provider clarity**: Clear docs on where commands actually live

## Test Plan
- [ ] Generate commands with `utils/generate-claude-commands.sh`
- [ ] Verify `/close-issue` works with new approach
- [ ] Confirm symlinks still function correctly

Related to: #721 (closed in favor of this unified approach)

Principle: versioning-mindset
Principle: subtraction-creates-value
Principle: tracer-bullets