### PR TITLE
feat(claude): apply global settings via wrapper function

### DIFF
--- a/.bash_aliases.d/claude-mcp.sh
+++ b/.bash_aliases.d/claude-mcp.sh
@@ -1,36 +1,107 @@
 #!/bin/bash
-# Claude Code MCP configuration alias
-# This ensures Claude Code always uses the global MCP configuration from dotfiles
+# Claude Code global configuration (MCP + settings)
+# This ensures Claude Code uses both MCP servers and settings from dotfiles globally
 
-# Define the global MCP config location
+# Define the global config locations
 # DOT_DEN is set by setup.sh, fallback to home dotfiles if not set
 DOT_DEN="${DOT_DEN:-$HOME/ppv/pillars/dotfiles}"
 GLOBAL_MCP_CONFIG="$DOT_DEN/mcp/mcp.json"
+GLOBAL_SETTINGS="$DOT_DEN/.claude/settings.json"
 
-# Create claude alias that includes the MCP config
-# This allows MCP servers to be available from any directory
-alias claude='claude --mcp-config "$GLOBAL_MCP_CONFIG"'
-
-# Optional: Add a variant that strictly uses only the global config
-# (ignoring any local .mcp.json files)
-alias claude-global='claude --mcp-config "$GLOBAL_MCP_CONFIG" --strict-mcp-config'
-
-# Helpful function to check current MCP config
-claude-mcp-info() {
-    echo "Global MCP config: $GLOBAL_MCP_CONFIG"
-    if [ -f "$GLOBAL_MCP_CONFIG" ]; then
-        echo "✓ Config file exists"
-        echo "Available MCP servers:"
-        jq -r '.mcpServers | keys[]' "$GLOBAL_MCP_CONFIG" 2>/dev/null | sed 's/^/  - /' || echo "  (unable to parse config)"
-    else
-        echo "✗ Config file not found!"
-        echo "  Run 'source \$DOT_DEN/setup.sh' to set up MCP configuration"
+# Main Claude wrapper that applies both MCP config and settings
+claude() {
+    # Export environment variables from settings.json
+    if [ -f "$GLOBAL_SETTINGS" ] && command -v jq &> /dev/null; then
+        while IFS='=' read -r key value; do
+            export "$key=$value"
+        done < <(jq -r '.env | to_entries[] | "\(.key)=\(.value)"' "$GLOBAL_SETTINGS" 2>/dev/null)
     fi
+
+    # Extract allowed tools from settings.json
+    local allowed_tools=""
+    if [ -f "$GLOBAL_SETTINGS" ] && command -v jq &> /dev/null; then
+        allowed_tools=$(jq -r '.permissions.allow[]' "$GLOBAL_SETTINGS" 2>/dev/null | tr '\n' ' ')
+    fi
+
+    # Build command with both MCP config and allowed tools
+    local cmd=(command claude --mcp-config "$GLOBAL_MCP_CONFIG")
+    
+    if [ -n "$allowed_tools" ]; then
+        cmd+=(--allowedTools "$allowed_tools")
+    fi
+    
+    # Execute with all arguments
+    "${cmd[@]}" "$@"
 }
 
-# Optional: Completion for the aliased claude command
-# This ensures tab completion still works with our alias
+# Variant that strictly uses only the global configs
+alias claude-global='claude --strict-mcp-config'
+
+# Function to check all global configurations
+claude-global-info() {
+    echo "=== Claude Code Global Configuration ==="
+    echo ""
+    echo "MCP Configuration:"
+    echo "  Path: $GLOBAL_MCP_CONFIG"
+    if [ -f "$GLOBAL_MCP_CONFIG" ]; then
+        echo "  ✓ MCP config exists"
+        echo "  Available MCP servers:"
+        jq -r '.mcpServers | keys[]' "$GLOBAL_MCP_CONFIG" 2>/dev/null | sed 's/^/    - /' || echo "    (unable to parse)"
+    else
+        echo "  ✗ MCP config not found!"
+    fi
+    
+    echo ""
+    echo "Settings Configuration:"
+    echo "  Path: $GLOBAL_SETTINGS"
+    if [ -f "$GLOBAL_SETTINGS" ]; then
+        echo "  ✓ Settings file exists"
+        echo "  Environment variables:"
+        jq -r '.env | to_entries[] | "    \(.key)=\(.value)"' "$GLOBAL_SETTINGS" 2>/dev/null || echo "    (unable to parse)"
+        echo "  Permissions: $(jq -r '.permissions.allow | length' "$GLOBAL_SETTINGS" 2>/dev/null || echo "?") allowed tools"
+    else
+        echo "  ✗ Settings file not found!"
+    fi
+    
+    echo ""
+    echo "Note: Settings wrapper active for environment variables and permissions"
+}
+
+# Backwards compatibility
+alias claude-mcp-info='claude-global-info'
+
+# Test function to verify settings are applied
+claude-test-settings() {
+    echo "Testing Claude Code global settings..."
+    echo ""
+    echo "Environment variables from dotfiles:"
+    
+    if [ -f "$GLOBAL_SETTINGS" ] && command -v jq &> /dev/null; then
+        while IFS='=' read -r key expected; do
+            current_value="${!key}"
+            if [ -n "$current_value" ]; then
+                if [ "$current_value" = "$expected" ]; then
+                    echo "  ✓ $key=$current_value"
+                else
+                    echo "  ⚠ $key=$current_value (expected: $expected)"
+                fi
+            else
+                echo "  ✗ $key (not set, expected: $expected)"
+            fi
+        done < <(jq -r '.env | to_entries[] | "\(.key)=\(.value)"' "$GLOBAL_SETTINGS" 2>/dev/null)
+    else
+        echo "  Unable to read settings file"
+    fi
+    
+    echo ""
+    echo "To verify in a Claude session:"
+    echo '  claude "echo \$CLAUDE_CODE_MAX_OUTPUT_TOKENS"'
+    echo "  Expected output: 8192"
+}
+
+# Optional: Completion for the wrapper function
 if command -v claude >/dev/null 2>&1; then
+    # Use function completion instead of alias completion
     complete -F _claude claude 2>/dev/null || true
     complete -F _claude claude-global 2>/dev/null || true
 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ A living log of notable changes, decisions, and modifications to the dotfiles se
 - Added `.bash_aliases.d/claude-mcp.sh` - provides global MCP access without manual copying (Spilled Coffee)
 - Enhanced `install-claude-code.sh` docs - clarified global MCP configuration approach (Systems Stewardship)
 - Added README section for Global MCP Configuration - documented commands and usage (Transparency in Agent Work)
+- **Global Claude Settings**: Enhanced wrapper to apply env vars and permissions from settings.json globally (#794)
+- Unified MCP and settings into single wrapper - exports env vars and passes allowed tools (Invent and Simplify)
+- Added `claude-test-settings` function - verify global settings are applied correctly (Tracer Bullets)
+- Workaround for Claude Code not reading ~/.claude/settings.json yet (Systems Stewardship)
 
 ## 2025-06-22
 

--- a/README.md
+++ b/README.md
@@ -255,31 +255,42 @@ To add or modify Claude Code settings:
 
 Current configured settings include co-authorship attribution, MCP servers, permissions, and more.
 
-## Global MCP Configuration
+## Global Claude Code Configuration
 
-The dotfiles provide global access to MCP (Model Context Protocol) servers from any directory on your system. After running `source setup.sh`, MCP servers are automatically available through the `claude` command alias.
+The dotfiles provide global configuration for Claude Code, including MCP servers, environment variables, and permissions. After running `source setup.sh`, these settings are automatically applied to all Claude sessions.
 
 ### How it works
 
-1. **Central Configuration**: MCP servers are defined in `mcp/mcp.json`
-2. **Global Alias**: The `claude` command is aliased to include `--mcp-config` automatically
-3. **Work Anywhere**: No need to copy `.mcp.json` files to each project directory
+1. **MCP Servers**: Defined in `mcp/mcp.json` and applied via `--mcp-config`
+2. **Settings**: Environment variables and permissions from `.claude/settings.json` 
+3. **Unified Wrapper**: The `claude` command applies both MCP and settings globally
+4. **Work Anywhere**: No need to copy configuration files to each project
 
 ### Available Commands
 
 ```bash
-# Standard claude command (includes global MCP config automatically)
+# Standard claude command (includes all global settings)
 claude "What files are in this directory?"
 
-# Check current MCP configuration
-claude-mcp-info
+# Check all global configurations
+claude-global-info
 
-# Use strict global config (ignores any local .mcp.json files)
-claude-global "Run a command with only global MCP servers"
+# Test if settings are being applied
+claude-test-settings
 
-# Add user-scoped servers (persists across all projects)
-claude mcp add my-server -s user /path/to/server
+# Use strict global config (ignores any local files)
+claude-global "Run with only global settings"
 ```
+
+### Global Settings Applied
+
+The following settings from `.claude/settings.json` are applied globally:
+
+- **Environment Variables**: Token limits, timeouts, and feature flags
+- **Permissions**: Allowed tools and commands
+- **MCP Servers**: Enabled servers from the configuration
+
+Note: Some settings like `includeCoAuthoredBy` require Claude Code to complete its migration to `settings.json`.
 
 ### MCP Servers Included
 


### PR DESCRIPTION
## Summary

This PR implements a workaround to apply Claude Code settings globally, addressing the issue where Claude Code doesn't yet read from `~/.claude/settings.json`.

## Problem

- Claude Code currently uses `~/.claude.json` (52MB file) instead of `~/.claude/settings.json`
- Environment variables and permissions defined in dotfiles weren't being applied globally
- The symlink exists but Claude Code doesn't use it yet

## Solution

Enhanced the `claude-mcp.sh` wrapper to:
1. Export environment variables from `settings.json` before launching Claude
2. Pass permissions via the `--allowedTools` flag
3. Combine both MCP configuration and settings into a unified wrapper

## Changes

- **Enhanced `.bash_aliases.d/claude-mcp.sh`**: 
  - Exports env vars from settings.json
  - Passes allowed tools via --allowedTools flag
  - Unified MCP and settings functionality
- **Added utility functions**:
  - `claude-global-info`: Shows both MCP and settings status
  - `claude-test-settings`: Verifies settings are applied
- **Updated documentation**: README and CHANGELOG reflect the new functionality

## Testing

```bash
# Source the updated aliases
source setup.sh

# Check global configuration
claude-global-info

# Test settings are applied
claude-test-settings

# Verify in Claude session
claude "echo \$CLAUDE_CODE_MAX_OUTPUT_TOKENS"
# Expected: 8192
```

## Benefits

- Settings from dotfiles are now applied globally to all Claude sessions
- No need to copy settings files to each project
- Provides a working solution until Claude Code completes its migration
- Follows the global-first configuration principle

## Notes

This is a temporary workaround. Once Claude Code completes its migration to reading from `~/.claude/settings.json`, this wrapper functionality will become unnecessary as the symlink will work directly.

Closes #794