### PR TITLE
Remove filesystem server binary verification

### DIFF
--- a/mcp/setup-all-mcp-servers.sh
+++ b/mcp/setup-all-mcp-servers.sh
@@ -109,7 +109,6 @@ echo -e "\n${GREEN}Verifying server binaries:${NC}"
 binaries=(
     "servers/github"
     "servers/git-mcp-server/.venv/bin/python"
-    "servers/filesystem-mcp-server/node_modules/.bin/filesystem-server"
 )
 
 for binary in "${binaries[@]}"; do


### PR DESCRIPTION
## Problem
Setup script shows false error for filesystem MCP server:
```
✗ servers/filesystem-mcp-server/node_modules/.bin/filesystem-server
```

## Solution
Remove the verification check since filesystem MCP server uses `dist/index.js` as the executable, not a binary in `node_modules/.bin/`.

## Result
- Eliminates false error noise during setup
- Cleaner setup output with only valid checks
- Follows **subtraction-creates-value** principle

## Testing
- [x] Verified filesystem MCP server works via wrapper script using `dist/index.js`
- [x] Setup script no longer shows false filesystem verification error