### PR TITLE
fix(claude): move cd command from allow list to disabledTools

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -129,6 +129,9 @@
     "MCP_TOOL_TIMEOUT": "60000",
     "MAX_MCP_OUTPUT_TOKENS": "25000"
   },
+  "disabledTools": [
+    "Bash(cd:*)"
+  ],
   "enableAllProjectMcpServers": false,
   "enabledMcpjsonServers": [
     "awslabs.aws-documentation-mcp-server",


### PR DESCRIPTION
## Summary
- Moved `Bash(cd:*)` from the allow list to the new disabledTools section
- Removed OSE principle comments that explained why cd was previously allowed
- Aligns with Claude Code's security model where agents should not change directories

## Test Plan
- [x] Verified cd command is blocked when attempted
- [x] Settings.json validates correctly with the new disabledTools section
- [x] No other permissions were affected

Closes #971