### PR TITLE
feat(commands): implement EARS integration with correct slash command architecture

### DIFF
--- a/commands/templates/close-issue.md
+++ b/commands/templates/close-issue.md
@@ -11,6 +11,8 @@ Use `mcp__github__get_issue` to read issue #{{ ISSUE_NUMBER }} and determine:
 - Check recent merged PRs for similar patterns → `mcp__github__list_pull_requests` (state: "closed")
 - Get issue comments with `mcp__github__get_issue_comments` to enrich understanding
 
+**Clarity opportunity**: If the issue contains vague language ("doesn't work", "should handle", "it depends"), consider exploring with EARS patterns to surface hidden assumptions and edge cases. This often reveals interesting test scenarios and sparks productive conversations about the real requirements. See [EARS Requirements](knowledge/procedures/ears-requirements.md) for conversation-driven discovery techniques.
+
 ## Quick Close Path
 If the issue is already resolved, invalid, or duplicate:
 1. Add explanatory comment with `mcp__github__add_issue_comment`

--- a/knowledge/procedures/ears-requirements.md
+++ b/knowledge/procedures/ears-requirements.md
@@ -1,0 +1,39 @@
+# EARS Requirements
+
+Transform vague specifications into clear, testable statements using EARS (Easy Approach to Requirements Syntax).
+
+**The joy**: EARS patterns reveal hidden assumptions and edge cases through natural conversation. Each pattern becomes a discovery tool that sparks "what if" discussions.
+
+**When to use**: When you find yourself saying "it depends" or when the team starts debating what "should" means.
+
+## Core Patterns as Conversation Starters
+
+**Event-driven:** `When <trigger>, the system shall <response>`
+- Surfaces: What are all the possible triggers? What about rapid-fire events?
+
+**State-driven:** `While <condition>, the system shall <response>`  
+- Surfaces: What states exist? What about transitions between states?
+
+**Optional features:** `Where <feature>, the system shall <response>`
+- Surfaces: Feature interactions, configuration dependencies, graceful degradation
+
+**Complex:** Combine patterns for emergent behavior
+- Surfaces: Real-world scenarios that simple patterns miss
+
+## Emergent Test Case Generation
+
+**Start with a fuzzy requirement:** "Handle MCP server disconnections gracefully"
+
+**EARS exploration unfolds:**
+- "When MCP server disconnects, system shall..."
+- "While reconnecting, system shall..."
+- "Where multiple servers exist, system shall..."
+- "When reconnection fails after 3 attempts, system shall..."
+
+Each pattern reveals new test scenarios organically. The conversation becomes about discovering edge cases, not documenting known ones.
+
+## Agent-Human Collaboration
+
+Use EARS as a thinking tool during pair programming with AI agents. The patterns help both parties explore assumptions and discover interesting corner cases together.
+
+→ [tracer-bullets](../principles/tracer-bullets.md) (clear targets enable precise feedback)


### PR DESCRIPTION
## Summary

Implements EARS (Easy Approach to Requirements Syntax) integration correctly by targeting source templates rather than generated files.

## Changes

- **Knowledge procedure**: `knowledge/procedures/ears-requirements.md` - conversation-driven EARS approach that emphasizes joy and emergent discovery
- **Source template enhancement**: `commands/templates/close-issue.md` - adds EARS exploration guidance for vague requirements
- **Generator verification**: Confirmed EARS guidance appears in actual `/close-issue` command at line 63

## Key Learning

**Correct slash command architecture applied:**
- ✅ Edit source: `commands/templates/close-issue.md` 
- ✅ Run generator: `utils/generate-claude-commands.sh` from main directory
- ✅ Verify output: EARS guidance now appears in `.claude/commands/close-issue.md`

## Educational Value

This PR demonstrates the correct process after PR #827 showed what NOT to do (editing generated files directly).

## EARS Demo in PR Description

**When** the user encounters vague requirements like "doesn't work" or "should handle", **the system shall** suggest EARS exploration patterns to surface hidden assumptions.

**While** using the `/close-issue` command, **the system shall** provide optional "Clarity opportunity" guidance for conversational requirement discovery.

## Closes

Closes #828 (correct implementation)
Supersedes #827 (incorrect implementation)
Closes #824 (original EARS integration request)

## Verification

- [x] Source template correctly modified
- [x] Generator script run from main directory  
- [x] EARS guidance appears in generated output file
- [x] Educational comments document correct process