### PR TITLE
fix(mcp): add auto-install to Playwright MCP wrapper

### DIFF
--- a/mcp/playwright-mcp-wrapper.sh
+++ b/mcp/playwright-mcp-wrapper.sh
@@ -7,10 +7,32 @@ set -e
 # Log file for debugging
 LOG_FILE="$HOME/.playwright-mcp.log"
 
+# Get the directory of this script
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 # Check if playwright-mcp is installed
 if ! command -v playwright-mcp &> /dev/null; then
-    echo "Error: playwright-mcp not found. Please run mcp/setup-playwright-mcp.sh first." | tee -a "$LOG_FILE"
-    exit 1
+    echo "playwright-mcp not found. Attempting to install automatically..." | tee -a "$LOG_FILE"
+    
+    # Check if setup script exists
+    if [[ -f "$SCRIPT_DIR/setup-playwright-mcp.sh" ]]; then
+        echo "Running setup script..." | tee -a "$LOG_FILE"
+        # Make sure it's executable
+        chmod +x "$SCRIPT_DIR/setup-playwright-mcp.sh"
+        # Run the setup script
+        "$SCRIPT_DIR/setup-playwright-mcp.sh"
+        
+        # Check again if installation was successful
+        if ! command -v playwright-mcp &> /dev/null; then
+            echo "Error: Installation failed. Please run mcp/setup-playwright-mcp.sh manually." | tee -a "$LOG_FILE"
+            exit 1
+        fi
+        
+        echo "Installation successful!" | tee -a "$LOG_FILE"
+    else
+        echo "Error: Setup script not found at $SCRIPT_DIR/setup-playwright-mcp.sh" | tee -a "$LOG_FILE"
+        exit 1
+    fi
 fi
 
 # Set default log level if not provided


### PR DESCRIPTION
## Overview

This PR enhances the Playwright MCP wrapper script to automatically install the Playwright MCP server if it's not already installed. This follows the Spilled Coffee Principle by ensuring that the system can recover automatically without manual intervention.

## Changes

- Update wrapper script to detect if `playwright-mcp` is installed
- Automatically run the setup script if the command is not found
- Add proper error handling and logging during the installation process
- Ensure the setup script is executable before running it

## Motivation

The previous implementation required manual execution of the setup script, which violates the Spilled Coffee Principle. This change ensures that anyone can use the Playwright MCP server without having to manually run setup scripts.

## Testing

- Tested by verifying that the wrapper script correctly detects when `playwright-mcp` is not installed
- Confirmed that the automatic installation process works correctly

## Principles Applied

- **Spilled Coffee Principle**: Anyone should be able to destroy their machine and be fully operational again that afternoon
- **Systems Stewardship**: Maintaining and improving systems through consistent patterns