### PR TITLE
fix: restore Claude commands directory and /close-issue functionality

### DIFF
--- a/utils/generate-commands.sh
+++ b/utils/generate-commands.sh
@@ -20,11 +20,10 @@ PROVIDER_CONFIG="$DOTFILES_DIR/.config/provider_dirs.conf"
 
 # Default provider directories if no config file exists
 # Use the vendor-agnostic commands/templates directory for all providers
-declare -A DEFAULT_PROVIDER_DIRS=(
-    ["claude"]="$DOTFILES_DIR/commands/templates|$HOME/.claude/commands"
-    ["amazonq"]="$DOTFILES_DIR/commands/templates|$HOME/.amazonq/commands"
-    ["cursor"]="$DOTFILES_DIR/commands/templates|$HOME/.cursor/commands"
-)
+declare -A DEFAULT_PROVIDER_DIRS
+DEFAULT_PROVIDER_DIRS["claude"]="$DOTFILES_DIR/commands/templates|$HOME/.claude/commands"
+DEFAULT_PROVIDER_DIRS["amazonq"]="$DOTFILES_DIR/commands/templates|$HOME/.amazonq/commands"
+DEFAULT_PROVIDER_DIRS["cursor"]="$DOTFILES_DIR/commands/templates|$HOME/.cursor/commands"
 
 # Load provider directories from config file if it exists
 declare -A PROVIDER_DIRS


### PR DESCRIPTION
## Problem

Recent cleanup removed empty `~/.claude/commands/` directory, breaking `/close-issue` command availability in Claude Code.

## Solution

- Fix associative array syntax in `generate-commands.sh`
- Restore `~/.claude/commands/` directory
- Ensure `/close-issue` and `/retro` commands are available

## Changes

- Modified `utils/generate-commands.sh` to fix bash compatibility issues
- Commands now properly generated in `~/.claude/commands/`

## Testing

- [x] Commands directory created successfully
- [x] `/close-issue` command available in Claude Code
- [x] Script runs without errors

## Related Issues

Fixes blocker identified after recent cleanup work that removed the commands directory.