### PR TITLE
feat(claude): add cat command to allowed tools

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,6 +15,7 @@
       "Bash(mkdir -p:*)",
       "Bash(source:*)",
       "Bash(cd:*)",
+      "Bash(cat:*)",
       
       "LS",
       "Read",


### PR DESCRIPTION
## Summary
- Added `Bash(cat:*)` to the allowed tools list in `.claude/settings.json`
- Enables viewing file contents via bash commands, complementing the existing Read tool

## Test Plan
- [x] Added cat command to the allowed list
- [x] Maintains all existing permissions including cd command

Closes #971