### PR TITLE
chore: remove Flywire-specific references

### DIFF
--- a/knowledge/principles/no-leaks.md
+++ b/knowledge/principles/no-leaks.md
@@ -7,17 +7,17 @@ Avoid leaking company details into your public dotfiles - it's about respect, no
 **Why this matters**: We want to be responsible practitioners of AI and not ruin a good thing we have going - for ourselves or anyone else. Leaking company details into AI training data hurts everyone's ability to use these tools professionally.
 
 **In practice**:
-- MUST use environment variables: `AWS_PROFILE="${FLYWIRE_AWS_PROFILE:-default}"` 
-- SHOULD point to gitignored docs: `# See flywire-notes/aws-setup.md`
-- MAY use public company name "Flywire" in comments and messages
+- MUST use environment variables: `AWS_PROFILE="${COMPANY_AWS_PROFILE:-default}"` 
+- SHOULD point to gitignored docs: `# See company-notes/aws-setup.md`
+- MAY use public company name in comments and messages
 - MUST NOT hardcode internal identifiers like profile names or server details
-- SHOULD keep comprehensive Flywire-specific documentation in `flywire-notes/` directory
+- SHOULD keep comprehensive company-specific documentation in `company-notes/` directory
 - MAY include as much detail as needed in gitignored notes - they stay local and private
 
-**Spilled Coffee Compatibility**: Flywire-notes are backed up in company cloud and only accessed on company hardware. AI can easily find flywire-notes documentation during setup, maintaining 20-minute recovery time. Inline comments create discoverable breadcrumbs.
+**Spilled Coffee Compatibility**: Company-notes are backed up in company cloud and only accessed on company hardware. AI can easily find company-notes documentation during setup, maintaining 20-minute recovery time. Inline comments create discoverable breadcrumbs.
 
-**Global Force Multiplier**: The `flywire-notes/` pattern works in ANY repository via global gitignore configuration. This multiplies the impact across your entire professional ecosystem - every repo gets rich Flywire context for AI agents while keeping company details private.
+**Global Force Multiplier**: The `company-notes/` pattern works in ANY repository via global gitignore configuration. This multiplies the impact across your entire professional ecosystem - every repo gets rich company context for AI agents while keeping company details private.
 
-**Remember**: Check and update flywire-notes documentation when working in these areas - keep the breadcrumbs fresh.
+**Remember**: Check and update company-notes documentation when working in these areas - keep the breadcrumbs fresh.
 
 Keep company details in your private vaults, not public dotfiles. Your employer didn't agree to have their internal names scattered across GitHub.

--- a/mcp/mcp.json
+++ b/mcp/mcp.json
@@ -17,21 +17,6 @@
       "args": [],
       "env": {}
     },
-    "gitlab": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@zereight/mcp-gitlab"
-      ],
-      "env": {
-        "GITLAB_API_URL": "https://gitlab.flywire.tech/api/v4",
-        "GITLAB_READ_ONLY_MODE": "false",
-        "USE_GITLAB_WIKI": "true",
-        "USE_MILESTONE": "true",
-        "USE_PIPELINE": "true",
-        "FASTMCP_LOG_LEVEL": "ERROR"
-      }
-    },
     "atlassian": {
       "command": "atlassian-mcp-wrapper.sh",
       "args": [],


### PR DESCRIPTION
## Summary
- Remove GitLab MCP server configuration pointing to Flywire's internal GitLab instance
- Update no-leaks.md principle to use generic company references instead of Flywire-specific examples
- Replace "flywire-notes" pattern with generic "company-notes" pattern

## Changes
- Removed GitLab server entry from `mcp/mcp.json` that contained Flywire GitLab URL
- Updated `knowledge/principles/no-leaks.md` to make examples company-agnostic
- All Flywire references have been replaced with generic equivalents

## Test plan
- [x] Verified no remaining Flywire references with case-insensitive search
- [x] MCP configuration remains valid JSON after GitLab removal
- [x] Documentation maintains clarity with generic examples