### PR TITLE
docs(principles): add MCP tool file path transparency examples

### DIFF
--- a/knowledge/principles/transparency-in-agent-work.md
+++ b/knowledge/principles/transparency-in-agent-work.md
@@ -10,3 +10,10 @@ Prioritize transparency by explicitly showing the agent's planning steps and dec
 - Use post-PR cycles as opportunities for agent-human knowledge transfer
 
 This principle ensures that human understanding grows alongside agent capability, creating a virtuous learning cycle where both parties improve through shared visibility into the work process.
+
+## MCP Tool File Path Transparency
+
+**Bad:** `../../../file.md` - forces mental path resolution
+**Good:** `/Users/morgan.joyce/ppv/pillars/dotfiles/file.md` - immediate clarity
+
+Use full paths in tool calls for user verification.


### PR DESCRIPTION
## Summary
- Added concise examples to transparency-in-agent-work principle
- Shows why full paths are better than relative paths for user verification
- Keeps examples minimal to save tokens in global context

## Changes
- Added "MCP Tool File Path Transparency" section with bad/good examples
- Emphasized user verification as the key benefit

## Test Plan
- [x] Verified examples are concise and clear
- [x] Confirmed token usage is minimal
- [x] Checked principle flows naturally with existing content

Closes #806