### PR TITLE
docs(readme): add global-first configuration principle

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,31 @@ At an even higher level, this is all about **creating value by serving others**.
 
 This serving mindset acknowledges the tension as a pendulum rather than trying to eliminate it. Like Ecclesiastes 3:1 says, there's a season for everything - sometimes lean into systems work to build leverage, sometimes focus purely on delivery. The key is conscious awareness and feedback loops, always returning to: "How does this serve others better?"
 
+### Global-First Configuration
+
+This principle establishes that configurations in dotfiles should default to global application unless explicitly marked otherwise. This aligns with the fundamental purpose of a dotfiles repository - to provide consistent configuration across your entire system.
+
+**Core Principle**: When implementing features, bias toward global configuration over local. Dotfiles are for global configuration.
+
+**Implementation Guidelines**:
+- **Default**: Make configurations global (system-wide)
+- **Exception**: If a configuration must be local, document why and add a plan to make it global
+- **Pattern**: Use aliases, symlinks, or tool-specific global config locations
+
+**Examples**:
+- ✅ MCP configuration via `claude` alias with `--mcp-config` (global by default)
+- ✅ Bash aliases sourced from `~/.bashrc` (apply everywhere)
+- ⚠️  Claude Code settings migration to `~/.claude/settings.json` (work in progress, see #577)
+
+**Documentation Distinction**:
+- **README.md**: Repository-specific documentation and principles (this file)
+- **knowledge/ directory**: Global context that applies across ALL repositories
+  - Automatically included in AI assistant context windows
+  - Contains principles, procedures, and patterns used everywhere
+  - Think of it as "portable wisdom" that travels with you
+
+When in doubt, ask: "Should this apply everywhere I code?" If yes → global configuration. If it's specific to how this dotfiles repo works → document it here in README.md.
+
 ## Repository Design Patterns
 
 This repository follows specific organizational patterns to maintain consistency and clarity:


### PR DESCRIPTION
## Problem & Solution
**Problem**: The distinction between local repository-specific documentation (README.md) and global context (knowledge/ directory) was unclear, leading to confusion about where configurations should be documented.

**Solution**: Added a new "Global-First Configuration" section to README.md that:
- Establishes the principle that dotfiles configurations should default to global application
- Clearly distinguishes between README.md (local) and knowledge/ directory (global)
- Provides implementation guidelines and examples

**Keywords**: dotfiles, global configuration, documentation structure, configuration management

## Related Issues
Closes #793

## Technical Details
**Files changed**: 
- `README.md` - Added new section after "The 80/20 Rule for Systems Work"

**Key modifications**: 
- Documented the global-first principle for dotfiles configurations
- Clarified when to use README.md vs knowledge/ directory
- Added concrete examples of global vs local configurations
- Provided implementation guidelines for new features

**Alternative approaches considered**: 
- Could have created a separate document, but README.md is the natural place for repository-specific principles
- Could have updated knowledge/ directory, but that would contradict the very principle being established

## Testing
- Documentation change only - no functional changes
- Reviewed formatting and clarity of the new section
- Verified examples align with current repository practices

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added/updated tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have updated the documentation accordingly (if applicable)