### PR TITLE
docs(knowledge): add throughput-definition to README index

### DIFF
--- a/knowledge/README.md
+++ b/knowledge/README.md
@@ -6,5 +6,6 @@ Modular rules automatically discovered by Amazon Q context system.
 When editing these foundational `.amazonq/rules/*.md` files, keep changes small and easy to approve. Avoid long code blocks or extensive additions. Every edit should be easy to say "yes" to without nitpicking.
 
 ## Structure
+- `throughput-definition.md` - **The North Star**: Defines throughput as AI agent management capability for 100x-1000x productivity
 - `principles/` - Foundational truths that rarely change
 - `procedures/` - Actionable processes that evolve


### PR DESCRIPTION
## Summary
Update knowledge/README.md to prominently feature throughput-definition.md as the North Star principle at the root level.

## Changes
- Added `throughput-definition.md` entry to the Structure section in knowledge/README.md
- Clearly labeled it as "The North Star" with a brief description

## Rationale
After elevating throughput-definition.md to the knowledge root in PR #1011, the README index should reflect this prominent position to help both humans and AI understand the hierarchy of principles.

Related to #1010 (follow-up to PR #1011)