### PR TITLE
feat(mcp): add Atlassian MCP server configuration

### DIFF
--- a/mcp/mcp.json
+++ b/mcp/mcp.json
@@ -28,6 +28,13 @@
         "USE_PIPELINE": "true"
       }
     },
+    "atlassian": {
+      "command": "atlassian-mcp-wrapper.sh",
+      "args": [],
+      "env": {
+        "FASTMCP_LOG_LEVEL": "ERROR"
+      }
+    },
     "brave-search": {
       "command": "brave-search-mcp-wrapper.sh",
       "args": [],


### PR DESCRIPTION
## Summary

Add missing Atlassian MCP server configuration to enable Jira and Confluence operations for work machines.

## Problem Solved

Resolves #938 - The Atlassian MCP wrapper script existed but wasn't included in the MCP configuration, preventing access to `mcp__atlassian__*` tools.

## Changes Made

- Added `atlassian` server configuration to `mcp/mcp.json`
- Server is conditionally loaded when `WORK_MACHINE=true` (handled by existing wrapper script)
- Follows existing MCP server patterns with error logging

## Available Operations

**Jira:**
- `mcp__atlassian__get_issue` - Get specific Jira ticket details
- `mcp__atlassian__search_issues` - Search Jira tickets
- `mcp__atlassian__create_issue` - Create new Jira tickets
- `mcp__atlassian__update_issue` - Update existing Jira tickets

**Confluence:**
- `mcp__atlassian__*` tools for reading/writing pages and spaces

## Testing

The existing `atlassian-mcp-wrapper.sh` script already handles:
- ✅ Work machine detection (`WORK_MACHINE=true` check)
- ✅ Environment variable validation
- ✅ Error handling and logging
- ✅ Proper credential management

## Principle

**systems-stewardship** - Adding to existing MCP infrastructure rather than creating new patterns, maintaining consistency with other work-specific servers like GitLab.