### PR TITLE
fix(git): remove hardcoded gh path for cross-platform compatibility

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -30,7 +30,6 @@
 [includeIf "gitdir:~/ppv/pillars/Flywire/"]
 		path=~/.gitconfig-work
 [credential "https://github.com"]
-		helper = !/usr/bin/gh auth git-credential
+		helper = !gh auth git-credential
 [credential "https://gist.github.com"]
-        helper = !/usr/bin/gh auth git-credential
-
+		helper = !gh auth git-credential


### PR DESCRIPTION
<!-- 
AUDIENCE: Future AI agents searching for solutions to similar problems
FORMAT: Use keywords, exact error messages, and technical details they'll search for
-->

## Problem & Solution
**Problem**: Git push fails with error: `/usr/bin/gh: No such file or directory` on Apple Silicon Macs where gh is installed at `/opt/homebrew/bin/gh`. The `.gitconfig` has hardcoded paths that don't work across different installations.

**Solution**: Remove the hardcoded path `/usr/bin/gh` and let the shell resolve `gh` from PATH. Changed credential helper from `!/usr/bin/gh auth git-credential` to `!gh auth git-credential`.

**Keywords**: git credential helper, gh not found, Apple Silicon, M1, M2, M3, homebrew path, /usr/bin/gh, /opt/homebrew/bin/gh, git push error

## Related Issues
Closes #723

## Technical Details
**Files changed**: `.gitconfig`
**Key modifications**: 
- Line 33: `helper = !/usr/bin/gh auth git-credential` → `helper = !gh auth git-credential`
- Line 35: `helper = !/usr/bin/gh auth git-credential` → `helper = !gh auth git-credential`
- Also fixed inconsistent indentation (spaces to tabs) on line 35

**Alternative approaches considered**: 
- Using `command -v gh` to dynamically find gh location - rejected as unnecessarily complex
- Creating platform-specific gitconfig files - rejected as it adds maintenance burden

## Testing
- Verified `which gh` returns `/opt/homebrew/bin/gh` on Apple Silicon Mac
- Confirmed git credential helper config now uses PATH resolution
- Tested that setup.sh copies the corrected .gitconfig

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have tested the fix on Apple Silicon Mac
- [x] No documentation updates needed (configuration file change only)

Principle: invent-and-simplify