### PR TITLE
feat(claude): add self-invocation instructions to always use -p flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,28 @@ See `knowledge/` directory for principles and procedures that apply across all p
 - Primary workflow: GitHub Pull Requests
 - See README.md for repository-specific principles
 
+## Critical: Claude Self-Invocation
+When invoking claude commands from within Claude Code:
+- **ALWAYS use**: `claude -p <command>` 
+- **NEVER use**: `claude <command>`
+
+This prevents nested interactive session conflicts since we're already in an interactive Claude session and our `claude` alias includes `--mcp-config` and `--add-dir` flags.
+
+Examples:
+```bash
+# Testing functionality
+claude -p "test the new MCP server"
+
+# Checking configuration
+claude -p config get theme
+
+# Running diagnostics
+claude -p doctor
+
+# Setting up tokens
+claude -p setup-token
+```
+
 ## For AI Providers
 - **Amazon Q**: Uses symlinked `~/.amazonq/rules/` → `knowledge/`
 - **Claude Code**: Uses generated `CLAUDE.local.md` files


### PR DESCRIPTION
## Summary
Added critical instructions to CLAUDE.md so Claude knows to always use `-p` flag when invoking itself, preventing nested interactive session conflicts.

## Context
When Claude Code runs commands for us, it needs to use `claude -p` because:
- We're already in an interactive Claude session
- Our alias adds `--mcp-config` and `--add-dir` flags that expect interactive mode
- Claude can't nest interactive sessions
- Testing/validation requires non-interactive execution

## Solution
Added a "Critical: Claude Self-Invocation" section to CLAUDE.md with:
- Clear ALWAYS/NEVER instructions
- Explanation of why this is necessary
- Practical examples of common self-invocation scenarios

## Impact
- **Throughput improvement**: Eliminates a whole class of failures
- **Self-testing**: Claude can now test its own functionality
- **Recursion safety**: Prevents interactive session nesting
- **Developer experience**: Claude "just works" when calling itself

## Testing
Verified `claude -p --version` works correctly during implementation.

Closes #872

**Principle**: `throughput-definition`