### PR TITLE
perf(mcp): comment out gdrive setup to improve setup.sh performance

### DIFF
--- a/mcp/setup-all-mcp-servers.sh
+++ b/mcp/setup-all-mcp-servers.sh
@@ -40,7 +40,7 @@ setup_scripts=(
     "setup-filesystem-mcp.sh"
     "setup-gitlab-mcp.sh"
     "setup-brave-search-mcp.sh"
-    "setup-gdrive-mcp.sh"
+    # "setup-gdrive-mcp.sh"  # Commented out to improve setup time - run manually when needed
 )
 
 failed_setups=()


### PR DESCRIPTION
## Summary
- Comments out `setup-gdrive-mcp.sh` from automated setup to reduce setup.sh execution time by ~30 seconds
- Google Drive MCP can still be manually configured by running `mcp/setup-gdrive-mcp.sh` directly
- Preserves all timeout handling logic and documentation for manual execution

## Motivation
The Google Drive MCP setup script causes a 30-second timeout delay during `setup.sh` execution, elongating development feedback loops. Since this server is not always needed immediately, moving it to manual setup improves the developer experience without losing functionality.

## Changes
- Commented out `setup-gdrive-mcp.sh` in the `setup_scripts` array in `mcp/setup-all-mcp-servers.sh`
- Added explanatory comment indicating manual setup option

## Testing
- [x] Verified setup.sh runs without gdrive setup
- [x] Confirmed setup-gdrive-mcp.sh still exists for manual execution
- [x] Timeout handling logic remains intact for manual runs

## Impact
- **Performance**: ~30 second reduction in setup.sh execution time
- **Functionality**: No loss - Google Drive MCP can be set up on-demand
- **Developer Experience**: Faster feedback loops during development

Closes #769