### PR TITLE
docs(knowledge): integrate cookie crumbs documentation pattern across procedures

### DIFF
--- a/knowledge/principles/systems-stewardship.md
+++ b/knowledge/principles/systems-stewardship.md
@@ -24,6 +24,21 @@ From Sam Carpenter's "Work the System" - adopt an external vantage point to see 
 - "Vísteme despacio, que tengo prisa" - move deliberately, not frantically
 - **Never let a crisis go to waste**: Each failure becomes input for stronger procedures and prevention systems
 
+**Cookie Crumbs Documentation Pattern:**
+Leave decision breadcrumbs throughout procedures - the "why" behind choices that seem obvious now but won't be obvious in 6 months. This prevents future confusion and reduces the need to reverse-engineer past decisions.
+
+- Document the context that led to specific choices
+- Explain why alternatives were rejected
+- Note assumptions that informed the decision
+- Reference the problem state that necessitated the solution
+- Leave traces of the decision-making process, not just the final outcome
+
+**Example applications:**
+- In git workflow: Why we chose specific branch naming patterns
+- In tool selection: What problems each tool solves vs alternatives
+- In procedure design: What failure modes each step prevents
+- In automation: What manual processes were replaced and why
+
 **GitHub Issues as WIP Inventory:**
 - Backlog buildup indicates bottlenecks in the development flow
 - Leading vs lagging indicators: measure what predicts success, not what confirms it

--- a/knowledge/procedures/README.md
+++ b/knowledge/procedures/README.md
@@ -2,9 +2,21 @@
 
 Actionable processes and workflows that evolve with experience.
 
+## Documentation Philosophy
+
+**Cookie Crumbs Pattern**: Each procedure documents not just the "what" but the "why" - leaving decision breadcrumbs for future developers (including your future self). This prevents the need to reverse-engineer decisions from git history or tribal knowledge.
+
+**Key principles:**
+- Document the context that led to specific choices
+- Explain why alternatives were rejected
+- Reference the problem state that necessitated the solution
+- Leave traces of the decision-making process, not just the final outcome
+
+## Core Procedures
+
 - `fs-write-full-paths.md` - Always use absolute paths in fs_write operations
-- `git-workflow.md` - Git conventions and branch management
-- `post-pr-mini-retro.md` - Systems improvement retro after feature PRs
+- `git-workflow.md` - Git conventions and branch management (includes documentation-over-git-history guidance)
+- `post-pr-mini-retro.md` - Systems improvement retro after feature PRs (includes cookie crumbs questions)
 - `worktree-workflow.md` - Git worktree workflow (beta/imperfect system)
 
 ## Future Procedure Ideas

--- a/knowledge/procedures/git-workflow.md
+++ b/knowledge/procedures/git-workflow.md
@@ -13,6 +13,33 @@
 - Remember: Commits build toward PRs - that's where feedback happens
   → [systems-stewardship](../principles/systems-stewardship.md) (OSE perspective)
 
+## Documentation Over Git History
+
+**Cookie Crumbs Principle**: Document the "why" in files, not just in commit messages. Git history is hard to search and easily lost; procedure documentation is discoverable and persistent.
+
+**What belongs in documentation vs git history:**
+- **Documentation**: Why decisions were made, what alternatives were considered, what problems solutions address
+- **Git history**: What changed, when it changed, immediate context for the change
+
+**Branch naming rationale example:**
+- ❌ Git commit: "use type/description pattern for branches"
+- ✅ Documentation: "Branch naming follows `type/description` pattern because it groups related work in branch lists and makes intent visible before opening the PR"
+
+**Implementation pattern:**
+- Document the decision and reasoning in the procedure file
+- Reference the procedure in commit messages rather than re-explaining
+- Use commit trailers to link to relevant principles
+
+**Example commit message:**
+```
+feat(workflow): implement cookie crumbs documentation pattern
+
+Refs: knowledge/procedures/post-pr-mini-retro.md
+Principle: systems-stewardship
+```
+
+This ensures future developers can discover the "why" through normal documentation browsing, not archaeological git diving.
+
 ## Branch Management
 
 **Core principle: Working on main creates future work**. Every commit on main that should be on a feature branch guarantees recovery work: cherry-picking, rebasing, or complex git surgery. This violates the subtraction principle - we're adding unnecessary future tasks.
@@ -36,6 +63,11 @@ Starting from a stale foundation guarantees the recovery tax - double work to ac
   → [subtraction-creates-value](../principles/subtraction-creates-value.md) (prevent recovery work)
 
 These standards make intent visible and prevent the recovery tax.
+
+**Why these specific standards?** (Cookie crumbs)
+- `type/description` groups related work in branch lists and makes intent visible before opening PRs
+- Issue suffix links work to specific problems without cluttering the main description
+- The prescribed order prevents the recovery tax by ensuring clean starting points
 
 ## Post-Merge Best Practice
 After merging a PR, switch to the base branch and pull latest to avoid working on stale code.

--- a/knowledge/procedures/post-pr-mini-retro.md
+++ b/knowledge/procedures/post-pr-mini-retro.md
@@ -60,6 +60,14 @@ The agent should:
 - How did choosing one principle over another create tension or trade-offs?
 - What decisions required balancing competing principles?
 
+**Cookie Crumbs Documentation:**
+- What decisions were made that seemed obvious in the moment but might need explanation later?
+- Which alternative approaches were considered and why were they rejected?
+- What context or constraints influenced key decisions that might not be apparent from the final code?
+- What assumptions were made that should be documented for future reference?
+- What "why" questions would your future self (or a teammate) ask about this implementation?
+- Which parts of the solution address specific failure modes or edge cases that aren't immediately obvious?
+
 ## Personality-Driven Focus
 
 The `/retro` command will select an appropriate consultant personality based on PR context:


### PR DESCRIPTION
## Summary
- **systems-stewardship.md**: Add comprehensive cookie crumbs documentation pattern with examples
- **post-pr-mini-retro.md**: Add cookie crumbs questions for post-PR retrospectives
- **git-workflow.md**: Add documentation-over-git-history guidance with rationale examples
- **procedures/README.md**: Update overview with documentation philosophy

## Key Changes

### Cookie Crumbs Documentation Pattern
Creates a cohesive approach to leaving decision breadcrumbs throughout procedures to prevent future confusion and reduce the need to reverse-engineer past decisions.

### Documentation Philosophy
- Document the "why" behind choices that seem obvious now but won't be obvious in 6 months
- Explain why alternatives were rejected
- Reference the problem state that necessitated the solution
- Leave traces of the decision-making process, not just the final outcome

### Documentation Over Git History
- Document decision reasoning in discoverable files, not just commit messages
- Git history is hard to search and easily lost; procedure documentation is persistent
- Use commit messages to reference procedures rather than re-explaining rationale

## Test plan
- [x] Enhanced systems-stewardship.md with cookie crumbs pattern definition and examples
- [x] Updated post-pr-mini-retro.md with specific cookie crumbs questions
- [x] Added documentation-over-git-history section to git-workflow.md
- [x] Updated procedures README.md with documentation philosophy overview
- [x] All files follow the cookie crumbs pattern with rationale examples