### PR TITLE
Fix missing os import in MCP git server

### DIFF
--- a/mcp/servers/git-mcp-server/src/mcp_server_git/server.py
+++ b/mcp/servers/git-mcp-server/src/mcp_server_git/server.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from enum import Enum
 from pathlib import Path
 from typing import Sequence


### PR DESCRIPTION
## Summary
- Fixes "name 'os' is not defined" error in `mcp__git__git_add` tool
- Adds missing `import os` statement to MCP git server

## Root Cause
The `git_add` function in `mcp/servers/git-mcp-server/src/mcp_server_git/server.py` uses:
- `os.path.normpath()`
- `os.path.join()` 
- `os.path.exists()`

But was missing the `import os` statement at the top of the file.

## Fix
Added `import os` to the imports section of `server.py`.

## Testing
- Previously: `mcp__git__git_add` failed with NameError
- After fix: Import statement resolves the undefined name error
- MCP server needs restart to pick up the fix

## Impact
- Restores MCP git workflow consistency
- Eliminates need for bash fallbacks in git operations
- Improves automation reliability

Closes #843