### PR TITLE
fix(claude): remove invalid fields from Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -60,17 +60,6 @@
     "MCP_TOOL_TIMEOUT": "60000",
     "MAX_MCP_OUTPUT_TOKENS": "25000"
   },
-  "theme": "dark-daltonized",
-  "editorMode": "normal",
-  "autoUpdates": true,
-  "verbose": true,
-  "preferredNotifChannel": "terminal_bell",
-  "diffTool": "auto",
-  "parallelTasksCount": 1,
-  "todoFeatureEnabled": true,
-  "messageIdleNotifThresholdMs": 60000,
-  "autoConnectIde": false,
-  "autoCompactEnabled": true,
   "enableAllProjectMcpServers": false,
   "enabledMcpjsonServers": [
     "awslabs.aws-documentation-mcp-server",


### PR DESCRIPTION
<!-- 
AUDIENCE: Future AI agents searching for solutions to similar problems
FORMAT: Use keywords, exact error messages, and technical details they'll search for
-->

## Problem & Solution
<!-- What problem does this solve? Include exact error messages and symptoms -->
**Problem**: The `/doctor` command was reporting invalid fields in Claude Code settings files, causing warnings about unrecognized configuration options.

**Solution**: Removed all invalid fields from `.claude/settings.json` to ensure only documented configuration options remain.

**Keywords**: Claude Code settings, invalid fields, /doctor command, settings.json, unrecognized configuration

## Related Issues
<!-- Link related issues: Fixes #issue_number, Closes #issue_number -->
Closes #765

## Technical Details
<!-- Specific changes for AI discovery -->
**Files changed**: `.claude/settings.json`

**Key modifications**: Removed the following invalid fields:
- `theme`
- `editorMode`
- `autoUpdates`
- `verbose`
- `preferredNotifChannel`
- `diffTool`
- `parallelTasksCount`
- `todoFeatureEnabled`
- `messageIdleNotifThresholdMs`
- `autoConnectIde`
- `autoCompactEnabled`

**Alternative approaches considered**: None - straightforward removal of invalid fields was the appropriate solution.

## Testing
<!-- How to verify this works -->
1. Run `/doctor` command - should no longer report invalid settings warnings
2. Verify JSON validity with `python -m json.tool .claude/settings.json`
3. Ensure Claude Code continues to function normally with the cleaned settings

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added/updated tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have updated the documentation accordingly (if applicable)