### PR TITLE
feat(mcp): enable global MCP configuration via claude alias

### DIFF
--- a/.bash_aliases.d/claude-mcp.sh
+++ b/.bash_aliases.d/claude-mcp.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Claude Code MCP configuration alias
+# This ensures Claude Code always uses the global MCP configuration from dotfiles
+
+# Define the global MCP config location
+# DOT_DEN is set by setup.sh, fallback to home dotfiles if not set
+DOT_DEN="${DOT_DEN:-$HOME/ppv/pillars/dotfiles}"
+GLOBAL_MCP_CONFIG="$DOT_DEN/mcp/mcp.json"
+
+# Create claude alias that includes the MCP config
+# This allows MCP servers to be available from any directory
+alias claude='claude --mcp-config "$GLOBAL_MCP_CONFIG"'
+
+# Optional: Add a variant that strictly uses only the global config
+# (ignoring any local .mcp.json files)
+alias claude-global='claude --mcp-config "$GLOBAL_MCP_CONFIG" --strict-mcp-config'
+
+# Helpful function to check current MCP config
+claude-mcp-info() {
+    echo "Global MCP config: $GLOBAL_MCP_CONFIG"
+    if [ -f "$GLOBAL_MCP_CONFIG" ]; then
+        echo "✓ Config file exists"
+        echo "Available MCP servers:"
+        jq -r '.mcpServers | keys[]' "$GLOBAL_MCP_CONFIG" 2>/dev/null | sed 's/^/  - /' || echo "  (unable to parse config)"
+    else
+        echo "✗ Config file not found!"
+        echo "  Run 'source ~/ppv/pillars/dotfiles/setup.sh' to set up MCP configuration"
+    fi
+}
+
+# Optional: Completion for the aliased claude command
+# This ensures tab completion still works with our alias
+if command -v claude >/dev/null 2>&1; then
+    complete -F _claude claude 2>/dev/null || true
+    complete -F _claude claude-global 2>/dev/null || true
+fi

--- a/.bash_aliases.d/claude-mcp.sh
+++ b/.bash_aliases.d/claude-mcp.sh
@@ -24,7 +24,7 @@ claude-mcp-info() {
         jq -r '.mcpServers | keys[]' "$GLOBAL_MCP_CONFIG" 2>/dev/null | sed 's/^/  - /' || echo "  (unable to parse config)"
     else
         echo "✗ Config file not found!"
-        echo "  Run 'source ~/ppv/pillars/dotfiles/setup.sh' to set up MCP configuration"
+        echo "  Run 'source \$DOT_DEN/setup.sh' to set up MCP configuration"
     fi
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 A living log of notable changes, decisions, and modifications to the dotfiles setup.
 
+## 2025-07-13
+
+- **Global MCP Configuration**: Created claude alias to include --mcp-config, enabling MCP servers from any directory (#791)
+- Added `.bash_aliases.d/claude-mcp.sh` - provides global MCP access without manual copying (Spilled Coffee)
+- Enhanced `install-claude-code.sh` docs - clarified global MCP configuration approach (Systems Stewardship)
+- Added README section for Global MCP Configuration - documented commands and usage (Transparency in Agent Work)
+
 ## 2025-06-22
 
 - **Claude Code Integration**: Added Claude Code CLI support after purchasing Claude Max plan

--- a/README.md
+++ b/README.md
@@ -255,6 +255,45 @@ To add or modify Claude Code settings:
 
 Current configured settings include co-authorship attribution, MCP servers, permissions, and more.
 
+## Global MCP Configuration
+
+The dotfiles provide global access to MCP (Model Context Protocol) servers from any directory on your system. After running `source setup.sh`, MCP servers are automatically available through the `claude` command alias.
+
+### How it works
+
+1. **Central Configuration**: MCP servers are defined in `mcp/mcp.json`
+2. **Global Alias**: The `claude` command is aliased to include `--mcp-config` automatically
+3. **Work Anywhere**: No need to copy `.mcp.json` files to each project directory
+
+### Available Commands
+
+```bash
+# Standard claude command (includes global MCP config automatically)
+claude "What files are in this directory?"
+
+# Check current MCP configuration
+claude-mcp-info
+
+# Use strict global config (ignores any local .mcp.json files)
+claude-global "Run a command with only global MCP servers"
+
+# Add user-scoped servers (persists across all projects)
+claude mcp add my-server -s user /path/to/server
+```
+
+### MCP Servers Included
+
+The dotfiles include pre-configured MCP servers for:
+- Git operations (git-mcp-server)
+- GitHub integration (github-mcp-server with read/write split)
+- GitLab integration (requires glab CLI)
+- Brave Search API
+- Filesystem operations
+- Google Drive access
+- Atlassian tools (work machines only)
+
+Work-specific servers (Atlassian, GitLab) require `WORK_MACHINE=true` in `~/.bash_exports.local`.
+
 ## Secret Management
 
 Sensitive information like API tokens are stored in `~/.bash_secrets` (not tracked in git).

--- a/utils/install-claude-code.sh
+++ b/utils/install-claude-code.sh
@@ -114,13 +114,15 @@ configure_claude_mcp() {
     fi
     
     echo -e "\n${BLUE}MCP Configuration Notes:${NC}"
-    echo -e "  • Dotfiles provides: $DOT_DEN/.mcp.json"
+    echo -e "  • Global MCP config: $DOT_DEN/mcp/mcp.json"
     echo -e "  • Work-only servers (Atlassian, GitLab) require WORK_MACHINE=true"
-    echo -e "  • To use in other projects: Copy .mcp.json to that project's root"
+    echo -e "  • ${GREEN}Global access enabled:${NC} 'claude' alias includes --mcp-config automatically"
+    echo -e "  • MCP servers available from ANY directory after running setup.sh"
     echo -e "\n${YELLOW}Claude Code MCP commands:${NC}"
     echo -e "  • List servers: claude mcp list"
-    echo -e "  • Add local override: claude mcp add <name> <command>"
-    echo -e "  • Force config file: claude --mcp-config /path/to/mcp.json"
+    echo -e "  • Add user-scoped server: claude mcp add <name> <command> -s user"
+    echo -e "  • Check MCP info: claude-mcp-info"
+    echo -e "  • Use strict global config: claude-global <command>"
 }
 
 # Run setup if script is executed directly (not sourced)


### PR DESCRIPTION
## Summary

This PR implements global MCP configuration access by creating a `claude` alias that automatically includes the `--mcp-config` flag. This eliminates the need to manually copy `.mcp.json` files to each project directory.

## Changes

- **Added `.bash_aliases.d/claude-mcp.sh`**: Creates `claude` alias with global MCP config and utility functions
- **Updated `install-claude-code.sh`**: Enhanced documentation to explain global MCP access
- **Updated README.md**: Added "Global MCP Configuration" section with usage instructions
- **Updated CHANGELOG.md**: Documented the changes

## How it works

1. The `claude` command is aliased to include `--mcp-config "$DOT_DEN/mcp/mcp.json"`
2. MCP servers are now available from any directory after running `source setup.sh`
3. Added `claude-mcp-info` function to check current MCP configuration
4. Added `claude-global` alias for strict global config mode

## Testing

- Sourced setup.sh to apply the alias
- Verified `type claude` shows the alias with --mcp-config
- Tested `claude-mcp-info` shows correct global config path
- Confirmed MCP servers are listed correctly

## Benefits

- No more manual copying of `.mcp.json` to project directories
- Consistent MCP server access across all projects
- Centralized MCP configuration management
- Follows the Spilled Coffee Principle - automated and reproducible

Closes #791