### PR TITLE
Remove obsolete generate-mcp-config.sh warning

### DIFF
--- a/mcp/setup-all-mcp-servers.sh
+++ b/mcp/setup-all-mcp-servers.sh
@@ -76,14 +76,6 @@ for script in "${setup_scripts[@]}"; do
     fi
 done
 
-# Generate MCP configuration for all clients
-if [ -f "$MCP_DIR/generate-mcp-config.sh" ]; then
-    echo -e "\n${GREEN}Generating MCP configurations...${NC}"
-    "$MCP_DIR/generate-mcp-config.sh"
-else
-    echo -e "${YELLOW}Warning: generate-mcp-config.sh not found${NC}"
-fi
-
 # Create servers directory if it doesn't exist
 mkdir -p "$MCP_DIR/servers"
 


### PR DESCRIPTION
## Problem
Setup script shows unnecessary warning:
```
Warning: generate-mcp-config.sh not found
```

## Investigation
The `generate-mcp-config.sh` script was designed to generate `mcp.json` from templates with work/personal machine conditionals. However, the current approach uses:
- Static `mcp.json` configuration 
- Wrapper scripts that handle work/personal differences via `WORK_MACHINE` env var
- No template generation needed

## Solution
Remove the obsolete check for `generate-mcp-config.sh` since:
- ✅ Current MCP setup works fine without it
- ✅ Static configuration is simpler and more reliable
- ✅ Work-specific servers handled by wrapper script logic
- ✅ No references to this script in current main branch

## Result
- Eliminates false warning during setup
- Cleaner setup output
- Follows **subtraction-creates-value** principle

## Testing
- [x] Setup runs without the warning
- [x] MCP servers still work correctly
- [x] Work/personal machine handling unchanged