### PR TITLE
docs(principles): align throughput definition with 100x-1000x developer concept

### DIFF
--- a/knowledge/principles/throughput-definition.md
+++ b/knowledge/principles/throughput-definition.md
@@ -1,12 +1,12 @@
 # Throughput Definition
 
 ## The Goal
-My throughput is measured by my ability to manage AI agents to complete assigned work while maintaining a competitive skills portfolio in the software engineering marketplace.
+My throughput is measured by my ability to manage AI agents to become the 100x-1000x developer through parallel execution and systems orchestration.
 
 ## Core Metrics
 1. **AI Agent Management Capability**: Directing agents across any framework/language
-2. **Marketplace Positioning**: Top 2% earning potential through strategic skill development
-3. **Systems Thinking Application**: Managing workflows, not just writing code
+2. **Productivity Multiplier**: Achieve 100x-1000x productivity through parallel AI orchestration
+3. **Systems Thinking Application**: Managing workflows at the macro level, not micro-editing code
 4. **Life Stewardship**: Using these systems to manage all aspects of life, stewarding gifts from God to serve others
 
 ## Strategic Insight


### PR DESCRIPTION
## Problem & Solution
**Problem**: The current throughput definition references "top 2% earning potential" which feels disconnected from the powerful "100x-1000x developer" concept already established in the OSE principle
**Solution**: Updated throughput-definition.md to use the 100x-1000x developer concept, creating better alignment between principles
**Keywords**: throughput, 100x developer, 1000x developer, productivity multiplier, OSE, principles alignment

## Related Issues
Closes #831

## Technical Details
**Files changed**: `knowledge/principles/throughput-definition.md`
**Key modifications**: 
- Replaced "maintaining a competitive skills portfolio" with "become the 100x-1000x developer through parallel execution and systems orchestration"
- Changed "Top 2% earning potential" to "Achieve 100x-1000x productivity through parallel AI orchestration"
- Added "at the macro level, not micro-editing code" to Systems Thinking Application metric
**Alternative approaches considered**: None - this was a straightforward documentation alignment task

## Testing
Documentation change - verified by reviewing the updated content aligns with OSE principle's mathematical model

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added/updated tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have updated the documentation accordingly (if applicable)