### PR TITLE
Add working directory warning to close-issue workflow

### DIFF
--- a/commands/templates/close-issue.md
+++ b/commands/templates/close-issue.md
@@ -8,6 +8,7 @@ Use `mcp__github__get_issue` to read issue #{{ ISSUE_NUMBER }} and determine:
 - Is this already resolved? → Quick close
 - Does this need implementation? → Full workflow
 - Is this invalid/duplicate? → Close with explanation
+- **Repository check**: If issue requires git operations in a different repo, STOP and ask human to restart session there. Claude Code cannot `cd` outside initial directory tree, breaking git workflows.
 - Check recent merged PRs for similar patterns → `mcp__github__list_pull_requests` (state: "closed")
 - Get issue comments with `mcp__github__get_issue_comments` to enrich understanding
 


### PR DESCRIPTION
## Summary
- Adds repository check to `/close-issue` workflow in Step 1 analysis
- Provides early detection of Claude Code directory restriction issues
- Prevents "cd was blocked" failures during git workflows

## Implementation
- Added subtle repository validation bullet point in issue analysis
- Agent will STOP and ask for human intervention if repository mismatch detected
- Focus on git operations constraint rather than file access limitation

## Testing
- Updated the source template at `commands/templates/close-issue.md`
- Change will be applied when command templates are regenerated

Closes #839

## Test plan
- [ ] Verify template change appears in generated commands after setup.sh
- [ ] Test with cross-repository issue scenarios
- [ ] Confirm early detection prevents mid-session failures