### PR TITLE
refactor(github-actions): rename claude-pr-review.yml to claude-code-assistant.yml

### DIFF
--- a/.github/workflows/claude-code-assistant.yml
+++ b/.github/workflows/claude-code-assistant.yml
@@ -1,4 +1,9 @@
-name: Claude PR Review
+# Claude Code Assistant workflow - handles both:
+# - Issue implementation: Creates branches, implements solutions, opens PRs
+# - PR review: Provides feedback on existing PRs
+# The anthropics/claude-code-action intelligently detects context and switches modes
+
+name: Claude Code Assistant
 on:
   issue_comment:
     types: [created]
@@ -11,12 +16,12 @@ permissions:
   pull-requests: write
 
 jobs:
-  claude-review:
+  claude-assistant:
     if: contains(github.event.comment.body, '@claude')
     runs-on: ubuntu-latest
 
     steps:
-      - name: Acknowledge review request
+      - name: Acknowledge request
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

This PR renames the GitHub Actions workflow file from `claude-pr-review.yml` to `claude-code-assistant.yml` to better reflect its dual-purpose nature.

## Changes

- **Renamed workflow file**: `claude-pr-review.yml` → `claude-code-assistant.yml`
- **Added clarifying comment**: Explains both issue implementation and PR review capabilities
- **Updated workflow name**: "Claude PR Review" → "Claude Code Assistant"
- **Updated job name**: `claude-review` → `claude-assistant`
- **Updated step name**: More generic "Acknowledge request"

## Why This Matters

The old filename created confusion about the workflow's capabilities. Despite the name suggesting it only reviews PRs, it actually handles both:
1. **Issue implementation**: Creates branches, implements solutions, opens PRs
2. **PR review**: Provides feedback on existing PRs

This rename removes the artificial limitation implied by the filename and acknowledges that AI models are "smart and getting smarter" - they can intelligently handle context switching.

## Principle Alignment

- **transparency-in-agent-work**: Making agent capabilities visible through naming
- **invent-and-simplify**: Simplifying assumptions about what the workflow does
- **ose**: Treating Claude as an intelligent agent that can handle multiple contexts

## Testing

No functional changes were made - only naming and comments. The workflow continues to:
- Trigger on `@claude` mentions in both issue and PR comments
- Add 👀 reaction to acknowledge requests
- Use the same authentication and action configuration

Closes #906