### PR TITLE
Fix: Shorten GitHub tool name for Claude Code 64-char limit

### DIFF
--- a/mcp/github-mcp-server/pkg/github/pullrequests.go
+++ b/mcp/github-mcp-server/pkg/github/pullrequests.go
@@ -1232,7 +1232,7 @@ func CreatePendingPullRequestReview(getGQLClient GetGQLClientFn, t translations.
 
 // AddPullRequestReviewCommentToPendingReview creates a tool to add a comment to a pull request review.
 func AddPullRequestReviewCommentToPendingReview(getGQLClient GetGQLClientFn, t translations.TranslationHelperFunc) (mcp.Tool, server.ToolHandlerFunc) {
-	return mcp.NewTool("add_pull_request_review_comment_to_pending_review",
+	return mcp.NewTool("add_pr_review_comment_to_pending_review",
 			mcp.WithDescription(t("TOOL_ADD_PULL_REQUEST_REVIEW_COMMENT_TO_PENDING_REVIEW_DESCRIPTION", "Add a comment to the requester's latest pending pull request review, a pending review needs to already exist to call this (check with the user if not sure).")),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
 				Title:        t("TOOL_ADD_PULL_REQUEST_REVIEW_COMMENT_TO_PENDING_REVIEW_USER_TITLE", "Add comment to the requester's latest pending pull request review"),


### PR DESCRIPTION
## Problem

Claude Code fails with:
```
API Error: 400 tools.N.custom.name: String should have at most 64 characters
```

**Root Cause**: Tool name `add_pull_request_review_comment_to_pending_review` (49 chars) + Claude Code's internal prefix `anthropic.custom.` = 66 characters (exceeds 64-char limit)

## Solution

**Minimal Fix**: Shorten tool name in source code
- **Before**: `add_pull_request_review_comment_to_pending_review` (49 chars)
- **After**: `add_pr_review_comment_to_pending_review` (39 chars)
- **Result**: 56 characters total (under 64-char limit)

## Files Changed

- `mcp/github-mcp-server/pkg/github/pullrequests.go` - Line 1235: Tool name shortened

## Expected Result

Claude Code interactive mode works without API validation errors.

Fixes #913