### PR TITLE
fix(commands): add validation for required issue number in close-issue command

### DIFF
--- a/commands/templates/close-issue.md
+++ b/commands/templates/close-issue.md
@@ -1,5 +1,14 @@
 Complete and implement GitHub issue #{{ ISSUE_NUMBER }}.
 
+## Validation: Issue Number Required
+If no issue number was provided, or if {{ ISSUE_NUMBER }} is:
+- Empty or undefined
+- Still contains placeholder text like "$ISSUE_NUMBER" 
+- Not a valid number
+
+STOP immediately and inform the user:
+"Error: The /close-issue command requires a GitHub issue number. Usage: /close-issue <number>"
+
 ## Core Principle: Target-First Development
 {{ INJECT:principles/tracer-bullets.md }}
 


### PR DESCRIPTION
## Summary
Add design-by-contract validation to the `/close-issue` command to ensure it fails fast when no issue number is provided.

## Changes
- Added validation section at the beginning of close-issue.md template
- Checks for empty, undefined, placeholder text, or non-numeric values
- Provides clear error message with usage instructions

## Why
Previously, if a user ran `/close-issue` without providing an issue number, the command would proceed and get confused trying to use an empty or placeholder value. This violates the fail-fast principle and creates a poor user experience.

## Testing
The validation will trigger when:
- `/close-issue` (no argument)
- `/close-issue $ISSUE_NUMBER` (placeholder not replaced)
- `/close-issue abc` (non-numeric value)

The command will stop immediately and show:
```
Error: The /close-issue command requires a GitHub issue number. Usage: /close-issue <number>
```