### PR TITLE
feat: add optional config sourcing

### DIFF
--- a/.bash_exports
+++ b/.bash_exports
@@ -17,3 +17,8 @@ export PATH="$PATH:$HOME/ppv/pillars/dotfiles/mcp"
 if [ -f ~/.bash_exports.local ]; then
     . ~/.bash_exports.local
 fi
+
+# Source company-specific configuration from flywire-notes (gitignored)
+if [ -f "$HOME/ppv/pillars/dotfiles/flywire-notes/bash-config.sh" ]; then
+    source "$HOME/ppv/pillars/dotfiles/flywire-notes/bash-config.sh"
+fi


### PR DESCRIPTION
## Problem

Need optional configuration sourcing for different environments.

## Solution

Add conditional sourcing of additional config files if present.

## Changes

- Modified `.bash_exports` to optionally source additional config
- Maintains existing functionality

## Testing

- [x] Works with and without additional config
- [x] No breaking changes