### PR TITLE
[Brent] Just add a rules folder already

### DIFF
--- a/knowledge/rules/README.md
+++ b/knowledge/rules/README.md
@@ -1,0 +1,5 @@
+# Rules
+
+Hard constraints that will bite you if you ignore them. These aren't procedures - they're immutable facts about how things work.
+
+Read these first. Learn them. Accept them. Move on.

--- a/knowledge/rules/context-window-limits.md
+++ b/knowledge/rules/context-window-limits.md
@@ -1,0 +1,10 @@
+# Context Window Limits
+
+200k tokens. That's it. When it's full, conversation's over.
+
+**Reality check**:
+- ~30k baseline (system prompts + knowledge)
+- ~170k for your actual work
+- Token counter is always right, your "just one more file" is always wrong
+
+Plan accordingly or lose everything mid-task.

--- a/knowledge/rules/git-worktree-isolation.md
+++ b/knowledge/rules/git-worktree-isolation.md
@@ -1,0 +1,9 @@
+# Git Worktree Isolation
+
+Worktrees start from ONE commit. Pick wrong = empty PR.
+
+**The rule**: Start from origin/main, not local main
+**Why**: GitHub compares against origin, not your local outdated copy
+**Fix**: Can't. Start over. Do it right.
+
+Check `git fetch && git status` BEFORE creating worktrees.

--- a/knowledge/rules/no-api-keys-in-claude.md
+++ b/knowledge/rules/no-api-keys-in-claude.md
@@ -1,0 +1,8 @@
+# No API Keys in Claude
+
+Claude Pro/Max = OAuth only. No API keys. Stop looking.
+
+**Won't work**: Setting ANTHROPIC_API_KEY, trying to find secret keys
+**Will work**: Browser-based auth through `claude -p setup-token`
+
+This isn't a config issue. It's how the product works.

--- a/knowledge/rules/non-interactive-execution.md
+++ b/knowledge/rules/non-interactive-execution.md
@@ -1,0 +1,8 @@
+# Non-Interactive Execution Only
+
+Claude can't type. Period. No interactive commands. Ever.
+
+**What breaks**: `claude setup-token`, `git commit` (without -m), `npm install` (without -y)
+**What works**: `claude -p setup-token`, `git commit -m "msg"`, `npm install -y`
+
+Stop trying to be clever. Claude IS the interactive session. It can't nest another one.


### PR DESCRIPTION
Look, I've been in the trenches long enough to know what matters. We need a place for the "this will never work no matter what you try" stuff. Call it rules, call it constraints, call it "stuff-that-breaks" - I don't care as long as people find it BEFORE they waste hours.

## What This Does
- Adds `knowledge/rules/` 
- Simple README that tells it like it is
- That's it. No over-engineering.

## Why
Because I'm tired of getting paged at 2am because someone tried to make Claude run an interactive command. Or thought they could outsmart a fundamental limitation. These aren't procedures you follow - they're walls you'll hit.

## Next Steps
Move `non-interactive-execution.md` here. Add other "this is impossible" docs as we find them.

Keep it simple. Keep it findable. Keep me from getting paged.

Closes #879

---
*As Brent the Phoenix Project firefighter*