### PR TITLE
chore(cleanup): gitignore setup-generated symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@
 CLAUDE.local.md
 # Claude Code local settings (personal overrides, not for source control per Anthropic docs)
 .claude/settings.local.json
+# Setup-generated symlinks (avoid duplicating tracked content)
+.claude/command-templates
 
 # Private SSH keys
 id_rsa
@@ -77,6 +79,9 @@ build/
 # MCP client directories
 mcp/clients/
 .nrepl-port
+
+# MCP server convenience symlinks (setup-generated executables)
+mcp/servers/*/git_mcp_server.py
 
 # Screenshots directory
 # Keep the directory structure but ignore all screenshot files

--- a/commands/README.md
+++ b/commands/README.md
@@ -25,7 +25,7 @@ commands/
 
 - **Always edit the actual template files** in `commands/templates/`
 - **Never edit via symlinks** (e.g., `.claude/command-templates/`)
-- Symlinks are created automatically by `setup.sh`
+- Symlinks are created automatically by `setup.sh` and gitignored to avoid content duplication
 
 ## Adding New Commands
 

--- a/mcp/servers/git-mcp-server/README.md
+++ b/mcp/servers/git-mcp-server/README.md
@@ -26,4 +26,5 @@ All standard Git operations: status, diff, commit, add, branch, checkout, push, 
 
 - Dependencies are in `.venv/` managed by the setup script
 - To modify: edit files in `src/mcp_server_git/` and restart your MCP client
+- `git_mcp_server.py` is a setup-generated symlink to `src/mcp_server_git/__main__.py` and is gitignored
 - Part of the dotfiles Snowball Method for continuous improvement


### PR DESCRIPTION
## Summary

Resolves #816 by adding `.gitignore` entries for setup-generated symlinks that were cluttering `git status`.

## Changes

- **`.claude/command-templates`** → gitignored (symlink to `commands/templates/` - avoid content duplication)  
- **`mcp/servers/*/git_mcp_server.py`** → gitignored (setup-generated convenience executables)
- Updated documentation in `commands/README.md` and `mcp/servers/git-mcp-server/README.md` with rationale

## Why These Should Be Gitignored

1. **`.claude/command-templates`**: Symlink created by `setup.sh` pointing to already-tracked `commands/templates/` directory. Committing would duplicate tracked content.

2. **`git_mcp_server.py`**: Symlink created by `mcp/setup-git-mcp.sh` pointing to `src/mcp_server_git/__main__.py`. These are convenience executables generated during setup.

## Test Plan

- [x] Verify `git status` clean after gitignore changes
- [x] Confirm symlinks still function properly 
- [x] Document decisions for future reference

## Impact

Clean `git status` output, reduced cognitive load, prevents accidental commits of setup-generated content.

Principle: subtraction-creates-value