### PR TITLE
fix(utils): correct nested if-else syntax in install-gh-cli.sh

### DIFF
--- a/utils/install-gh-cli.sh
+++ b/utils/install-gh-cli.sh
@@ -78,20 +78,21 @@ setup_gh_cli() {
     if [[ -n "$LATEST_VERSION" ]]; then
       VERSION_STATUS=$(version_compare "$CURRENT_VERSION" "$LATEST_VERSION")
       if [[ "$VERSION_STATUS" == "older" ]]; then
-      log_info "Updating to: $LATEST_VERSION"
-      install_or_update_gh_cli
-      
-      if [ $? -eq 0 ]; then
-        NEW_VERSION=$(extract_version "gh" "$(gh --version)")
-        UPDATE_STATUS=$(version_compare "$CURRENT_VERSION" "$NEW_VERSION")
-        if [[ "$UPDATE_STATUS" == "older" ]]; then
-          log_success "Updated: $CURRENT_VERSION → $NEW_VERSION"
-        else
-          log_warning "Update failed, still: $CURRENT_VERSION"
+        log_info "Updating to: $LATEST_VERSION"
+        install_or_update_gh_cli
+        
+        if [ $? -eq 0 ]; then
+          NEW_VERSION=$(extract_version "gh" "$(gh --version)")
+          UPDATE_STATUS=$(version_compare "$CURRENT_VERSION" "$NEW_VERSION")
+          if [[ "$UPDATE_STATUS" == "older" ]]; then
+            log_success "Updated: $CURRENT_VERSION → $NEW_VERSION"
+          else
+            log_warning "Update failed, still: $CURRENT_VERSION"
+          fi
         fi
-      fi
       else
-      log_success "Already latest: $CURRENT_VERSION"
+        log_success "Already latest: $CURRENT_VERSION"
+      fi
     fi
   else
     log_info "Installing gh..."


### PR DESCRIPTION
## Description

Fix syntax error in `utils/install-gh-cli.sh` that was preventing the setup script from completing successfully.

## Problem

The `setup_gh_cli` function had improperly nested if-else blocks causing a "syntax error near unexpected token '}'" at line 130. The else block for "Already latest" was incorrectly positioned outside the inner if statement, resulting in a missing `fi` error.

## Solution

- Moved the else block inside the inner if statement where it belongs
- Properly indented all code blocks for clarity
- Verified script syntax with `bash -n` and confirmed it sources without errors

## Testing

- [x] Syntax check passes: `bash -n utils/install-gh-cli.sh`
- [x] Script sources without errors: `source utils/install-gh-cli.sh`
- [x] No regression in functionality

Closes #961