### PR TITLE
docs(procedures): Embed principle links at command level - v2

### DIFF
--- a/knowledge/principles/tracer-bullets.md
+++ b/knowledge/principles/tracer-bullets.md
@@ -19,7 +19,6 @@ Once you have a target, use tracer rounds to zero in:
 - **Pull requests as tracer rounds**: Each PR is the observable unit where feedback happens - not individual commits
 - **Commit early and often**: Commits show trajectory toward the PR target, building the complete picture
 - **OSE perspective**: From "Outside and Slightly Elevated" we review complete changes, not micro-edits
-- **Short feedback loops over long planning**: Rapid PR iterations beat extensive upfront design
 - **Human checkpoint at PR level**: The human sees the full context and provides course correction
 - **AI-human feedback loop**: Core to this approach - neither operates in isolation
 - **Balance with other principles**: 

--- a/knowledge/principles/tracer-bullets.md
+++ b/knowledge/principles/tracer-bullets.md
@@ -16,15 +16,21 @@ Once you have a target, use tracer rounds to zero in:
 - **Walk fire onto target**: Start with rough attempts, progressively refine precision
 
 ## Feedback Mechanisms
-- **Pull requests as tracer rounds**: Each PR is the observable unit where feedback happens - not individual commits
-- **Commit early and often**: Commits show trajectory toward the PR target, building the complete picture
+- **Pull requests as tracer rounds**: First shot establishes the feedback loop - not expected to hit target immediately
+- **Subsequent adjustments via commits**: Once PR shows we're "close enough", fine-tune with commits to the same PR
+- **Commit early and often**: Commits show trajectory, both initial attempt and adjustments after feedback
 - **OSE perspective**: From "Outside and Slightly Elevated" we review complete changes, not micro-edits
 - **Human checkpoint at PR level**: The human sees the full context and provides course correction
 - **AI-human feedback loop**: Core to this approach - neither operates in isolation
+- **The full sequence**:
+  1. PR establishes initial feedback loop (first tracer)
+  2. Human feedback indicates adjustments needed
+  3. Commits to same PR refine based on feedback (subsequent tracers)
+  4. Iterate until target is hit
 - **Balance with other principles**: 
   - Start with "go slow to go fast" (proper orientation)
   - Build toward PR with multiple commits (trajectory)
-  - Review at PR level (elevated perspective)
+  - Review and adjust at appropriate altitude
 
 ## Target-First Development
 This principle naturally leads to test-driven behaviors:

--- a/knowledge/principles/tracer-bullets.md
+++ b/knowledge/principles/tracer-bullets.md
@@ -2,11 +2,14 @@
 
 Like military tracer rounds that help soldiers adjust their aim in real-time, each iteration provides immediate feedback to guide the next action. But first, you need a target.
 
+This approach acknowledges that even experts often discover what they want through seeing attempts - "I'll know it when I see it" is valid. Rather than spending extensive time specifying exact requirements upfront, tracer bullets allow the vision to emerge through rapid iterations of "a little to the left, a little to the right."
+
 ## Establishing the Target
 Before firing any rounds, define what you're aiming at:
 - **Clear success criteria**: What does "hitting the target" look like? (tests, expected outputs, acceptance criteria)
 - **Negative space mapping**: Understanding what failure looks like helps define the target's boundaries
 - **Measurable outcomes**: Targets must be observable - you need to know when you've hit or missed
+- **Emergent clarity**: The target itself may become clearer through iterations - expert intuition often needs concrete attempts to crystallize
 
 ## Iterative Targeting
 Once you have a target, use tracer rounds to zero in:

--- a/knowledge/principles/tracer-bullets.md
+++ b/knowledge/principles/tracer-bullets.md
@@ -16,21 +16,11 @@ Once you have a target, use tracer rounds to zero in:
 - **Walk fire onto target**: Start with rough attempts, progressively refine precision
 
 ## Feedback Mechanisms
-- **Pull requests as tracer rounds**: First shot establishes the feedback loop - not expected to hit target immediately
-- **Subsequent adjustments via commits**: Once PR shows we're "close enough", fine-tune with commits to the same PR
-- **Commit early and often**: Commits show trajectory, both initial attempt and adjustments after feedback
-- **OSE perspective**: From "Outside and Slightly Elevated" we review complete changes, not micro-edits
-- **Human checkpoint at PR level**: The human sees the full context and provides course correction
+- **Observable units of change**: Feedback happens at the level where changes become meaningful - typically PRs
+- **Trajectory over perfection**: Early attempts show direction; subsequent adjustments refine the aim
+- **Appropriate altitude**: Review at the level that balances completeness with comprehension
 - **AI-human feedback loop**: Core to this approach - neither operates in isolation
-- **The full sequence**:
-  1. PR establishes initial feedback loop (first tracer)
-  2. Human feedback indicates adjustments needed
-  3. Commits to same PR refine based on feedback (subsequent tracers)
-  4. Iterate until target is hit
-- **Balance with other principles**: 
-  - Start with "go slow to go fast" (proper orientation)
-  - Build toward PR with multiple commits (trajectory)
-  - Review and adjust at appropriate altitude
+- **Natural rhythm emerges**: Not prescriptive steps, but a pattern of attempt → feedback → adjustment
 
 ## Target-First Development
 This principle naturally leads to test-driven behaviors:

--- a/knowledge/principles/tracer-bullets.md
+++ b/knowledge/principles/tracer-bullets.md
@@ -4,6 +4,8 @@ Like military tracer rounds that help soldiers adjust their aim in real-time, ea
 
 This approach acknowledges that even experts often discover what they want through seeing attempts - "I'll know it when I see it" is valid. Rather than spending extensive time specifying exact requirements upfront, tracer bullets allow the vision to emerge through rapid iterations of "a little to the left, a little to the right."
 
+The metaphor has limits: unlike military targeting, this is collaborative convergence toward a shared understanding. Both the implementation and the target evolve together through feedback - it's not adversarial, it's co-creative.
+
 ## Establishing the Target
 Before firing any rounds, define what you're aiming at:
 - **Clear success criteria**: What does "hitting the target" look like? (tests, expected outputs, acceptance criteria)
@@ -15,7 +17,6 @@ Before firing any rounds, define what you're aiming at:
 Once you have a target, use tracer rounds to zero in:
 - **Ground truth at each step**: Gain concrete feedback from the environment (tool results, code execution, system responses)
 - **Progress assessment**: Each iteration should get closer - watch for diminishing returns
-- **Adjust aim, not target**: Keep success criteria stable while refining your approach (though targets may evolve as understanding deepens)
 - **Walk fire onto target**: Start with rough attempts, progressively refine precision
 - **Proximity awareness**: Recognize feedback patterns like "a little to the left" or "90% there" - these guide refinement without over-specification
 - **Course correction over stubbornness**: If attempts regress, be willing to reset and try a different angle

--- a/knowledge/principles/tracer-bullets.md
+++ b/knowledge/principles/tracer-bullets.md
@@ -16,11 +16,16 @@ Once you have a target, use tracer rounds to zero in:
 - **Walk fire onto target**: Start with rough attempts, progressively refine precision
 
 ## Feedback Mechanisms
-- **Commit early and often**: Each commit is a tracer round showing trajectory
-- **Short feedback loops over long planning**: Rapid iteration beats extensive upfront design
-- **Human checkpoint pauses**: Stop for feedback when encountering blockers or at natural decision points
+- **Pull requests as tracer rounds**: Each PR is the observable unit where feedback happens - not individual commits
+- **Commit early and often**: Commits show trajectory toward the PR target, building the complete picture
+- **OSE perspective**: From "Outside and Slightly Elevated" we review complete changes, not micro-edits
+- **Short feedback loops over long planning**: Rapid PR iterations beat extensive upfront design
+- **Human checkpoint at PR level**: The human sees the full context and provides course correction
 - **AI-human feedback loop**: Core to this approach - neither operates in isolation
-- **Stopping conditions**: Maintain control with maximum iterations or clear completion criteria
+- **Balance with other principles**: 
+  - Start with "go slow to go fast" (proper orientation)
+  - Build toward PR with multiple commits (trajectory)
+  - Review at PR level (elevated perspective)
 
 ## Target-First Development
 This principle naturally leads to test-driven behaviors:
@@ -32,3 +37,11 @@ This principle naturally leads to test-driven behaviors:
 6. Confirm stability (multiple hits = reliable solution)
 
 This principle enables effective development in unfamiliar territory by providing constant course correction through environmental feedback - but it all starts with having a clear target to aim at.
+
+## Relationship to Other Principles
+- **Go slow to go fast**: Proper orientation prevents ghost commits in PRs
+- **OSE (Outside and Slightly Elevated)**: Review at PR level, not edit-by-edit
+- **Versioning mindset**: Each PR iteration improves on the last
+- **Systems stewardship**: PRs become teachable units of change
+
+The PR is where principles converge - it's the right altitude for meaningful feedback.

--- a/knowledge/principles/tracer-bullets.md
+++ b/knowledge/principles/tracer-bullets.md
@@ -14,9 +14,11 @@ Before firing any rounds, define what you're aiming at:
 ## Iterative Targeting
 Once you have a target, use tracer rounds to zero in:
 - **Ground truth at each step**: Gain concrete feedback from the environment (tool results, code execution, system responses)
-- **Progress assessment**: Each cycle/loop/iteration should feel like getting closer to the target
-- **Adjust aim, not target**: Keep success criteria stable while refining your approach
+- **Progress assessment**: Each iteration should get closer - watch for diminishing returns
+- **Adjust aim, not target**: Keep success criteria stable while refining your approach (though targets may evolve as understanding deepens)
 - **Walk fire onto target**: Start with rough attempts, progressively refine precision
+- **Proximity awareness**: Recognize feedback patterns like "a little to the left" or "90% there" - these guide refinement without over-specification
+- **Course correction over stubbornness**: If attempts regress, be willing to reset and try a different angle
 
 ## Feedback Mechanisms
 - **Observable units of change**: Feedback happens at the level where changes become meaningful - typically PRs

--- a/knowledge/procedures/git-workflow.md
+++ b/knowledge/procedures/git-workflow.md
@@ -10,6 +10,8 @@
 - Use `Principle: <slug>` trailer when work resonates with a specific principle (e.g., `Principle: subtraction-creates-value`, `Principle: versioning-mindset`, `Principle: systems-stewardship`)
 - Commit early and often with meaningful changes
   → [tracer-bullets](../principles/tracer-bullets.md) → [versioning-mindset](../principles/versioning-mindset.md)
+- Remember: Commits build toward PRs - that's where feedback happens
+  → [systems-stewardship](../principles/systems-stewardship.md) (OSE perspective)
 
 ## Branch Management
 

--- a/knowledge/procedures/git-workflow.md
+++ b/knowledge/procedures/git-workflow.md
@@ -9,6 +9,7 @@
 - Good scope choices add context about what component is being modified (e.g., api, ui, auth, config, docs)
 - Use `Principle: <slug>` trailer when work resonates with a specific principle (e.g., `Principle: subtraction-creates-value`, `Principle: versioning-mindset`, `Principle: systems-stewardship`)
 - Commit early and often with meaningful changes
+  → [tracer-bullets](../principles/tracer-bullets.md) → [versioning-mindset](../principles/versioning-mindset.md)
 
 ## Branch Management
 
@@ -18,8 +19,10 @@
 
 ### Quick orientation checks (prevent future cleanup)
 1. `mcp__git__git_status` - Where am I? What's already changed?
+   → [subtraction-creates-value](../principles/subtraction-creates-value.md) (avoid recovery tax)
 2. Check current branch - Am I on main? Do I have uncommitted work?
 3. **Is main current?** - `git fetch && git status` - Behind origin/main means your PR will include unwanted commits
+   → [subtraction-creates-value](../principles/subtraction-creates-value.md)
 4. If changes exist on main - commit them properly or stash before branching
 
 Starting from a stale foundation guarantees the recovery tax - double work to achieve what orientation would have prevented.
@@ -28,6 +31,7 @@ Starting from a stale foundation guarantees the recovery tax - double work to ac
 - Branch naming: `type/description` (e.g., `feature/add-authentication`, `fix/login-bug`)
 - Issue suffix: `type/description-123` (e.g., `feature/add-authentication-512`)
 - Order: Check surroundings → create branch → switch → work → commit
+  → [subtraction-creates-value](../principles/subtraction-creates-value.md) (prevent recovery work)
 
 These standards make intent visible and prevent the recovery tax.
 


### PR DESCRIPTION
## Summary
Second iteration: embedding principle links directly at command/action level where decisions happen.

## Changes
- Added principle links with `→` arrow notation next to specific commands/actions:
  - `git status` command → links to subtraction-creates-value (avoid recovery tax)
  - `git fetch && git status` → links to subtraction-creates-value
  - "Commit early and often" → links to tracer-bullets & versioning-mindset
  - "Check surroundings → create branch" order → links to subtraction-creates-value

## Format
```
1. `mcp__git__git_status` - Where am I? What's already changed?
   → [subtraction-creates-value](../principles/subtraction-creates-value.md) (avoid recovery tax)
```

## Key Improvements from v1
- Links are at the actual command level, not section headers
- Uses file links instead of inline explanations
- Brief contextual note in parentheses when helpful
- Minimal visual disruption with → arrow notation

## Test Plan
- [ ] Links appear next to actual commands/decisions
- [ ] Format is scannable and non-intrusive
- [ ] Links point to valid principle files
- [ ] Get feedback on this approach

Continues #741

## Principles Applied
- **Tracer Bullets**: Second iteration based on feedback
- **Versioning Mindset**: Iterating on the approach
- **Systems Stewardship**: Making knowledge actionable at point of use