### PR TITLE
fix[mcp]: export GITLAB_API_URL for GitLab MCP server authentication

### DIFF
--- a/mcp/gitlab-mcp-wrapper.sh
+++ b/mcp/gitlab-mcp-wrapper.sh
@@ -34,6 +34,7 @@ mcp_check_env_var "GITLAB" "GITLAB_URL" "Add: export GITLAB_URL=\"https://gitlab
 mcp_check_env_var "GITLAB" "GITLAB_PERSONAL_ACCESS_TOKEN" "Add: export GITLAB_PERSONAL_ACCESS_TOKEN=\"your_personal_access_token\""
 
 # Pass through any environment variables from the MCP config
+export GITLAB_API_URL="${GITLAB_URL}/api/v4"
 export GITLAB_READ_ONLY_MODE="${GITLAB_READ_ONLY_MODE:-false}"
 export USE_GITLAB_WIKI="${USE_GITLAB_WIKI:-true}"
 export USE_MILESTONE="${USE_MILESTONE:-true}"


### PR DESCRIPTION
## Summary
- Fixed GitLab MCP server authentication by exporting `GITLAB_API_URL` environment variable
- The server was defaulting to gitlab.com instead of using configured GitLab instances

## Details
The GitLab MCP server expects `GITLAB_API_URL` to be set, but our wrapper was only checking for `GITLAB_URL`. Added export to properly set the API URL:
```bash
export GITLAB_API_URL="${GITLAB_URL}/api/v4"
```

## Test plan
- [x] Tested with self-hosted GitLab instance
- [x] Verified authentication works after restart
- [x] Confirmed repository search returns results

Closes #737

🤖 Generated with [Claude Code](https://claude.ai/code)