### PR TITLE
fix(commands): keep worktree active after PR creation for tracer bullets feedback

### DIFF
--- a/commands/templates/close-issue.md
+++ b/commands/templates/close-issue.md
@@ -58,8 +58,8 @@ Apply tracer bullets methodology:
 - Reference "Closes #{{ ISSUE_NUMBER }}" in PR body
 - Add "Conduct post-PR mini retro" to your todo list
 
-### 4. Cleanup
-Remove worktree after PR is created.
+### 4. Iterate Based on Feedback
+Keep worktree active for PR adjustments based on the tracer bullets principle. Only cleanup after PR is merged.
 
 ## REQUIRED: Post-PR Mini Retro (if PR was created)
 **TRIGGER**: If you created a pull request, you MUST complete this step before finishing.


### PR DESCRIPTION
## Problem & Solution
**Problem**: The `/close-issue` workflow removes the worktree immediately after PR creation, which violates the tracer bullets principle by preventing iteration based on PR feedback. This breaks the fire-observe-adjust cycle that's core to tracer bullets development.

**Solution**: Modified the close-issue command template to keep worktrees active after PR creation, allowing for iteration based on PR feedback. Cleanup now happens after PR merge instead of after PR creation.

**Keywords**: worktree cleanup, tracer bullets, PR feedback loop, close-issue workflow

## Related Issues
Closes #833

## Technical Details
**Files changed**: `commands/templates/close-issue.md`

**Key modifications**: 
- Changed section 4 from "Cleanup" to "Iterate Based on Feedback"
- Updated instructions to keep worktree active for PR adjustments
- Aligned workflow with tracer bullets principle of continuous course correction

**Alternative approaches considered**: 
- Could have added a separate cleanup command, but that adds complexity
- Could have made cleanup optional, but clear guidance is better

## Testing
The change is straightforward text modification to the workflow documentation. Future uses of `/close-issue` will follow the improved workflow.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added/updated tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have updated the documentation accordingly (if applicable)