### PR TITLE
fix(claude): remove JSON comments from settings.json to eliminate validation warnings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,11 +1,5 @@
 {
   "permissions": {
-    // Global Claude Code permissions configuration
-    // These permissions align with the OSE (Outside and Slightly Elevated) principle:
-    // - cd command allows agents to navigate and maintain perspective across different contexts
-    // - Enables orchestration from the right altitude without getting stuck in one directory
-    // - Supports the manager mindset by allowing movement between different areas of concern
-    // See knowledge/principles/ose.md for full OSE principle documentation
     "allow": [
       "Bash(find:*)",
       "Bash(grep:*)",


### PR DESCRIPTION
## Description
Remove JavaScript-style comments from `.claude/settings.json` that were causing Claude Code to show "Invalid settings files" warnings.

## Problem
Claude Code validates JSON strictly and rejects files with `//` comments, even though these comments documented important permission rationale.

## Solution
- Removed all JSON comments from `.claude/settings.json`
- Created `knowledge/procedures/claude-code-permissions.md` to preserve the documentation
- Updated `.claude/README.md` to reference the new documentation location

## Benefits
- ✅ No more validation warnings
- ✅ Documentation is actually more comprehensive now
- ✅ Follows knowledge base patterns
- ✅ AI agents can easily find and reference the docs

## Testing
- Validated JSON with `python -m json.tool`
- Confirmed no syntax errors

Closes #978