### PR TITLE
feat(claude): establish non-Bedrock as default with Bedrock as opt-in

### DIFF
--- a/.bash_aliases.d/claude.sh
+++ b/.bash_aliases.d/claude.sh
@@ -10,3 +10,45 @@ alias claude-sonnet="export ANTHROPIC_MODEL=claude-3-7-sonnet-latest"
 # Switch to Claude 3 Opus model
 alias claude-opus="export ANTHROPIC_MODEL=claude-3-opus-latest"
 
+# Claude Code with AWS Bedrock
+# This function checks AWS SSO status and runs Claude Code with Bedrock
+claude-bedrock() {
+    # Check if Bedrock exports are configured
+    if [[ -z "$CLAUDE_CODE_USE_BEDROCK" ]] || [[ "$CLAUDE_CODE_USE_BEDROCK" != "1" ]]; then
+        echo "Error: Bedrock environment not configured."
+        echo "Please ensure ~/.bash_exports.bedrock.local exists and is sourced."
+        echo "Run: source ~/.bashrc"
+        return 1
+    fi
+    
+    # Check if AWS profile is set
+    if [[ -z "$AWS_PROFILE" ]]; then
+        echo "Error: AWS_PROFILE not set."
+        echo "Please set AWS_PROFILE in ~/.bash_exports.bedrock.local"
+        return 1
+    fi
+    
+    # Check AWS SSO login status
+    if ! aws sts get-caller-identity --profile "$AWS_PROFILE" >/dev/null 2>&1; then
+        echo "AWS SSO session expired or not logged in."
+        echo "Running: aws sso login --profile $AWS_PROFILE"
+        aws sso login --profile "$AWS_PROFILE"
+        
+        # Verify login succeeded
+        if ! aws sts get-caller-identity --profile "$AWS_PROFILE" >/dev/null 2>&1; then
+            echo "Error: AWS SSO login failed."
+            return 1
+        fi
+    fi
+    
+    # Show current Bedrock configuration
+    echo "Running Claude Code with AWS Bedrock:"
+    echo "  Profile: $AWS_PROFILE"
+    echo "  Region: $AWS_REGION"
+    echo "  Model: ${ANTHROPIC_MODEL:-default}"
+    echo ""
+    
+    # Run Claude Code with all arguments passed through
+    claude "$@"
+}
+

--- a/.bash_exports.bedrock.template
+++ b/.bash_exports.bedrock.template
@@ -1,0 +1,27 @@
+#!/bin/bash
+# AWS Bedrock Configuration for Claude Code
+# Copy this to ~/.bash_exports.bedrock.local and customize with your specific values
+
+# Enable Bedrock integration
+export CLAUDE_CODE_USE_BEDROCK=1
+
+# AWS Region for Bedrock (required)
+export AWS_REGION=us-east-1
+
+# Optional: Override region for small/fast model (Haiku)
+# export ANTHROPIC_SMALL_FAST_MODEL_AWS_REGION=us-west-2
+
+# AWS Profile to use (customize this with your profile name)
+export AWS_PROFILE=bedrock_profile
+
+# Model configuration
+# Using inference profile IDs (recommended)
+export ANTHROPIC_MODEL='us.anthropic.claude-3-7-sonnet-20250219-v1:0'
+export ANTHROPIC_SMALL_FAST_MODEL='us.anthropic.claude-3-5-haiku-20241022-v1:0'
+
+# Alternative: Using application inference profile ARNs
+# export ANTHROPIC_MODEL='arn:aws:bedrock:us-east-1:YOUR_ACCOUNT_ID:application-inference-profile/YOUR_PROFILE_ID'
+# export ANTHROPIC_SMALL_FAST_MODEL='arn:aws:bedrock:us-east-1:YOUR_ACCOUNT_ID:application-inference-profile/YOUR_PROFILE_ID'
+
+# Optional: Additional AWS configurations
+# export AWS_SESSION_DURATION=8h  # SSO session duration

--- a/.bash_exports.claude.template
+++ b/.bash_exports.claude.template
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Default Claude Code Configuration Template (Non-Bedrock)
+# Copy this to ~/.bash_exports.claude.local and customize as needed
+
+# Explicitly disable Bedrock integration (this is the default)
+export CLAUDE_CODE_USE_BEDROCK=0
+
+# Clear any AWS-related environment variables that might interfere
+unset AWS_REGION
+unset AWS_PROFILE
+unset ANTHROPIC_SMALL_FAST_MODEL_AWS_REGION
+
+# Standard model configuration - customize as needed
+export ANTHROPIC_MODEL='claude-3-opus-latest'
+export ANTHROPIC_SMALL_FAST_MODEL='claude-3-5-haiku-20241022'
+
+# Ensure we're using the standard Anthropic API
+unset ANTHROPIC_BASE_URL

--- a/.bashrc
+++ b/.bashrc
@@ -140,6 +140,11 @@ if [ -f ~/.bash_exports ]; then
     . ~/.bash_exports
 fi
 
+# Load Bedrock exports if available (for Claude Code AWS Bedrock integration)
+if [ -f ~/.bash_exports.bedrock.local ]; then
+    . ~/.bash_exports.bedrock.local
+fi
+
 # Load secrets file if it exists
 if [ -f ~/.bash_secrets ]; then
     . ~/.bash_secrets

--- a/.bashrc
+++ b/.bashrc
@@ -140,7 +140,12 @@ if [ -f ~/.bash_exports ]; then
     . ~/.bash_exports
 fi
 
-# Load Bedrock exports if available (for Claude Code AWS Bedrock integration)
+# Load default Claude Code configuration first (non-Bedrock)
+if [ -f ~/.bash_exports.claude.local ]; then
+    . ~/.bash_exports.claude.local
+fi
+
+# Load Bedrock exports if available (overrides defaults for enterprise users)
 if [ -f ~/.bash_exports.bedrock.local ]; then
     . ~/.bash_exports.bedrock.local
 fi

--- a/README.md
+++ b/README.md
@@ -244,9 +244,18 @@ To modify a slash command:
 
 **Principle**: This vendor-agnostic approach follows `systems-stewardship` - building reusable patterns across tools.
 
-### AWS Bedrock Integration (Enterprise Claude Code)
+### Claude Code Configuration
 
-Run Claude Code through AWS Bedrock for enterprise environments with proper IAM controls and cost tracking:
+Claude Code is configured to work out-of-the-box with the standard Anthropic API using Claude Opus as the default model:
+
+- **Default Setup**: Run `source setup.sh` for immediate Claude Code functionality
+- **Model**: Claude 3 Opus Latest (configurable via `ANTHROPIC_MODEL`)
+- **Configuration**: Stored in `~/.bash_exports.claude.local` (created from template)
+- **No AWS Required**: Works immediately with your Anthropic API key
+
+### AWS Bedrock Integration (Optional Enterprise Feature)
+
+For enterprise environments, you can optionally run Claude Code through AWS Bedrock with proper IAM controls and cost tracking:
 
 - **Quick Setup**: Run `source setup.sh` and answer 'y' when prompted for Bedrock setup
 - **Manual Setup**: Run `bash utils/setup-bedrock-claude.sh`

--- a/README.md
+++ b/README.md
@@ -244,6 +244,18 @@ To modify a slash command:
 
 **Principle**: This vendor-agnostic approach follows `systems-stewardship` - building reusable patterns across tools.
 
+### AWS Bedrock Integration (Enterprise Claude Code)
+
+Run Claude Code through AWS Bedrock for enterprise environments with proper IAM controls and cost tracking:
+
+- **Quick Setup**: Run `source setup.sh` and answer 'y' when prompted for Bedrock setup
+- **Manual Setup**: Run `bash utils/setup-bedrock-claude.sh`
+- **Configuration**: Templates in `aws/` directory and `.bash_exports.bedrock.template`
+- **Usage**: `claude-bedrock` command with automatic AWS SSO authentication
+- **Documentation**: See [Claude Bedrock Setup Guide](docs/claude-bedrock-setup.md) for detailed instructions
+
+The integration supports multiple AWS profiles, automatic SSO session management, and fallback to standard Claude Code when Bedrock is unavailable.
+
 ## Secret Management
 
 Sensitive information like API tokens are stored in `~/.bash_secrets` (not tracked in git).

--- a/aws/README.md
+++ b/aws/README.md
@@ -1,0 +1,17 @@
+# AWS Configuration Templates
+
+This directory contains templates for AWS configuration needed to run Claude Code through AWS Bedrock.
+
+## Files
+
+- `config.template` - AWS SSO profile configuration template
+- `bedrock-iam-policy.json` - IAM policy required for Bedrock access
+
+## Usage
+
+1. Copy `config.template` to `~/.aws/config` and customize with your organization's values
+2. Use `bedrock-iam-policy.json` when setting up IAM roles for Bedrock access
+
+## Security
+
+Never commit actual AWS account IDs, role names, or other sensitive information to this repository. Keep all sensitive values in `.local` files.

--- a/aws/bedrock-iam-policy.json
+++ b/aws/bedrock-iam-policy.json
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "bedrock:InvokeModel",
+        "bedrock:InvokeModelWithResponseStream",
+        "bedrock:ListInferenceProfiles"
+      ],
+      "Resource": [
+        "arn:aws:bedrock:*:*:inference-profile/*",
+        "arn:aws:bedrock:*:*:application-inference-profile/*"
+      ]
+    }
+  ]
+}

--- a/aws/config.template
+++ b/aws/config.template
@@ -1,0 +1,20 @@
+# AWS SSO Configuration Template for Bedrock Access
+# Copy this to ~/.aws/config and customize with your organization's values
+
+# Example profile for Claude Code Bedrock access
+[profile bedrock_profile]
+sso_start_url  = https://your-org.awsapps.com/start
+sso_region     = us-east-1
+sso_account_id = YOUR_ACCOUNT_ID
+sso_role_name  = YOUR_ROLE_NAME
+region         = us-east-1
+cli_pager      =
+
+# You can add multiple profiles for different environments
+# [profile bedrock_dev]
+# sso_start_url  = https://your-org.awsapps.com/start
+# sso_region     = us-east-1
+# sso_account_id = YOUR_DEV_ACCOUNT_ID
+# sso_role_name  = YOUR_DEV_ROLE_NAME
+# region         = us-east-1
+# cli_pager      =

--- a/docs/claude-bedrock-setup.md
+++ b/docs/claude-bedrock-setup.md
@@ -1,0 +1,242 @@
+# Claude Code AWS Bedrock Setup Guide
+
+This guide helps you configure Claude Code to run through AWS Bedrock, enabling enterprise users to leverage corporate AWS accounts with proper IAM controls and cost tracking.
+
+## Prerequisites
+
+Before setting up Bedrock integration, ensure you have:
+
+1. **AWS Account with Bedrock Access**
+   - Access enabled in your AWS account
+   - Appropriate IAM permissions (see IAM Configuration below)
+
+2. **Claude Model Access**
+   - Access to desired Claude models (e.g., Claude Sonnet 4) in Bedrock
+   - Navigate to Amazon Bedrock console → Model access → Request access
+   - Wait for approval (usually instant for most regions)
+
+3. **AWS CLI Installed**
+   - Download from: https://aws.amazon.com/cli/
+   - Verify installation: `aws --version`
+
+4. **Claude Code Installed**
+   - Install via npm: `npm install -g @anthropic-ai/claude-code`
+   - Or use the dotfiles setup: `source setup.sh`
+
+## Quick Start
+
+1. **Run the automated setup**:
+   ```bash
+   source setup.sh
+   # Answer 'y' when prompted for Bedrock setup
+   ```
+
+   Or run directly:
+   ```bash
+   bash ~/ppv/pillars/dotfiles/utils/setup-bedrock-claude.sh
+   ```
+
+2. **Configure your AWS profile**:
+   Edit `~/.aws/config` with your organization's SSO details:
+   ```ini
+   [profile bedrock_profile]
+   sso_start_url  = https://your-org.awsapps.com/start
+   sso_region     = us-east-1
+   sso_account_id = YOUR_ACCOUNT_ID
+   sso_role_name  = YOUR_ROLE_NAME
+   region         = us-east-1
+   ```
+
+3. **Configure Bedrock environment**:
+   Edit `~/.bash_exports.bedrock.local`:
+   ```bash
+   export AWS_PROFILE=bedrock_profile
+   export ANTHROPIC_MODEL='us.anthropic.claude-3-7-sonnet-20250219-v1:0'
+   # Or use your organization's specific ARNs
+   ```
+
+4. **Login to AWS SSO**:
+   ```bash
+   aws sso login --profile bedrock_profile
+   ```
+
+5. **Run Claude Code with Bedrock**:
+   ```bash
+   source ~/.bashrc  # Load the environment
+   claude-bedrock    # Run with automatic SSO check
+   ```
+
+## Manual Setup
+
+If you prefer manual configuration:
+
+### 1. AWS Configuration
+
+Create or update `~/.aws/config`:
+```ini
+[profile bedrock_profile]
+sso_start_url  = https://your-org.awsapps.com/start
+sso_region     = us-east-1
+sso_account_id = YOUR_ACCOUNT_ID
+sso_role_name  = YOUR_ROLE_NAME
+region         = us-east-1
+cli_pager      =
+```
+
+### 2. Environment Variables
+
+Create `~/.bash_exports.bedrock.local`:
+```bash
+#!/bin/bash
+# Enable Bedrock integration
+export CLAUDE_CODE_USE_BEDROCK=1
+export AWS_REGION=us-east-1
+export AWS_PROFILE=bedrock_profile
+
+# Model configuration
+export ANTHROPIC_MODEL='us.anthropic.claude-3-7-sonnet-20250219-v1:0'
+export ANTHROPIC_SMALL_FAST_MODEL='us.anthropic.claude-3-5-haiku-20241022-v1:0'
+```
+
+### 3. Update .bashrc
+
+Add to your `~/.bashrc`:
+```bash
+# Source Bedrock exports if available
+[[ -f ~/.bash_exports.bedrock.local ]] && source ~/.bash_exports.bedrock.local
+```
+
+## IAM Configuration
+
+Your IAM role needs these permissions:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "bedrock:InvokeModel",
+        "bedrock:InvokeModelWithResponseStream",
+        "bedrock:ListInferenceProfiles"
+      ],
+      "Resource": [
+        "arn:aws:bedrock:*:*:inference-profile/*",
+        "arn:aws:bedrock:*:*:application-inference-profile/*"
+      ]
+    }
+  ]
+}
+```
+
+## Usage
+
+### Basic Usage
+
+```bash
+# Run with Bedrock (checks SSO automatically)
+claude-bedrock
+
+# Or set environment and run standard claude
+source ~/.bash_exports.bedrock.local
+claude
+```
+
+### Multiple AWS Profiles
+
+Add multiple profiles to `~/.aws/config`:
+```ini
+[profile bedrock_dev]
+sso_start_url  = https://your-org.awsapps.com/start
+sso_account_id = DEV_ACCOUNT_ID
+# ...
+
+[profile bedrock_prod]
+sso_start_url  = https://your-org.awsapps.com/start
+sso_account_id = PROD_ACCOUNT_ID
+# ...
+```
+
+Switch between them:
+```bash
+export AWS_PROFILE=bedrock_dev
+claude-bedrock
+```
+
+### Using Specific Models
+
+```bash
+# Via environment variable
+export ANTHROPIC_MODEL='us.anthropic.claude-opus-4-20250514-v1:0'
+claude-bedrock
+
+# Or use inference profile ARNs
+export ANTHROPIC_MODEL='arn:aws:bedrock:us-east-1:123456789:inference-profile/your-profile'
+```
+
+## Troubleshooting
+
+### SSO Login Issues
+
+```bash
+# Check current identity
+aws sts get-caller-identity --profile bedrock_profile
+
+# Force new login
+aws sso logout --profile bedrock_profile
+aws sso login --profile bedrock_profile
+```
+
+### Region Issues
+
+```bash
+# Check model availability
+aws bedrock list-inference-profiles --region your-region
+
+# Override region for specific model
+export ANTHROPIC_SMALL_FAST_MODEL_AWS_REGION=us-west-2
+```
+
+### Environment Not Loading
+
+```bash
+# Verify exports are loaded
+echo $CLAUDE_CODE_USE_BEDROCK  # Should output: 1
+echo $AWS_PROFILE               # Should output: bedrock_profile
+
+# Reload environment
+source ~/.bashrc
+```
+
+### Model Access Errors
+
+If you receive "on-demand throughput isn't supported":
+- Ensure you're using an inference profile ID, not a model ID
+- Check model access in Bedrock console
+- Verify your IAM permissions
+
+## Security Best Practices
+
+1. **Never commit sensitive data**:
+   - Keep AWS account IDs in `.local` files
+   - Use `.gitignore` for `*.local` files
+
+2. **Use SSO instead of long-lived credentials**:
+   - Temporary credentials auto-expire
+   - Centrally managed access
+
+3. **Restrict IAM permissions**:
+   - Use least-privilege principle
+   - Limit to specific inference profiles if possible
+
+4. **Separate AWS accounts**:
+   - Consider dedicated account for AI workloads
+   - Simplifies cost tracking and access control
+
+## Additional Resources
+
+- [Claude Code on Amazon Bedrock docs](https://docs.anthropic.com/en/docs/claude-code/deployment/amazon-bedrock)
+- [AWS Bedrock documentation](https://docs.aws.amazon.com/bedrock/)
+- [AWS Bedrock pricing](https://aws.amazon.com/bedrock/pricing/)
+- [AWS SSO configuration](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html)

--- a/mcp/setup-all-mcp-servers.sh
+++ b/mcp/setup-all-mcp-servers.sh
@@ -40,7 +40,7 @@ setup_scripts=(
     "setup-filesystem-mcp.sh"
     "setup-gitlab-mcp.sh"
     "setup-brave-search-mcp.sh"
-    "setup-gdrive-mcp.sh"
+    # "setup-gdrive-mcp.sh"  # Temporarily disabled - doesn't work currently
 )
 
 failed_setups=()

--- a/setup.sh
+++ b/setup.sh
@@ -349,6 +349,39 @@ else
   echo -e "${YELLOW}Warning: .claude/settings.json not found. Skipping settings symlink.${NC}"
 fi
 
+# AWS Bedrock integration for Claude Code (optional)
+echo -e "${DIVIDER}"
+echo "Checking AWS Bedrock integration..."
+
+# Check if AWS CLI is installed
+if command -v aws >/dev/null 2>&1; then
+  echo -e "${GREEN}✓ AWS CLI is installed${NC}"
+  
+  # Check if Bedrock setup has already been done
+  if [[ -f "$HOME/.bash_exports.bedrock.local" ]]; then
+    echo -e "${GREEN}✓ AWS Bedrock exports already configured${NC}"
+  else
+    echo "AWS CLI is available. Would you like to set up Claude Code with AWS Bedrock?"
+    echo "This allows running Claude Code through your organization's AWS account."
+    read -p "Setup AWS Bedrock integration? (y/N): " -n 1 -r
+    echo
+    
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+      if [[ -f "$DOT_DEN/utils/setup-bedrock-claude.sh" ]]; then
+        bash "$DOT_DEN/utils/setup-bedrock-claude.sh"
+      else
+        echo -e "${YELLOW}Warning: Bedrock setup script not found${NC}"
+      fi
+    else
+      echo "Skipping AWS Bedrock setup. You can run it later with:"
+      echo "  bash $DOT_DEN/utils/setup-bedrock-claude.sh"
+    fi
+  fi
+else
+  echo -e "${YELLOW}AWS CLI not found. Skipping Bedrock integration.${NC}"
+  echo "To use Claude Code with AWS Bedrock, install AWS CLI first:"
+  echo "  https://aws.amazon.com/cli/"
+fi
 
 # Node.js setup with NVM
 echo -e "${DIVIDER}"

--- a/setup.sh
+++ b/setup.sh
@@ -355,8 +355,8 @@ echo "Setting up AWS CLI..."
 
 # Install or update AWS CLI
 if [[ -f "$DOT_DEN/utils/install-aws-cli.sh" ]]; then
-  source "$DOT_DEN/utils/install-aws-cli.sh"
-  setup_aws_cli || {
+  # Run in subshell to avoid sourcing issues
+  bash "$DOT_DEN/utils/install-aws-cli.sh" || {
     echo -e "${YELLOW}Warning: AWS CLI installation had issues${NC}"
   }
 else

--- a/setup.sh
+++ b/setup.sh
@@ -375,20 +375,14 @@ if command -v aws >/dev/null 2>&1; then
   if [[ -f "$HOME/.bash_exports.bedrock.local" ]]; then
     echo -e "${GREEN}✓ AWS Bedrock exports already configured${NC}"
   else
-    echo "AWS CLI is available. Would you like to set up Claude Code with AWS Bedrock?"
+    echo "AWS CLI is available. Setting up Claude Code with AWS Bedrock..."
     echo "This allows running Claude Code through your organization's AWS account."
-    read -p "Setup AWS Bedrock integration? (y/N): " -n 1 -r
-    echo
     
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
-      if [[ -f "$DOT_DEN/utils/setup-bedrock-claude.sh" ]]; then
-        bash "$DOT_DEN/utils/setup-bedrock-claude.sh"
-      else
-        echo -e "${YELLOW}Warning: Bedrock setup script not found${NC}"
-      fi
+    # Always set up Bedrock if AWS CLI is available and config doesn't exist
+    if [[ -f "$DOT_DEN/utils/setup-bedrock-claude.sh" ]]; then
+      bash "$DOT_DEN/utils/setup-bedrock-claude.sh"
     else
-      echo "Skipping AWS Bedrock setup. You can run it later with:"
-      echo "  bash $DOT_DEN/utils/setup-bedrock-claude.sh"
+      echo -e "${YELLOW}Warning: Bedrock setup script not found${NC}"
     fi
   fi
 else

--- a/setup.sh
+++ b/setup.sh
@@ -349,6 +349,20 @@ else
   echo -e "${YELLOW}Warning: .claude/settings.json not found. Skipping settings symlink.${NC}"
 fi
 
+# AWS CLI setup (required for Bedrock integration)
+echo -e "${DIVIDER}"
+echo "Setting up AWS CLI..."
+
+# Install or update AWS CLI
+if [[ -f "$DOT_DEN/utils/install-aws-cli.sh" ]]; then
+  source "$DOT_DEN/utils/install-aws-cli.sh"
+  setup_aws_cli || {
+    echo -e "${YELLOW}Warning: AWS CLI installation had issues${NC}"
+  }
+else
+  echo -e "${YELLOW}AWS CLI installation script not found${NC}"
+fi
+
 # AWS Bedrock integration for Claude Code (optional)
 echo -e "${DIVIDER}"
 echo "Checking AWS Bedrock integration..."

--- a/setup.sh
+++ b/setup.sh
@@ -363,9 +363,25 @@ else
   echo -e "${YELLOW}AWS CLI installation script not found${NC}"
 fi
 
-# AWS Bedrock integration for Claude Code (optional)
+# Claude Code configuration setup
 echo -e "${DIVIDER}"
-echo "Checking AWS Bedrock integration..."
+echo "Setting up Claude Code configuration..."
+
+# Step 1: Always establish non-Bedrock defaults first
+if [[ ! -f "$HOME/.bash_exports.claude.local" ]]; then
+  echo -e "${BLUE}Creating default Claude Code configuration (non-Bedrock)...${NC}"
+  if [[ -f "$DOT_DEN/.bash_exports.claude.template" ]]; then
+    cp "$DOT_DEN/.bash_exports.claude.template" "$HOME/.bash_exports.claude.local"
+    echo -e "${GREEN}✓ Created default Claude Code configuration${NC}"
+  else
+    echo -e "${YELLOW}Warning: Claude template not found${NC}"
+  fi
+else
+  echo -e "${GREEN}✓ Claude Code configuration already exists${NC}"
+fi
+
+# Step 2: AWS Bedrock integration (optional, opt-in only)
+echo -e "${BLUE}Checking AWS Bedrock integration (optional)...${NC}"
 
 # Check if AWS CLI is installed
 if command -v aws >/dev/null 2>&1; then
@@ -374,20 +390,26 @@ if command -v aws >/dev/null 2>&1; then
   # Check if Bedrock setup has already been done
   if [[ -f "$HOME/.bash_exports.bedrock.local" ]]; then
     echo -e "${GREEN}✓ AWS Bedrock exports already configured${NC}"
+    echo -e "${YELLOW}Note: Bedrock config will override default Claude settings when sourced${NC}"
   else
-    echo "AWS CLI is available. Setting up Claude Code with AWS Bedrock..."
+    echo "AWS CLI is available. You can optionally set up Claude Code with AWS Bedrock."
     echo "This allows running Claude Code through your organization's AWS account."
-    
-    # Always set up Bedrock if AWS CLI is available and config doesn't exist
-    if [[ -f "$DOT_DEN/utils/setup-bedrock-claude.sh" ]]; then
-      bash "$DOT_DEN/utils/setup-bedrock-claude.sh"
+    echo ""
+    read -p "Would you like to set up AWS Bedrock integration? (y/N): " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+      if [[ -f "$DOT_DEN/utils/setup-bedrock-claude.sh" ]]; then
+        bash "$DOT_DEN/utils/setup-bedrock-claude.sh"
+      else
+        echo -e "${YELLOW}Warning: Bedrock setup script not found${NC}"
+      fi
     else
-      echo -e "${YELLOW}Warning: Bedrock setup script not found${NC}"
+      echo -e "${GREEN}✓ Skipping Bedrock setup - using default Claude Code configuration${NC}"
     fi
   fi
 else
-  echo -e "${YELLOW}AWS CLI not found. Skipping Bedrock integration.${NC}"
-  echo "To use Claude Code with AWS Bedrock, install AWS CLI first:"
+  echo -e "${YELLOW}AWS CLI not found. Using default Claude Code configuration.${NC}"
+  echo "To use Claude Code with AWS Bedrock later, install AWS CLI first:"
   echo "  https://aws.amazon.com/cli/"
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -660,6 +660,17 @@ echo -e "${GREEN}✅ Dotfiles setup complete!${NC}"
 echo "Your development environment is now configured and ready to use."
 echo -e "${DIVIDER}"
 
+# Reload environment configuration to ensure current session has correct settings
+echo "Reloading environment configuration..."
+if [[ -f ~/.bash_exports.claude.local ]]; then
+    source ~/.bash_exports.claude.local
+    echo -e "${GREEN}✓ Claude Code configured for standard Anthropic API${NC}"
+    echo "  CLAUDE_CODE_USE_BEDROCK: ${CLAUDE_CODE_USE_BEDROCK:-not set}"
+    echo "  ANTHROPIC_MODEL: ${ANTHROPIC_MODEL:-not set}"
+else
+    echo -e "${YELLOW}Warning: Claude Code default configuration not found${NC}"
+fi
+
 # Clear the error trap to prevent it from persisting in the shell session
 trap - ERR
 

--- a/utils/install-aws-cli.sh
+++ b/utils/install-aws-cli.sh
@@ -69,7 +69,7 @@ install_aws_cli_macos() {
         sudo installer -pkg AWSCLIV2.pkg -target /
         
         # Cleanup
-        cd -
+        cd - >/dev/null 2>&1
         rm -rf "$temp_dir"
     fi
 }
@@ -107,22 +107,12 @@ install_aws_cli_linux() {
 update_aws_cli() {
     echo -e "${BLUE}Checking for AWS CLI updates...${NC}"
     
-    # Get latest version from GitHub API
-    local latest_version=$(curl -s https://api.github.com/repos/aws/aws-cli/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+    # Skip update check - just report current version
     local current_version=$(get_aws_version)
+    echo -e "${GREEN}✓ AWS CLI version $current_version${NC}"
     
-    if [[ -z "$latest_version" ]]; then
-        echo -e "${YELLOW}Could not determine latest AWS CLI version${NC}"
-        return 0
-    fi
-    
-    if version_gt "$latest_version" "$current_version"; then
-        echo -e "${YELLOW}AWS CLI update available: $current_version → $latest_version${NC}"
-        echo "Updating AWS CLI..."
-        install_aws_cli
-    else
-        echo -e "${GREEN}✓ AWS CLI is up to date (version $current_version)${NC}"
-    fi
+    # Don't do automatic updates - they can be disruptive
+    return 0
 }
 
 # Main execution

--- a/utils/install-aws-cli.sh
+++ b/utils/install-aws-cli.sh
@@ -89,7 +89,7 @@ install_aws_cli_linux() {
         curl -s "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"
     else
         echo -e "${RED}Unsupported architecture: $arch${NC}"
-        cd -
+        cd - >/dev/null 2>&1
         rm -rf "$temp_dir"
         return 1
     fi
@@ -99,7 +99,7 @@ install_aws_cli_linux() {
     sudo ./aws/install --update
     
     # Cleanup
-    cd -
+    cd - >/dev/null 2>&1
     rm -rf "$temp_dir"
 }
 

--- a/utils/install-aws-cli.sh
+++ b/utils/install-aws-cli.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+# Install AWS CLI v2
+set -euo pipefail
+
+# ANSI color codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}Checking AWS CLI installation...${NC}"
+
+# Function to check if command exists
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Function to get current AWS CLI version
+get_aws_version() {
+    if command_exists aws; then
+        aws --version 2>/dev/null | awk '{print $1}' | cut -d'/' -f2
+    else
+        echo "0"
+    fi
+}
+
+# Function to compare versions
+version_gt() {
+    test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"
+}
+
+# Main installation function
+install_aws_cli() {
+    local os_type="$(uname -s)"
+    
+    case "$os_type" in
+        Darwin)
+            install_aws_cli_macos
+            ;;
+        Linux)
+            install_aws_cli_linux
+            ;;
+        *)
+            echo -e "${RED}Unsupported operating system: $os_type${NC}"
+            return 1
+            ;;
+    esac
+}
+
+# macOS installation
+install_aws_cli_macos() {
+    echo -e "${BLUE}Installing AWS CLI for macOS...${NC}"
+    
+    # Check if Homebrew is available
+    if command_exists brew; then
+        echo "Using Homebrew to install AWS CLI..."
+        brew install awscli
+    else
+        # Manual installation for macOS
+        echo "Installing AWS CLI manually..."
+        local temp_dir=$(mktemp -d)
+        cd "$temp_dir"
+        
+        # Download AWS CLI
+        curl -s "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
+        
+        # Install the package
+        sudo installer -pkg AWSCLIV2.pkg -target /
+        
+        # Cleanup
+        cd -
+        rm -rf "$temp_dir"
+    fi
+}
+
+# Linux installation
+install_aws_cli_linux() {
+    echo -e "${BLUE}Installing AWS CLI for Linux...${NC}"
+    
+    local temp_dir=$(mktemp -d)
+    cd "$temp_dir"
+    
+    # Detect architecture
+    local arch=$(uname -m)
+    if [[ "$arch" == "x86_64" ]]; then
+        curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+    elif [[ "$arch" == "aarch64" ]]; then
+        curl -s "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"
+    else
+        echo -e "${RED}Unsupported architecture: $arch${NC}"
+        cd -
+        rm -rf "$temp_dir"
+        return 1
+    fi
+    
+    # Unzip and install
+    unzip -q awscliv2.zip
+    sudo ./aws/install --update
+    
+    # Cleanup
+    cd -
+    rm -rf "$temp_dir"
+}
+
+# Update AWS CLI if needed
+update_aws_cli() {
+    echo -e "${BLUE}Checking for AWS CLI updates...${NC}"
+    
+    # Get latest version from GitHub API
+    local latest_version=$(curl -s https://api.github.com/repos/aws/aws-cli/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+    local current_version=$(get_aws_version)
+    
+    if [[ -z "$latest_version" ]]; then
+        echo -e "${YELLOW}Could not determine latest AWS CLI version${NC}"
+        return 0
+    fi
+    
+    if version_gt "$latest_version" "$current_version"; then
+        echo -e "${YELLOW}AWS CLI update available: $current_version → $latest_version${NC}"
+        echo "Updating AWS CLI..."
+        install_aws_cli
+    else
+        echo -e "${GREEN}✓ AWS CLI is up to date (version $current_version)${NC}"
+    fi
+}
+
+# Main execution
+main() {
+    if command_exists aws; then
+        local current_version=$(get_aws_version)
+        echo -e "${GREEN}✓ AWS CLI is already installed (version $current_version)${NC}"
+        
+        # Check for updates
+        update_aws_cli
+    else
+        echo -e "${YELLOW}AWS CLI not found. Installing...${NC}"
+        install_aws_cli
+        
+        # Verify installation
+        if command_exists aws; then
+            local version=$(get_aws_version)
+            echo -e "${GREEN}✓ AWS CLI installed successfully (version $version)${NC}"
+        else
+            echo -e "${RED}Failed to install AWS CLI${NC}"
+            return 1
+        fi
+    fi
+    
+    # Verify AWS CLI is in PATH
+    if ! command_exists aws; then
+        echo -e "${YELLOW}AWS CLI installed but not in PATH${NC}"
+        echo "You may need to add it to your PATH or restart your shell"
+    fi
+}
+
+# Export function for sourcing
+setup_aws_cli() {
+    main "$@"
+}
+
+# Run if executed directly
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/utils/setup-bedrock-claude.sh
+++ b/utils/setup-bedrock-claude.sh
@@ -127,7 +127,12 @@ main() {
     fi
     
     echo
+    echo
     echo -e "${GREEN}Bedrock setup complete!${NC}"
+    echo
+    echo -e "${BLUE}Important:${NC} This Bedrock configuration will override the default Claude Code setup."
+    echo "- Default: ~/.bash_exports.claude.local (standard Anthropic API)"
+    echo "- Bedrock: ~/.bash_exports.bedrock.local (AWS Bedrock - loaded after defaults)"
     echo
     echo "Next steps:"
     echo "1. Edit ~/.bash_exports.bedrock.local with your AWS account details"
@@ -136,6 +141,7 @@ main() {
     echo "4. Run: source ~/.bashrc"
     echo "5. Run: claude-bedrock (or just 'claude' with Bedrock env vars set)"
     echo
+    echo "To temporarily use default Claude Code, run: source ~/.bash_exports.claude.local"
     echo "For more information, see: docs/claude-bedrock-setup.md"
 }
 

--- a/utils/setup-bedrock-claude.sh
+++ b/utils/setup-bedrock-claude.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+# Setup script for Claude Code AWS Bedrock integration
+set -euo pipefail
+
+# ANSI color codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}Setting up Claude Code AWS Bedrock integration...${NC}"
+
+# Function to check if command exists
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Function to check AWS SSO login status
+check_aws_sso_status() {
+    local profile="${1:-$AWS_PROFILE}"
+    if [[ -z "$profile" ]]; then
+        return 1
+    fi
+    
+    # Try to get caller identity
+    if aws sts get-caller-identity --profile "$profile" >/dev/null 2>&1; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Function to setup Bedrock exports
+setup_bedrock_exports() {
+    local DOT_DEN="${DOT_DEN:-$HOME/ppv/pillars/dotfiles}"
+    local template_file="$DOT_DEN/.bash_exports.bedrock.template"
+    local local_file="$HOME/.bash_exports.bedrock.local"
+    
+    if [[ ! -f "$template_file" ]]; then
+        echo -e "${RED}Error: Template file not found at $template_file${NC}"
+        return 1
+    fi
+    
+    if [[ -f "$local_file" ]]; then
+        echo -e "${YELLOW}Bedrock exports file already exists at $local_file${NC}"
+        echo "Would you like to:"
+        echo "  1) Keep existing file"
+        echo "  2) View existing file"
+        echo "  3) Create from template (backup existing)"
+        read -p "Choose [1-3]: " choice
+        
+        case $choice in
+            1)
+                echo -e "${GREEN}Keeping existing Bedrock configuration${NC}"
+                return 0
+                ;;
+            2)
+                echo -e "${BLUE}Current Bedrock configuration:${NC}"
+                cat "$local_file"
+                echo
+                return 0
+                ;;
+            3)
+                backup_file="$local_file.backup.$(date +%Y%m%d_%H%M%S)"
+                cp "$local_file" "$backup_file"
+                echo -e "${GREEN}Backed up existing file to $backup_file${NC}"
+                ;;
+            *)
+                echo -e "${YELLOW}Invalid choice. Keeping existing file.${NC}"
+                return 0
+                ;;
+        esac
+    fi
+    
+    # Create new file from template
+    cp "$template_file" "$local_file"
+    echo -e "${GREEN}Created Bedrock exports file at $local_file${NC}"
+    echo -e "${YELLOW}Please edit this file to add your specific AWS account details${NC}"
+}
+
+# Function to setup AWS config
+setup_aws_config() {
+    local DOT_DEN="${DOT_DEN:-$HOME/ppv/pillars/dotfiles}"
+    local template_file="$DOT_DEN/aws/config.template"
+    local aws_config_dir="$HOME/.aws"
+    local aws_config_file="$aws_config_dir/config"
+    
+    # Create .aws directory if it doesn't exist
+    mkdir -p "$aws_config_dir"
+    
+    if [[ ! -f "$template_file" ]]; then
+        echo -e "${RED}Error: AWS config template not found at $template_file${NC}"
+        return 1
+    fi
+    
+    if [[ -f "$aws_config_file" ]]; then
+        echo -e "${YELLOW}AWS config already exists at $aws_config_file${NC}"
+        echo "Would you like to:"
+        echo "  1) Keep existing file"
+        echo "  2) View Bedrock profile template"
+        echo "  3) Append Bedrock profile template to existing config"
+        read -p "Choose [1-3]: " choice
+        
+        case $choice in
+            1)
+                echo -e "${GREEN}Keeping existing AWS configuration${NC}"
+                return 0
+                ;;
+            2)
+                echo -e "${BLUE}Bedrock profile template:${NC}"
+                cat "$template_file"
+                echo
+                return 0
+                ;;
+            3)
+                echo "" >> "$aws_config_file"
+                echo "# Added by dotfiles setup-bedrock-claude.sh on $(date)" >> "$aws_config_file"
+                cat "$template_file" >> "$aws_config_file"
+                echo -e "${GREEN}Appended Bedrock profile template to AWS config${NC}"
+                echo -e "${YELLOW}Please edit $aws_config_file to customize the profile${NC}"
+                ;;
+            *)
+                echo -e "${YELLOW}Invalid choice. Keeping existing file.${NC}"
+                return 0
+                ;;
+        esac
+    else
+        # Create new config from template
+        cp "$template_file" "$aws_config_file"
+        echo -e "${GREEN}Created AWS config at $aws_config_file${NC}"
+        echo -e "${YELLOW}Please edit this file to add your specific AWS SSO details${NC}"
+    fi
+}
+
+# Main setup function
+main() {
+    # Check for AWS CLI
+    if ! command_exists aws; then
+        echo -e "${RED}AWS CLI is not installed${NC}"
+        echo "Please install AWS CLI first: https://aws.amazon.com/cli/"
+        return 1
+    fi
+    
+    # Check for Claude Code
+    if ! command_exists claude; then
+        echo -e "${YELLOW}Claude Code is not installed${NC}"
+        echo "Installing Claude Code is recommended before using Bedrock integration"
+    fi
+    
+    # Setup AWS config
+    echo -e "${BLUE}Step 1: Setting up AWS configuration${NC}"
+    setup_aws_config
+    
+    # Setup Bedrock exports
+    echo -e "${BLUE}Step 2: Setting up Bedrock environment variables${NC}"
+    setup_bedrock_exports
+    
+    # Check if .bashrc sources the Bedrock exports
+    if ! grep -q ".bash_exports.bedrock.local" "$HOME/.bashrc" 2>/dev/null; then
+        echo -e "${BLUE}Step 3: Adding Bedrock exports to .bashrc${NC}"
+        echo "" >> "$HOME/.bashrc"
+        echo "# Source Bedrock exports if available" >> "$HOME/.bashrc"
+        echo "[[ -f ~/.bash_exports.bedrock.local ]] && source ~/.bash_exports.bedrock.local" >> "$HOME/.bashrc"
+        echo -e "${GREEN}Added Bedrock exports to .bashrc${NC}"
+    else
+        echo -e "${GREEN}Bedrock exports already configured in .bashrc${NC}"
+    fi
+    
+    echo
+    echo -e "${GREEN}Bedrock setup complete!${NC}"
+    echo
+    echo "Next steps:"
+    echo "1. Edit ~/.bash_exports.bedrock.local with your AWS account details"
+    echo "2. Edit ~/.aws/config with your SSO configuration"
+    echo "3. Run: aws sso login --profile bedrock_profile"
+    echo "4. Run: source ~/.bashrc"
+    echo "5. Run: claude-bedrock (or just 'claude' with Bedrock env vars set)"
+    echo
+    echo "For more information, see: docs/claude-bedrock-setup.md"
+}
+
+# Run main function
+main "$@"

--- a/utils/setup-bedrock-claude.sh
+++ b/utils/setup-bedrock-claude.sh
@@ -43,34 +43,9 @@ setup_bedrock_exports() {
     fi
     
     if [[ -f "$local_file" ]]; then
-        echo -e "${YELLOW}Bedrock exports file already exists at $local_file${NC}"
-        echo "Would you like to:"
-        echo "  1) Keep existing file"
-        echo "  2) View existing file"
-        echo "  3) Create from template (backup existing)"
-        read -p "Choose [1-3]: " choice
-        
-        case $choice in
-            1)
-                echo -e "${GREEN}Keeping existing Bedrock configuration${NC}"
-                return 0
-                ;;
-            2)
-                echo -e "${BLUE}Current Bedrock configuration:${NC}"
-                cat "$local_file"
-                echo
-                return 0
-                ;;
-            3)
-                backup_file="$local_file.backup.$(date +%Y%m%d_%H%M%S)"
-                cp "$local_file" "$backup_file"
-                echo -e "${GREEN}Backed up existing file to $backup_file${NC}"
-                ;;
-            *)
-                echo -e "${YELLOW}Invalid choice. Keeping existing file.${NC}"
-                return 0
-                ;;
-        esac
+        echo -e "${GREEN}Bedrock exports file already exists at $local_file${NC}"
+        echo -e "${GREEN}Keeping existing configuration${NC}"
+        return 0
     fi
     
     # Create new file from template
@@ -95,36 +70,20 @@ setup_aws_config() {
     fi
     
     if [[ -f "$aws_config_file" ]]; then
-        echo -e "${YELLOW}AWS config already exists at $aws_config_file${NC}"
-        echo "Would you like to:"
-        echo "  1) Keep existing file"
-        echo "  2) View Bedrock profile template"
-        echo "  3) Append Bedrock profile template to existing config"
-        read -p "Choose [1-3]: " choice
+        echo -e "${GREEN}AWS config already exists at $aws_config_file${NC}"
         
-        case $choice in
-            1)
-                echo -e "${GREEN}Keeping existing AWS configuration${NC}"
-                return 0
-                ;;
-            2)
-                echo -e "${BLUE}Bedrock profile template:${NC}"
-                cat "$template_file"
-                echo
-                return 0
-                ;;
-            3)
-                echo "" >> "$aws_config_file"
-                echo "# Added by dotfiles setup-bedrock-claude.sh on $(date)" >> "$aws_config_file"
-                cat "$template_file" >> "$aws_config_file"
-                echo -e "${GREEN}Appended Bedrock profile template to AWS config${NC}"
-                echo -e "${YELLOW}Please edit $aws_config_file to customize the profile${NC}"
-                ;;
-            *)
-                echo -e "${YELLOW}Invalid choice. Keeping existing file.${NC}"
-                return 0
-                ;;
-        esac
+        # Check if bedrock_profile already exists
+        if grep -q "profile bedrock_profile" "$aws_config_file" 2>/dev/null; then
+            echo -e "${GREEN}Bedrock profile already configured${NC}"
+            return 0
+        else
+            # Append the template
+            echo "" >> "$aws_config_file"
+            echo "# Added by dotfiles setup-bedrock-claude.sh on $(date)" >> "$aws_config_file"
+            cat "$template_file" >> "$aws_config_file"
+            echo -e "${GREEN}Appended Bedrock profile template to AWS config${NC}"
+            echo -e "${YELLOW}Please edit $aws_config_file to customize the profile${NC}"
+        fi
     else
         # Create new config from template
         cp "$template_file" "$aws_config_file"


### PR DESCRIPTION
## Summary
Establishes non-Bedrock Claude Code configuration as the default experience while keeping Bedrock integration available as an opt-in enterprise feature.

## Key Changes

### 1. Default Non-Bedrock Configuration
- **Created**: `.bash_exports.claude.template` - template for default Claude Code setup
- **Ensures**: Claude Code works out-of-the-box with standard Anthropic API
- **Model**: Claude 3 Opus Latest as default (as requested)
- **No AWS Required**: Works immediately without any AWS configuration

### 2. Shell Configuration Priority
- **Updated**: `.bashrc` to load Claude defaults first, then Bedrock overrides
- **Pattern**: `~/.bash_exports.claude.local` → `~/.bash_exports.bedrock.local`
- **Result**: Non-Bedrock works by default, Bedrock overrides when present

### 3. Setup Script Improvements
- **Always creates**: Default non-Bedrock configuration first
- **Makes Bedrock opt-in**: Requires explicit user confirmation (y/N prompt)
- **No auto-setup**: Stops automatically configuring Bedrock when AWS CLI detected
- **Clear messaging**: Explains what each configuration does

### 4. Documentation Updates
- **README**: Emphasizes default non-Bedrock experience first
- **Bedrock docs**: Repositioned as "Optional Enterprise Feature"
- **Setup scripts**: Include notes about configuration precedence

### 5. Built on Existing Work
- **Branched from**: `feature/bedrock-integration-761` 
- **Keeps all**: Bedrock documentation and functionality intact
- **Versioning Mindset**: Builds on rather than replaces existing work

## Testing
- ✅ Fresh setup creates working non-Bedrock configuration
- ✅ `source setup.sh` results in `CLAUDE_CODE_USE_BEDROCK=0`
- ✅ Bedrock integration still works when explicitly enabled
- ✅ Clear separation between default and enterprise configurations

## Usage

### Default Experience (New Users)
```bash
git clone && source setup.sh
# → Claude Code works immediately with Anthropic API
```

### Enterprise Users (Opt-in)
```bash
source setup.sh
# → Answer 'y' when prompted for Bedrock setup
# → Or run: bash utils/setup-bedrock-claude.sh
```

### Switching Between Configurations
```bash
# Use default (non-Bedrock)
source ~/.bash_exports.claude.local

# Use Bedrock (if configured)
source ~/.bash_exports.bedrock.local
```

## Addresses
- Closes #763 - Establishes default non-Bedrock Claude Code environment
- Complements #761 - Keeps Bedrock functionality as opt-in feature
- Follows **Spilled Coffee Principle** - All configuration is scripted and reproducible
- Follows **Developer Experience** - Joy in the loop with working defaults

Principle: developer-experience, systems-stewardship