### PR TITLE
fix(github-actions): add checkout step to Claude PR review workflow

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -40,6 +40,11 @@ jobs:
               // The review should still proceed
             }
 
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary
Fixes the "fatal: not a git repository" error in Claude PR review workflow by adding the required checkout step.

## Problem
The Claude action was failing with:
```
Run anthropics/claude-code-action@beta
Error: git: Command failed: git rev-parse --abbrev-ref HEAD
fatal: not a git repository (or any of the parent directories): .git
```

This occurred because the workflow was trying to run git commands without first checking out the repository.

## Solution
- Added `actions/checkout@v4` step between the emoji reaction and Claude action
- Restored the permissions block to ensure write access for reactions
- Restored error handling in the emoji reaction step for robustness

## Test Plan
After merging, test by commenting "@claude" on any PR or issue. The workflow should:
1. ✅ Add eyeball emoji reaction immediately
2. ✅ Successfully run Claude action without git errors
3. ✅ Create a branch and potentially a PR based on the request

Fixes #886