### PR TITLE
fix(github-mcp): prevent nil pointer dereference on server startup

### DIFF
--- a/mcp/github-mcp-server/pkg/github/tools.go
+++ b/mcp/github-mcp-server/pkg/github/tools.go
@@ -146,7 +146,7 @@ func DefaultToolsetGroup(readOnly bool, writeOnly bool, getClient GetClientFn, g
 
 	// Add batch toolset for chained operations
 	batch := toolsets.NewToolset("batch", "Batch execution of multiple GitHub operations").
-		AddReadTools(
+		AddWriteTools(
 			toolsets.NewServerTool(GitHubBatch(getClient, getGQLClient, getRawClient, t)),
 		)
 

--- a/mcp/github-mcp-server/pkg/toolsets/toolsets.go
+++ b/mcp/github-mcp-server/pkg/toolsets/toolsets.go
@@ -204,7 +204,7 @@ func (t *Toolset) AddWriteTools(tools ...server.ServerTool) *Toolset {
 
 func (t *Toolset) AddReadTools(tools ...server.ServerTool) *Toolset {
 	for _, tool := range tools {
-		if !*tool.Tool.Annotations.ReadOnlyHint {
+		if tool.Tool.Annotations.ReadOnlyHint == nil || !*tool.Tool.Annotations.ReadOnlyHint {
 			panic(fmt.Sprintf("tool (%s) must be annotated as read-only", tool.Tool.Name))
 		}
 	}


### PR DESCRIPTION
<!-- 
AUDIENCE: Future AI agents searching for solutions to similar problems
FORMAT: Use keywords, exact error messages, and technical details they'll search for
-->

## Problem & Solution
**Problem**: GitHub MCP server crashes immediately on startup with nil pointer dereference:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x104890200]

goroutine 1 [running]:
github.com/github/github-mcp-server/pkg/toolsets.(*Toolset).AddReadTools(0x10499d9b8?, {0x14000036a18?, 0x1049b7fcf?, 0x2c?})
	/Users/morgan.joyce/ppv/pillars/dotfiles/mcp/github-mcp-server/pkg/toolsets/toolsets.go:207 +0x60
```

**Solution**: 
1. Add nil check for ReadOnlyHint in AddReadTools method
2. Move github_batch from read tools to write tools (it performs mutations)

**Keywords**: github mcp server crash, nil pointer dereference, SIGSEGV, AddReadTools panic, ReadOnlyHint nil, github_batch tool

## Related Issues
Closes #722

## Technical Details
**Files changed**: 
- `mcp/github-mcp-server/pkg/toolsets/toolsets.go`
- `mcp/github-mcp-server/pkg/github/tools.go`

**Key modifications**: 
1. **toolsets.go line 207**: Added nil check: `if tool.Tool.Annotations.ReadOnlyHint == nil || !*tool.Tool.Annotations.ReadOnlyHint`
2. **tools.go line 149**: Moved GitHubBatch from `AddReadTools` to `AddWriteTools`

**Alternative approaches considered**: 
- Setting default values for ReadOnlyHint - rejected as it masks the real issue
- Removing the panic entirely - rejected as it's important to catch miscategorized tools

## Testing
- Server now starts without panicking
- Both read and write tool modes function correctly
- github_batch tool properly categorized as write operation

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] The fix addresses the root cause, not just symptoms
- [x] No documentation updates needed (internal fix only)

Principle: tracer-bullets