### PR TITLE
Remove GitLab server binary verification

### DIFF
--- a/mcp/setup-all-mcp-servers.sh
+++ b/mcp/setup-all-mcp-servers.sh
@@ -110,7 +110,6 @@ binaries=(
     "servers/github"
     "servers/git-mcp-server/.venv/bin/python"
     "servers/filesystem-mcp-server/node_modules/.bin/filesystem-server"
-    "servers/gitlab-mcp-server/.venv/bin/python"
 )
 
 for binary in "${binaries[@]}"; do


### PR DESCRIPTION
## Problem
Setup script shows false error for GitLab MCP server:
```
✗ servers/gitlab-mcp-server/.venv/bin/python
```

## Solution
Remove the verification check since GitLab MCP server is now installed externally via npm (`@zereight/mcp-gitlab`) rather than as a local Python server.

## Result
- Eliminates false error noise during setup
- Cleaner, more accurate setup output
- Follows **subtraction-creates-value** principle

## Testing
- [x] Verified setup script no longer shows GitLab verification error
- [x] GitLab MCP functionality still works via external installation