### PR TITLE
docs(claude): add tip about using -p flag with aliased claude command

### DIFF
--- a/knowledge/procedures/claude-code-tips.md
+++ b/knowledge/procedures/claude-code-tips.md
@@ -2,6 +2,10 @@
 
 Force multiplier discoveries for 1000x Claude Code productivity. Default to one-liners, but force multipliers that enable exponential productivity gains deserve the space they need - they pay for themselves in tokens.
 
+## Command Line Usage
+
+- **`claude` is aliased**: Our `claude` command includes `--mcp-config` and `--add-dir` flags. For subcommands, use `-p`: `claude -p setup-token`, `claude -p config`, etc.
+
 ## Installation & Uninstallation
 
 - **Uninstall**: `npm uninstall -g @anthropic-ai/claude-code`


### PR DESCRIPTION
## Summary
Document the solution for using Claude Code subcommands with our aliased setup.

## Context
Our `claude` command is aliased to include `--mcp-config` and `--add-dir` flags, which causes Claude to expect interactive input. This prevents subcommands like `setup-token` and `config` from working as expected.

## Solution
Added documentation explaining that the `-p` (print) flag switches Claude to non-interactive mode, allowing subcommands to work properly:
- `claude -p setup-token`
- `claude -p config`
- `claude -p mcp`
- etc.

## Changes
- Updated `knowledge/procedures/claude-code-tips.md` with concise explanation

Resolves #869