### PR TITLE
feat(mcp): integrate official Microsoft Playwright MCP server

### DIFF
--- a/mcp/mcp.json
+++ b/mcp/mcp.json
@@ -55,6 +55,13 @@
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"
       }
+    },
+    "playwright": {
+      "command": "playwright-mcp-wrapper.sh",
+      "args": [],
+      "env": {
+        "FASTMCP_LOG_LEVEL": "ERROR"
+      }
     }
   }
 }

--- a/mcp/playwright-mcp-wrapper.sh
+++ b/mcp/playwright-mcp-wrapper.sh
@@ -20,8 +20,8 @@ echo "Starting Microsoft Playwright MCP server..." | tee -a "$LOG_FILE"
 echo "$(date): Playwright MCP server started" >> "$LOG_FILE"
 
 # Execute the Playwright MCP server
-# The exec replaces this shell process with the MCP server process
-exec playwright-mcp "$@"
-
-# This part will only execute if exec fails
-echo "$(date): Playwright MCP server exited with code $?" >> "$LOG_FILE"
+playwright-mcp "$@"
+exit_code=$?
+# Log the exit code
+echo "$(date): Playwright MCP server exited with code $exit_code" >> "$LOG_FILE"
+exit $exit_code

--- a/mcp/playwright-mcp-wrapper.sh
+++ b/mcp/playwright-mcp-wrapper.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Wrapper script for Microsoft Playwright MCP server
+# This script handles execution and error handling for the Playwright MCP server
+
+set -e
+
+# Log file for debugging
+LOG_FILE="$HOME/.playwright-mcp.log"
+
+# Check if playwright-mcp is installed
+if ! command -v playwright-mcp &> /dev/null; then
+    echo "Error: playwright-mcp not found. Please run mcp/setup-playwright-mcp.sh first." | tee -a "$LOG_FILE"
+    exit 1
+fi
+
+# Set default log level if not provided
+export FASTMCP_LOG_LEVEL="${FASTMCP_LOG_LEVEL:-ERROR}"
+
+echo "Starting Microsoft Playwright MCP server..." | tee -a "$LOG_FILE"
+echo "$(date): Playwright MCP server started" >> "$LOG_FILE"
+
+# Execute the Playwright MCP server
+# The exec replaces this shell process with the MCP server process
+exec playwright-mcp "$@"
+
+# This part will only execute if exec fails
+echo "$(date): Playwright MCP server exited with code $?" >> "$LOG_FILE"

--- a/mcp/setup-playwright-mcp.sh
+++ b/mcp/setup-playwright-mcp.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Setup script for Microsoft Playwright MCP server
+# Following the Spilled Coffee Principle - anyone should be able to set this up easily
+
+set -e
+
+echo "Setting up Microsoft Playwright MCP server..."
+
+# Check if npm is installed
+if ! command -v npm &> /dev/null; then
+    echo "Error: npm is required but not installed. Please install Node.js and npm first."
+    exit 1
+fi
+
+# Install the official Microsoft Playwright MCP server
+echo "Installing @microsoft/playwright-mcp..."
+npm install -g @microsoft/playwright-mcp
+
+# Verify installation
+if ! command -v playwright-mcp &> /dev/null; then
+    echo "Error: Installation failed. playwright-mcp command not found."
+    exit 1
+fi
+
+# Get the installed version
+PLAYWRIGHT_MCP_VERSION=$(npm list -g @microsoft/playwright-mcp | grep playwright-mcp | sed 's/.*@//')
+echo "Successfully installed @microsoft/playwright-mcp version $PLAYWRIGHT_MCP_VERSION"
+
+# Install Playwright browsers
+echo "Installing Playwright browsers..."
+npx playwright install
+
+echo "Playwright MCP server setup complete!"
+echo "You can now use the Playwright MCP server through the mcp/playwright-mcp-wrapper.sh script."

--- a/mcp/setup-playwright-mcp.sh
+++ b/mcp/setup-playwright-mcp.sh
@@ -23,8 +23,15 @@ if ! command -v playwright-mcp &> /dev/null; then
 fi
 
 # Get the installed version
-PLAYWRIGHT_MCP_VERSION=$(npm list -g @microsoft/playwright-mcp | grep playwright-mcp | sed 's/.*@//')
+# Extract version using npm list and awk for simpler parsing
+PLAYWRIGHT_MCP_VERSION=$(npm list -g @microsoft/playwright-mcp --depth=0 | awk -F@ '/playwright-mcp/ {print $NF}')
 echo "Successfully installed @microsoft/playwright-mcp version $PLAYWRIGHT_MCP_VERSION"
+
+# Check if npx is installed
+if ! command -v npx &> /dev/null; then
+    echo "Error: npx is required but not installed. Please install Node.js and npm first."
+    exit 1
+fi
 
 # Install Playwright browsers
 echo "Installing Playwright browsers..."


### PR DESCRIPTION
## Overview

This PR integrates the official Microsoft Playwright MCP server into our dotfiles setup, following the "Subtraction Creates Value" principle by using the official implementation rather than maintaining a custom one.

## Changes

- Added `setup-playwright-mcp.sh` for installing the official package
- Created `playwright-mcp-wrapper.sh` for executing the MCP server
- Updated `mcp/mcp.json` to include the Playwright MCP server

## Testing

- Installation script has been tested on macOS
- Wrapper script includes proper error handling and logging
- MCP configuration has been validated

## Related Issues

Closes #950

## Principles Applied

- **Subtraction Creates Value**: Using the official Microsoft implementation reduces maintenance burden
- **Systems Stewardship**: Following consistent patterns for MCP server integration