### PR TITLE
Configure Claude Code to use opus as default model

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "model": "claude-opus-4-20250514",
   "permissions": {
     "allow": [
       "Bash(find:*)",

--- a/knowledge/procedures/claude-code-tips.md
+++ b/knowledge/procedures/claude-code-tips.md
@@ -13,3 +13,9 @@ Force multiplier discoveries for 1000x Claude Code productivity. Default to one-
 ## Keyboard Shortcuts
 
 - **ThinkPad conversation navigation**: Hold Escape to view conversation history and fork from any previous message. (ThinkPad users: if Fn Lock is on, toggle with Fn+Esc first)
+
+## Model Configuration
+
+- **Default model**: Set in `.claude/settings.json` with `"model": "claude-opus-4-20250514"`
+- **Environment variable**: Alternatively use `ANTHROPIC_MODEL` environment variable
+- **CLI flag**: Override per-session with `claude --model opus` or `claude --model claude-opus-4-20250514`


### PR DESCRIPTION
## Summary
- Added `"model": "claude-opus-4-20250514"` to `.claude/settings.json`
- Documented the configuration option in knowledge base
- Tested with comprehensive positive and negative test cases

## What changed
1. **`.claude/settings.json`**: Added the `model` key at the top level to set opus as the default model
2. **`knowledge/procedures/claude-code-tips.md`**: Added Model Configuration section documenting:
   - How to set default model in settings.json
   - Alternative environment variable method (`ANTHROPIC_MODEL`)
   - CLI flag override option

## Testing
Created and ran comprehensive tests including:
- ✓ Positive test: Verified opus model is set correctly
- ✓ Negative tests: Ensured other models (sonnet, haiku, old opus-3) are NOT set
- ✓ JSON structure validation
- ✓ Tested behavior with model setting removed

## Impact
Users will no longer need to manually run `/model` command to switch to opus - it will be the default on Claude Code startup.

Closes #1006