### PR TITLE
docs(git-workflow): add post-merge best practice note

### DIFF
--- a/knowledge/procedures/git-workflow.md
+++ b/knowledge/procedures/git-workflow.md
@@ -37,6 +37,10 @@ Starting from a stale foundation guarantees the recovery tax - double work to ac
 
 These standards make intent visible and prevent the recovery tax.
 
+## Post-Merge Best Practice
+After merging a PR, switch to the base branch and pull latest to avoid working on stale code.
+→ [versioning-mindset](../principles/versioning-mindset.md) (stay current with ground truth)
+
 ## Common Errors to Avoid
 - Don't thank self when closing your own PRs
 


### PR DESCRIPTION
## Summary
Added simple reminder to git workflow about post-merge branch switching.

## Implementation
- One line in existing git-workflow.md
- References versioning mindset principle
- No code changes, no complex metadata

## Principle
**Versioning Mindset**: Stay current with ground truth after merge operations.

Much simpler than the original complex MCP enhancement approach.

Closes #772