### PR TITLE
fix(utils): add missing fi statement in install-gh-cli.sh

### DIFF
--- a/utils/install-gh-cli.sh
+++ b/utils/install-gh-cli.sh
@@ -93,6 +93,7 @@ setup_gh_cli() {
       else
       log_success "Already latest: $CURRENT_VERSION"
     fi
+    fi
   else
     log_info "Installing gh..."
     install_or_update_gh_cli


### PR DESCRIPTION
## Description

Minimal fix for syntax error in `utils/install-gh-cli.sh`. Adds only the missing `fi` statement without any indentation changes.

## Problem

The `setup_gh_cli` function has a missing `fi` statement causing:
```
syntax error near unexpected token '}'
```

## Solution

Add single `fi` statement at line 96:
```diff
       else
       log_success "Already latest: $CURRENT_VERSION"
     fi
+    fi
   else
```

## Testing

- [x] Syntax check passes: `bash -n utils/install-gh-cli.sh`
- [x] Script sources without errors
- [x] Minimal 1-line change following `subtraction-creates-value` principle

Closes #961