### PR TITLE
fix[github-mcp]: add missing nil check in AddWriteTools method

### DIFF
--- a/mcp/github-mcp-server/pkg/toolsets/toolsets.go
+++ b/mcp/github-mcp-server/pkg/toolsets/toolsets.go
@@ -192,7 +192,7 @@ func (t *Toolset) SetWriteOnly() {
 func (t *Toolset) AddWriteTools(tools ...server.ServerTool) *Toolset {
 	// Silently ignore if the toolset is read-only to avoid any breach of that contract
 	for _, tool := range tools {
-		if *tool.Tool.Annotations.ReadOnlyHint {
+		if tool.Tool.Annotations.ReadOnlyHint != nil && *tool.Tool.Annotations.ReadOnlyHint {
 			panic(fmt.Sprintf("tool (%s) is incorrectly annotated as read-only", tool.Tool.Name))
 		}
 	}


### PR DESCRIPTION
The previous fix only added the nil check to AddReadTools but missed
AddWriteTools, causing the server to still crash with nil pointer
dereference when write tools were being added.

This completes the fix from commit 83b174b1 by adding the same nil
check to AddWriteTools method.

Principle: tracer-bullets