### PR TITLE
fix: remove debug logging from terminal startup

### DIFF
--- a/.bash_aliases.d/claude.sh
+++ b/.bash_aliases.d/claude.sh
@@ -4,17 +4,10 @@
 DOT_DEN="${DOT_DEN:-$HOME/ppv/pillars/dotfiles}"
 GLOBAL_MCP_CONFIG="$DOT_DEN/mcp/mcp.json"
 
-# Debug logging for work machine detection
-echo "🔍 Claude Config Debug:"
-echo "  WORK_MACHINE variable: '${WORK_MACHINE:-<unset>}'"
-echo "  Evaluation result: '${WORK_MACHINE:-false}'"
-
 # Conditional Bedrock integration - only on work machines
 if [ "${WORK_MACHINE:-false}" = "true" ]; then
-    echo "🏢 Work machine detected - Bedrock integration enabled"
     alias claude='AWS_PROFILE=ai_codegen CLAUDE_CODE_USE_BEDROCK=1 claude --mcp-config "$GLOBAL_MCP_CONFIG" --add-dir "$DOT_DEN/knowledge"'
 else
-    echo "🏠 Personal machine detected - Using Claude Pro Max only"
     alias claude='claude --mcp-config "$GLOBAL_MCP_CONFIG" --add-dir "$DOT_DEN/knowledge"'
 fi
 


### PR DESCRIPTION
## Summary
- Removed debug echo statements from `.bash_aliases.d/claude.sh` that were cluttering terminal startup
- Cleaned up WORK_MACHINE variable debug output
- Preserved Claude provider selection functionality

## Test plan
- [x] Verified Claude alias works for personal machines (WORK_MACHINE=false)
- [x] Verified Claude alias works for work machines (WORK_MACHINE=true with Bedrock integration)
- [x] Confirmed no debug output appears during terminal startup

Closes #925