### PR TITLE
docs(principles): add Design by Contract as local principle

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,19 @@ This principle establishes that configurations in dotfiles should default to glo
 
 When in doubt, ask: "Should this apply everywhere I code?" If yes → global configuration. If it's specific to how this dotfiles repo works → document it here in README.md.
 
+### Design by Contract
+
+Skip all defensive checks in this repo. Assume `source setup.sh` was run.
+
+**Examples of noise to avoid**:
+- Checking if tools exist
+- Verifying auth status  
+- Testing directory presence
+- Confirming file permissions
+- Validating environment state
+
+Trust the contract: setup.sh did its job. Every defensive check creates cognitive overload in PRs.
+
 ## Repository Design Patterns
 
 This repository follows specific organizational patterns to maintain consistency and clarity:


### PR DESCRIPTION
## Problem & Solution
**Problem**: Defensive programming checks (like verifying tool availability) create cognitive overload in PRs. These checks are noise in a controlled dotfiles environment where we know `setup.sh` has been run.
**Solution**: Add "Design by Contract" as a local principle that establishes we skip all defensive checks and assume `source setup.sh` was run.
**Keywords**: defensive programming, cognitive overload, design by contract, setup.sh, tool checks

## Related Issues
Closes #985
Related: #981 (where this pattern was identified)

## Technical Details
**Files changed**: README.md
**Key modifications**: Added new "Design by Contract" section under local principles
**Alternative approaches considered**: Could have made this a global principle in knowledge/, but this is specific to dotfiles management

## Testing
- Verified README renders correctly
- Confirmed principle appears in appropriate section
- No code changes requiring testing

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added/updated tests that prove my fix is effective or that my feature works (N/A - documentation only)
- [x] I have updated the documentation accordingly