### PR TITLE
fix(github-actions): add missing permissions for emoji reactions

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -5,6 +5,11 @@ on:
   pull_request_review_comment:
     types: [created]
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   claude-review:
     if: contains(github.event.comment.body, '@claude')
@@ -16,13 +21,24 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            // Add eyeball reaction to show Claude saw the request
-            await github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: 'eyes'
-            });
+            try {
+              // Add eyeball reaction to show Claude saw the request
+              const reaction = await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                content: 'eyes'
+              });
+              
+              console.log(`✅ Successfully added eyeball reaction to comment ${context.payload.comment.id}`);
+              console.log(`Reaction ID: ${reaction.data.id}`);
+            } catch (error) {
+              console.error(`❌ Failed to add reaction: ${error.message}`);
+              console.error(`Comment ID: ${context.payload.comment.id}`);
+              console.error(`Repository: ${context.repo.owner}/${context.repo.repo}`);
+              // Don't fail the workflow if reaction fails
+              // The review should still proceed
+            }
 
       - uses: anthropics/claude-code-action@beta
         with:


### PR DESCRIPTION
## Fix for Claude PR Review Emoji Reactions

### Problem
The Claude PR review workflow was failing with "Resource not accessible by integration" (403) when trying to add the eyeball emoji reaction. This was happening because the default `GITHUB_TOKEN` only has read permissions.

### Solution
Added explicit permissions to the workflow:
```yaml
permissions:
  contents: read
  issues: write
  pull-requests: write
```

### Additional Improvements
- Added try-catch error handling so the workflow doesn't fail if the emoji reaction fails
- Added detailed logging for debugging
- The review will still proceed even if the emoji fails

### Testing
After this PR is merged, the workflow should successfully add 👁️ reactions when @claude is mentioned in comments.

Fixes the issue discovered in #884