### PR TITLE
docs(procedures): Embed principle references in git-workflow.md

### DIFF
--- a/knowledge/procedures/git-workflow.md
+++ b/knowledge/procedures/git-workflow.md
@@ -1,14 +1,16 @@
 # Git Workflow Rules
 
 ## MCP Git Tools Usage
+**[Principle: systems-stewardship]** - Standardized tools create consistent, maintainable workflows
 **IMPORTANT**: Use `mcp__git__*` tools instead of bash commands.
 - **Chain Commands**: Use `mcp__git__git_batch` to combine multiple git operations efficiently
 
 ## Commit Standards
+**[Principle: tracer-bullets]** - Each commit is a tracer round showing trajectory toward the target
 - Always use conventional commit syntax: `<type>[scope]: description` (scope optional but encouraged; use separate `-m` for trailers)
 - Good scope choices add context about what component is being modified (e.g., api, ui, auth, config, docs)
 - Use `Principle: <slug>` trailer when work resonates with a specific principle (e.g., `Principle: subtraction-creates-value`, `Principle: versioning-mindset`, `Principle: systems-stewardship`)
-- Commit early and often with meaningful changes
+- **[Principle: versioning-mindset]** - Commit early and often with meaningful changes (history enables iteration)
 
 ## Branch Management
 
@@ -17,14 +19,17 @@
 **Go slow to go fast**: The recovery tax compounds invisibly. A stale starting point pollutes every subsequent action - your PR carries ghost commits, review gets clouded by unintended diffs, context windows fill with noise. The principle isn't about git mechanics but about preserving clarity of intent. When we rush past orientation, we mortgage our future attention.
 
 ### Quick orientation checks (prevent future cleanup)
+**[Principle: go-slow-to-go-fast]** - The recovery tax compounds invisibly when we skip orientation
 1. `mcp__git__git_status` - Where am I? What's already changed?
 2. Check current branch - Am I on main? Do I have uncommitted work?
-3. **Is main current?** - `git fetch && git status` - Behind origin/main means your PR will include unwanted commits
+3. **Is main current?** - `git fetch && git status`
+   **[Principle: subtraction-creates-value]** - Behind origin/main means your PR will include unwanted commits
 4. If changes exist on main - commit them properly or stash before branching
 
 Starting from a stale foundation guarantees the recovery tax - double work to achieve what orientation would have prevented.
 
 ### Standards (not methods)
+**[Principle: systems-stewardship]** - Consistent naming makes intent visible across the team
 - Branch naming: `type/description` (e.g., `feature/add-authentication`, `fix/login-bug`)
 - Issue suffix: `type/description-123` (e.g., `feature/add-authentication-512`)
 - Order: Check surroundings → create branch → switch → work → commit
@@ -35,6 +40,7 @@ These standards make intent visible and prevent the recovery tax.
 - Don't thank self when closing your own PRs
 
 ## Directory to Symlink Conversions
+**[Principle: go-slow-to-go-fast]** - Rushing this operation creates git tree corruption requiring complex recovery
 When converting a directory to a symlink (or vice versa), it's safer to use different names or do it in separate commits to avoid git tree corruption.
 
 **Why**: Git can create invalid tree objects when the same path transitions from directory to symlink within a single commit, causing push failures with "duplicateEntries" errors.


### PR DESCRIPTION
## Summary
Pilot implementation of embedding principle references directly in procedures to reinforce WHY each step matters at the point of use.

## Changes
Added **[Principle: name]** tags with contextual explanations at key decision points in git-workflow.md:
- MCP Git Tools Usage → systems-stewardship (standardized tools)
- Commit Standards → tracer-bullets (commits as trajectory) & versioning-mindset (history enables iteration)
- Quick orientation checks → go-slow-to-go-fast (recovery tax) & subtraction-creates-value (avoid unwanted commits)
- Standards section → systems-stewardship (consistent naming)
- Directory to Symlink Conversions → go-slow-to-go-fast (avoid corruption)

## Motivation
During retro on lifehacking#106, discovered that knowing principles doesn't guarantee following them. By embedding principles at decision points, we make the "why" visible when it matters most.

## Implementation Approach
- Started with git-workflow.md as tracer bullet pilot
- Can expand pattern to other procedures based on feedback
- Format: **[Principle: name]** - brief contextual reason

## Test Plan
- [x] Principles appear at relevant decision points
- [x] Each includes context for why it applies HERE
- [x] Format is consistent and scannable
- [ ] Get feedback on effectiveness before expanding

Closes #741

## Principles Applied
- **Tracer Bullets**: Testing pattern on one procedure first
- **Versioning Mindset**: Enhancing existing procedures in place
- **Systems Stewardship**: Making knowledge visible at point of need