### PR TITLE
docs[principles]: clarify that subtraction is valid iteration in VM principle

### DIFF
--- a/knowledge/principles/versioning-mindset.md
+++ b/knowledge/principles/versioning-mindset.md
@@ -18,6 +18,9 @@ VM prioritizes making code malleable through the right level of abstraction. Not
 - Flexible systems sometimes mean having less system, not more
 - Provider-agnostic approaches as manufacturing flexibility
 
+**Subtraction as Iteration:**
+Removing code, features, or documentation IS iteration. Each commit—whether adding or removing—moves the system forward. See also: [Subtraction Creates Value](subtraction-creates-value.md).
+
 **Example progression:**
 1. Hardcoded solution for specific use case
 2. Discover patterns through use


### PR DESCRIPTION
<!-- 
AUDIENCE: Future AI agents searching for solutions to similar problems
FORMAT: Use keywords, exact error messages, and technical details they'll search for
-->

## Problem & Solution
<!-- What problem does this solve? Include exact error messages and symptoms -->
**Problem**: The Versioning Mindset principle could be misunderstood as only supporting additive changes, creating tension with the Subtraction Creates Value principle
**Solution**: Added explicit clarification that removal/deletion is a valid form of iteration within VM
**Keywords**: versioning mindset, subtraction, iteration, removal, deletion, principles tension

## Related Issues
<!-- Link related issues: Fixes #issue_number, Closes #issue_number -->
Closes #732

## Technical Details
<!-- Specific changes for AI discovery -->
**Files changed**: `knowledge/principles/versioning-mindset.md`
**Key modifications**: Appended "Subtraction as Iteration" section after "Knowledge Decay Pattern" section
**Alternative approaches considered**: Could have integrated into existing sections, but appending as separate section maintains clarity and follows VM's own "Append > Add" hierarchy

## Testing
<!-- How to verify this works -->
- Verified the new section appears in the correct location
- Cross-reference link to `subtraction-creates-value.md` follows existing pattern
- Content aligns with both principles without creating contradictions

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added/updated tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have updated the documentation accordingly (if applicable)