### PR TITLE
feat(gitlab): GitLab MCP authentication automation for Spilled Coffee recovery

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -278,6 +278,14 @@ else
   echo -e "${YELLOW}MCP server setup script not found. Skipping MCP server setup.${NC}"
 fi
 
+# Set up GitLab MCP authentication (work machines only)
+if [[ -f "$DOT_DEN/utils/setup-gitlab-mcp-auth.sh" ]]; then
+  echo -e "${DIVIDER}"
+  "$DOT_DEN/utils/setup-gitlab-mcp-auth.sh"
+else
+  echo -e "${YELLOW}GitLab MCP auth setup script not found. Skipping GitLab authentication.${NC}"
+fi
+
 # Generate AI provider commands from templates
 if [[ -f "$DOT_DEN/utils/generate-commands.sh" ]]; then
   echo "Generating AI provider commands from templates..."

--- a/utils/setup-gitlab-mcp-auth.sh
+++ b/utils/setup-gitlab-mcp-auth.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# =========================================================
+# GITLAB MCP AUTHENTICATION SETUP
+# =========================================================
+# PURPOSE: Automate GitLab MCP server authentication setup
+# PRINCIPLE: Spilled Coffee - destroy machine, operational that afternoon
+# =========================================================
+
+set -e
+
+echo "🔧 Setting up GitLab MCP authentication..."
+
+# Check if this is a work machine
+if [[ "$WORK_MACHINE" != "true" ]]; then
+    echo "⚠️  GitLab MCP only available on work machines"
+    echo "   Set WORK_MACHINE=true in ~/.bash_exports.local to enable"
+    exit 0
+fi
+
+# Check if glab is installed
+if ! command -v glab &> /dev/null; then
+    echo "❌ glab CLI not found. Installing..."
+    if command -v brew &> /dev/null; then
+        brew install glab
+    else
+        echo "❌ Please install glab CLI: https://gitlab.com/gitlab-org/cli"
+        exit 1
+    fi
+fi
+
+# Check current authentication status
+echo "🔍 Checking GitLab authentication..."
+if glab auth status --host gitlab.flywire.tech >/dev/null 2>&1; then
+    echo "✅ GitLab authentication already configured"
+else
+    echo "🔑 GitLab authentication needed"
+    echo ""
+    echo "📋 Steps to get token:"
+    echo "   1. Go to: https://gitlab.flywire.tech/-/profile/personal_access_tokens"
+    echo "   2. Click 'Add new token'"
+    echo "   3. Name: 'MCP Server - $(date +%Y-%m-%d)'"
+    echo "   4. Scopes: api, read_user, read_repository, write_repository"
+    echo "   5. Expiration: 1 year from now"
+    echo ""
+    
+    # Check if we're in an interactive environment
+    if [[ -t 0 ]]; then
+        read -p "Enter GitLab token: " GITLAB_TOKEN
+        if [[ -n "$GITLAB_TOKEN" ]]; then
+            glab config set token "$GITLAB_TOKEN" --host gitlab.flywire.tech
+            echo "✅ Token configured"
+        else
+            echo "❌ No token provided"
+            exit 1
+        fi
+    else
+        echo "❌ Non-interactive environment - manual token setup required"
+        echo "   Run: glab config set token <YOUR_TOKEN> --host gitlab.flywire.tech"
+        exit 1
+    fi
+fi
+
+# Set correct default host (critical for MCP server)
+echo "🎯 Setting default GitLab host to flywire.tech..."
+glab config set host gitlab.flywire.tech
+
+# Verify authentication
+echo "🧪 Testing GitLab MCP server..."
+if glab auth status --host gitlab.flywire.tech >/dev/null 2>&1; then
+    echo "✅ GitLab MCP authentication ready"
+    echo ""
+    echo "🚀 Test with: claude 'Get my GitLab user info'"
+else
+    echo "❌ GitLab authentication failed"
+    exit 1
+fi


### PR DESCRIPTION
## Problem Solved

GitLab MCP server was experiencing 401 authentication errors due to:
- Revoked personal access tokens
- Incorrect default host configuration (`gitlab.com` instead of `gitlab.flywire.tech`)
- Manual setup process that violated Spilled Coffee Principle

## Solution

### 🔧 Automated GitLab Authentication Setup
- **New script**: `utils/setup-gitlab-mcp-auth.sh`
- **Integration**: Added to main `setup.sh` workflow
- **Work machine detection**: Only runs when `WORK_MACHINE=true`
- **Dependency management**: Auto-installs `glab` CLI if missing

### 🎯 Key Features
- Interactive token configuration with clear instructions
- Automatic default host configuration (`gitlab.flywire.tech`)
- Authentication verification and testing
- Graceful handling of non-interactive environments

### ☕ Spilled Coffee Compliance
Running `source setup.sh` on a fresh work machine now:
1. Detects missing GitLab authentication
2. Provides clear token generation instructions
3. Configures authentication automatically
4. Verifies MCP server functionality
5. **Recovery time**: ~5 minutes including token generation

## Security (No Leaks Principle)
- ✅ No actual tokens in code (uses interactive prompts)
- ✅ Public server name `gitlab.flywire.tech` is acceptable
- ✅ Placeholder `<YOUR_TOKEN>` in documentation
- ✅ Token stored in local `~/.config/glab-cli/config.yml` only

## Testing
```bash
# Test the setup script
./utils/setup-gitlab-mcp-auth.sh

# Verify MCP functionality
claude "Get my GitLab user info"
```

## Files Changed
- `setup.sh` - Added GitLab auth setup integration
- `utils/setup-gitlab-mcp-auth.sh` - New automation script

**Principle**: `spilled-coffee` - Anyone can destroy their machine and be fully operational that afternoon