### PR TITLE
docs(procedures): add think-tank directory documentation

### DIFF
--- a/knowledge/procedures/think-tank.md
+++ b/knowledge/procedures/think-tank.md
@@ -1,0 +1,29 @@
+# Think-Tank Directory
+
+A designated space for personal content that lives outside the codebase but needs version control.
+
+## Purpose
+Store personal documents, notes, and drafts that:
+- Don't belong in code directories
+- Need to persist across development sessions
+- Require version control for safety
+
+## Location
+**Always use**: `/think-tank/` in the main repository
+**Never use**: Worktree locations (they're ephemeral)
+
+## What Belongs Here
+✓ Personal notes and brainstorming
+✓ Resume drafts and career documents
+✓ Learning notes and research
+✓ Project ideas and planning docs
+✓ Personal scripts or configurations
+
+## What Doesn't Belong Here
+✗ Code documentation (use `/docs/`)
+✗ Project-specific notes (use project directories)
+✗ Sensitive credentials (use `.bash_secrets`)
+✗ Generated files or build artifacts
+
+## Key Principle
+Think-tank content is personal workspace material. It's tracked by git but kept separate from the technical ecosystem of the dotfiles.


### PR DESCRIPTION
## Problem & Solution
**Problem**: After implementing warnings about not putting think-tank content in worktrees (#1003, #1004), there was no clear documentation about what the think-tank directory is actually for.
**Solution**: Created a concise procedure document explaining the think-tank directory's purpose, location, and usage guidelines.
**Keywords**: think-tank, personal content, worktree, persistence, documentation

## Related Issues
Closes #1005

## Technical Details
**Files changed**: 
- Added `knowledge/procedures/think-tank.md`

**Key modifications**: 
- Clear purpose statement for personal content storage
- Explicit location guidance (main repo only, never worktrees)
- Examples of what belongs vs what doesn't
- Concise format for quick reference

**Alternative approaches considered**: 
- Could have added to existing docs, but standalone procedure is clearer
- Kept it intentionally brief per issue requirements

## Testing
- Review document for clarity and completeness
- Ensure it addresses the core confusion about think-tank usage

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added/updated tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have updated the documentation accordingly (if applicable)