### PR TITLE
docs(ose): add micro vs macro productivity section with 100x claims

### DIFF
--- a/knowledge/principles/ose.md
+++ b/knowledge/principles/ose.md
@@ -26,7 +26,7 @@ The productivity gains from OSE aren't just subjective - they're mathematical. Y
 - Single-threaded mental model: one change at a time
 - Cognitive overhead of remembering file locations, syntax, implementation details
 
-**Macro Level (OSE Agent Management):**
+**Macro Level ([tmux-git-worktrees-claude-code](../procedures/tmux-git-worktrees-claude-code.md)):**
 - Manage tasks at the system level
 - Compose complex tasks from multiple subtasks
 - Execute multiple tasks in parallel using AI agents

--- a/knowledge/principles/ose.md
+++ b/knowledge/principles/ose.md
@@ -26,7 +26,7 @@ The productivity gains from OSE aren't just subjective - they're mathematical. Y
 - Single-threaded mental model: one change at a time
 - Cognitive overhead of remembering file locations, syntax, implementation details
 
-**Macro Level ([tmux-git-worktrees-claude-code](../procedures/tmux-git-worktrees-claude-code.md)):**
+**Macro Level ([tmux + git worktrees + Claude Code](../procedures/tmux-git-worktrees-claude-code.md)):**
 - Manage tasks at the system level
 - Compose complex tasks from multiple subtasks
 - Execute multiple tasks in parallel using AI agents

--- a/knowledge/principles/ose.md
+++ b/knowledge/principles/ose.md
@@ -15,6 +15,29 @@ As AI capabilities accelerate, the most valuable skillset shifts from writing co
 - **Build durable skills**: Agent management capabilities compound with each AI generation
 - **Prevent firefighting**: Avoid the reactive patterns that lead to burnout and technical debt
 
+## Micro vs Macro: The 100x Productivity Multiplier
+
+The productivity gains from OSE aren't just subjective - they're mathematical. You're shifting from single-threaded to multi-threaded mental models.
+
+**Micro Level (Traditional IDE Development):**
+- Navigate between files in Visual Studio/Cursor/IntelliJ/neovim
+- Edit individual lines of code sequentially
+- Debug line-by-line, file-by-file
+- Single-threaded mental model: one change at a time
+- Cognitive overhead of remembering file locations, syntax, implementation details
+
+**Macro Level (OSE Agent Management):**
+- Manage tasks at the system level
+- Compose complex tasks from multiple subtasks
+- Execute multiple tasks in parallel using AI agents
+- Multi-threaded mental model: orchestrate multiple streams simultaneously
+- Focus on problem definition, principles, and outcomes while agents handle implementation
+
+**The Math:**
+Instead of `1 developer × 1 task × 1 file at a time = linear productivity`, you get `1 developer × N tasks × parallel execution = exponential productivity`.
+
+How could this NOT be 100x-1000x more productive? You're not just faster - you're operating at a fundamentally different level. This is computational parallelism applied to human work, and the skill itself becomes exponentially more valuable as AI capabilities advance.
+
 ## In Practice
 
 - Ask "What would I delegate?" before diving into manual work

--- a/knowledge/procedures/tmux-git-worktrees-claude-code.md
+++ b/knowledge/procedures/tmux-git-worktrees-claude-code.md
@@ -1,0 +1,46 @@
+# tmux + git worktrees + Claude Code
+
+The triumvirate trinity that delivers 100x productivity: tmux orchestrates, git worktrees isolate, Claude Code executes. This is how you manage multiple AI agents in parallel without IDE context switching overhead.
+
+## The Three Components
+
+- **tmux**: Multi-session task orchestration with keyboard-driven pane management
+- **git worktrees**: Complete repository isolation per issue (no cross-contamination)  
+- **Claude Code CLI**: Context window management with resuming/branching capabilities
+
+## Core Workflow
+
+**New task received:**
+`tmux pane + /close-issue <number> → automated workflow to PR`
+
+**Parallel isolation:**
+Automatic worktree creation per agent prevents interference between simultaneous tasks.
+
+**Context management strategy:**
+- Resume/branch existing conversations for related context
+- Fresh 200k token windows for clean starts with embedded GitHub issue intelligence
+- Favor fresh initialization over ephemeral long-running sessions
+
+**Strategic context window usage:**
+- 200k tokens = precious resource
+- 25k (Anthropic) + 5k (knowledge/) = 30k baseline
+- Git worktrees enable strategic fresh starts without losing isolation
+
+**Broken window detection:**
+Immediate issue creation/resolution cycle maintains snowball method momentum rather than cognitive debt accumulation.
+
+## Key Benefits
+
+- **True parallelism**: Multiple agents work simultaneously without interference
+- **Strategic context**: Fresh 200k windows with knowledge/ directory state
+- **Empowering workflow**: Fix broken windows immediately instead of noting them
+- **Automation**: Slash commands handle worktree creation and management
+- **Joy**: Git-like conversation branching and tmux orchestration feel delightful
+
+## Related Procedures
+
+- [Worktree Workflow](worktree-workflow.md) - technical isolation details
+- [Slash Command Generation](slash-command-generation.md) - automation mechanics
+- [Post-PR Mini Retro](post-pr-mini-retro.md) - continuous improvement
+
+This workflow transforms development from sequential file-editing to parallel task orchestration - the foundation of the 100x productivity multiplier.


### PR DESCRIPTION
## Summary

Adds a new "Micro vs Macro: The 100x Productivity Multiplier" section to the OSE principle that clearly articulates the massive productivity gains from operating at the task/system level versus the line/file level.

## Changes

- ✅ Add new section contrasting traditional IDE navigation with task-level orchestration
- ✅ Explain mathematical nature of productivity gains: linear vs exponential
- ✅ Emphasize single-threaded vs multi-threaded mental models
- ✅ Include concrete examples of micro vs macro approaches
- ✅ Position as computational parallelism applied to human work
- ✅ Connect to increasing value of agent management skills

## Key Messages

- **Mathematical productivity gains**: `1 developer × N tasks × parallel execution = exponential productivity`
- **Fundamental level shift**: You're not just faster - you're operating at a different level
- **Computational parallelism**: Multi-threaded mental models vs single-threaded approaches
- **Future-proof skillset**: Agent management capabilities become exponentially more valuable

## The Core Insight

Instead of navigating between files in Visual Studio/Cursor/IntelliJ/neovim and editing individual lines sequentially, you manage tasks at the system level and execute multiple tasks in parallel using AI agents.

How could this NOT be 100x-1000x more productive?

## Test plan

- [ ] Verify the new section flows naturally with existing content
- [ ] Confirm the mathematical formula is clear and compelling
- [ ] Check that examples resonate with developers familiar with IDEs

Closes #825