### PR TITLE
Fix critical setup failure and enhance principles with metaphors

### DIFF
--- a/knowledge/principles/systems-stewardship.md
+++ b/knowledge/principles/systems-stewardship.md
@@ -22,6 +22,7 @@ From Sam Carpenter's "Work the System" - adopt an external vantage point to see 
 - Make systems malleable for future iteration (VM)
 - When tempted to dive in, ask "What would I delegate?"
 - "Vísteme despacio, que tengo prisa" - move deliberately, not frantically
+- **Never let a crisis go to waste**: Each failure becomes input for stronger procedures and prevention systems
 
 **GitHub Issues as WIP Inventory:**
 - Backlog buildup indicates bottlenecks in the development flow

--- a/knowledge/procedures/post-pr-mini-retro.md
+++ b/knowledge/procedures/post-pr-mini-retro.md
@@ -2,6 +2,8 @@
 
 After submitting a pull request for feature-related workflows, conduct a mini retro focused on systems improvement. This supports the Snowball Method by capturing learnings and dedicating 20% of time to systems improvement.
 
+**Wring out the towel**: Extract every drop of learning from each experience - the insights that seem obvious in hindsight are often the most valuable to document. **Never let a crisis go to waste**: Each failure or unexpected challenge becomes raw material for stronger systems and procedures.
+
 ## IMPORTANT: Agent-Led Collaborative Process
 
 **The agent drives the retro while actively inviting human participation:**

--- a/knowledge/procedures/worktree-workflow.md
+++ b/knowledge/procedures/worktree-workflow.md
@@ -11,9 +11,9 @@ Suppose you need to work on multiple tasks simultaneously with complete code iso
    - **New branch**: Use `mcp__git__git_worktree_add` with `create_branch: true`
    - **Existing branch**: Use `mcp__git__git_worktree_add` with branch name
 3. Initialize worktree environment (if working on dotfiles repo): 
-   - `cd` into worktree and run `source setup.sh`
-   - This ensures PATH and environment are configured for the worktree context
-   - Skip this step for other repositories that don't have setup.sh
+   - **CRITICAL**: Do NOT run `source setup.sh` from worktree - creates broken symlinks
+   - Only use worktree for isolated development, not environment setup
+   - setup.sh automatically detects and fixes broken symlinks from deleted worktrees
 4. Work in worktree: Pass worktree path as `repo_path` to MCP tools (no `cd` needed!)
 5. Commit, push, create PR as normal
 6. Ask for any pr feedback and address if any

--- a/knowledge/procedures/worktree-workflow.md
+++ b/knowledge/procedures/worktree-workflow.md
@@ -4,17 +4,33 @@ Suppose you need to work on multiple tasks simultaneously with complete code iso
 
 **PRINCIPLE**: Start worktrees from the same commit GitHub will use for the PR diff (usually origin/main).
 
-**IMPORTANT**: Use git MCP tools instead of bash commands when possible. The `repo_path` parameter acts like `git -C` for worktrees.
+**CRITICAL**: Empty PR Prevention - Multiple failure modes discovered through painful experience.
 
+## Pre-flight Checks (REQUIRED)
+1. **Sync with origin**: `git fetch && git status` - ensure local main == origin/main
+2. **Clean workspace**: No untracked files or uncommitted changes in main
+3. **Verify starting point**: Worktree must branch from origin/main, not local main
+
+## Procedure
 1. `mkdir -p ~/ppv/pillars/dotfiles/worktrees`
-2. Create worktree:
+2. Create worktree from CLEAN origin/main:
    - **New branch**: Use `mcp__git__git_worktree_add` with `create_branch: true`
    - **Existing branch**: Use `mcp__git__git_worktree_add` with branch name
-3. Initialize worktree environment (if working on dotfiles repo): 
-   - **CRITICAL**: Do NOT run `source setup.sh` from worktree - creates broken symlinks
+3. **CRITICAL**: Do NOT run `source setup.sh` from worktree - creates broken symlinks
    - Only use worktree for isolated development, not environment setup
    - setup.sh automatically detects and fixes broken symlinks from deleted worktrees
-4. Work in worktree: Pass worktree path as `repo_path` to MCP tools (no `cd` needed!)
-5. Commit, push, create PR as normal
-6. Ask for any pr feedback and address if any
-7. Cleanup: Use `mcp__git__git_worktree_remove`
+4. **CRITICAL**: ALL file operations must use worktree paths
+5. Work in worktree: Pass worktree path as `repo_path` to MCP tools
+6. **Before commit**: Verify files exist in worktree directory
+7. **CRITICAL**: Check diff vs origin/main - `mcp__git__git_diff target: origin/main`
+8. **After PR creation**: Immediately verify PR has content with `mcp__github-read__get_pull_request_files`
+9. Cleanup: Use `mcp__git__git_worktree_remove`
+
+## Known Failure Modes (From Crisis Learning)
+- **Dirty main**: Worktree inherits untracked files → empty PR
+- **Wrong base commit**: Local main ahead of origin → PR shows no diff
+- **Wrong file paths**: Files created in main, not worktree → empty commits
+- **MCP git tool failures**: False success reporting on failed commits
+- **OSE Principle**: Only GitHub PR diff matters for review - must verify before creating PR
+- **CRITICAL DISCOVERY**: MCP git tools fundamentally broken - use GitHub API direct push instead
+- **Broken symlinks**: Running setup.sh from worktree creates symlinks that break when worktree is deleted

--- a/setup.sh
+++ b/setup.sh
@@ -47,7 +47,8 @@ if [[ "$DOT_DEN" == *"/worktrees/"* ]]; then
     echo -e "${YELLOW}WARNING: Running setup.sh from a worktree directory!${NC}"
     echo -e "${YELLOW}This will create symlinks that break when the worktree is deleted.${NC}"
     echo -e "${YELLOW}Consider running from the main repository instead.${NC}"
-    echo -e "${YELLOW}Continuing anyway - broken symlinks will be automatically fixed...${NC}"
+    # Remove user interaction and continue with the script
+    echo -e "${YELLOW}Proceeding with setup - broken symlinks will be handled automatically.${NC}"
 fi
 
 # Add MCP directory to PATH for easier access to MCP scripts

--- a/setup.sh
+++ b/setup.sh
@@ -42,6 +42,14 @@ DOT_DEN="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Export DOT_DEN as a global variable for other scripts to use
 export DOT_DEN
 
+# Critical: Warn if running from worktree to prevent broken symlinks
+if [[ "$DOT_DEN" == *"/worktrees/"* ]]; then
+    echo -e "${YELLOW}WARNING: Running setup.sh from a worktree directory!${NC}"
+    echo -e "${YELLOW}This will create symlinks that break when the worktree is deleted.${NC}"
+    echo -e "${YELLOW}Consider running from the main repository instead.${NC}"
+    echo -e "${YELLOW}Continuing anyway - broken symlinks will be automatically fixed...${NC}"
+fi
+
 # Add MCP directory to PATH for easier access to MCP scripts
 export PATH="$DOT_DEN/mcp:$PATH"
 # Add MCP servers directory to PATH
@@ -135,6 +143,17 @@ fi
 
 # Create symlinks for other configuration files
 echo "Creating symlinks for config files..."
+
+# Critical: Detect and fix broken symlinks from deleted worktrees
+echo "Checking for broken symlinks from deleted worktrees..."
+for config_file in .bashrc .bash_aliases .bash_profile .bash_exports .tmux.conf .zprofile .zshrc .zsh_prompt; do
+    home_link="$HOME/$config_file"
+    if [[ -L "$home_link" && ! -e "$home_link" ]]; then
+        echo "Removing broken symlink: $home_link"
+        rm -f "$home_link"
+    fi
+done
+
 ln -sf "$DOT_DEN/.bashrc" ~/.bashrc
 ln -sf "$DOT_DEN/.bash_aliases" ~/.bash_aliases
 ln -sf "$DOT_DEN/.bash_profile" ~/.bash_profile


### PR DESCRIPTION
## Summary
• **Critical Fix**: Resolve setup failure caused by broken symlinks from deleted worktrees (#814)
• **Prevention**: Add warning and detection system to prevent future occurrences  
• **Enhancement**: Add "wring out the towel" and "never let crisis go to waste" metaphors (#812)
• **Note**: Python __pycache__ patterns already properly covered in .gitignore (#813)

## Technical Changes
- Add broken symlink detection and automatic cleanup in setup.sh
- Add warning when running setup.sh from worktree directories
- Update worktree workflow documentation to prevent setup.sh usage
- Enhance post-PR retro procedure with learning extraction metaphor
- Add crisis-to-improvement principle to systems stewardship

## Test Plan
- [ ] Verify setup.sh detects and removes broken symlinks
- [ ] Test warning appears when running from worktree
- [ ] Confirm updated procedures prevent future symlink issues
- [ ] Validate enhanced principles incorporate new metaphors

Closes #812, #813, #814