### PR TITLE
feat(claude): disable co-authorship attribution in commits

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -81,5 +81,6 @@
     "filesystem",
     "gdrive",
     "gitlab"
-  ]
+  ],
+  "includeCoAuthoredBy": false
 }

--- a/README.md
+++ b/README.md
@@ -244,6 +244,17 @@ To modify a slash command:
 
 **Principle**: This vendor-agnostic approach follows `systems-stewardship` - building reusable patterns across tools.
 
+### Claude Code Settings
+
+Global Claude Code settings are managed through `.claude/settings.json`. This file is symlinked to `~/.claude/settings.json` by the setup script, ensuring settings persist across all projects.
+
+To add or modify Claude Code settings:
+1. Edit `.claude/settings.json` in the dotfiles repo
+2. Run `source setup.sh` to update the symlink
+3. Settings apply globally to all Claude Code sessions
+
+Current configured settings include co-authorship attribution, MCP servers, permissions, and more.
+
 ## Secret Management
 
 Sensitive information like API tokens are stored in `~/.bash_secrets` (not tracked in git).


### PR DESCRIPTION
## Summary
- Added `includeCoAuthoredBy: false` to `.claude/settings.json` to disable Claude's co-authorship attribution in commits and PRs
- Documented the Claude Code settings management system in README.md
- Leveraged existing symlink infrastructure that was already in place in setup.sh

## Implementation Details
Rather than creating a new settings infrastructure as originally planned, I discovered and used the existing system:
- `.claude/settings.json` already existed with various Claude Code settings
- `setup.sh` already symlinks this file to `~/.claude/settings.json`
- Simply added the new setting to the existing file

## Test Plan
- [x] Verified symlink exists: `ls -la ~/.claude/settings.json`
- [x] Confirmed setting is present: `grep includeCoAuthoredBy ~/.claude/settings.json`
- [x] Documentation added to README.md (9 lines, under the 13 line limit)
- [x] Tested that `source setup.sh` maintains the symlink

Closes #759