### PR TITLE
feat(claude-code): add minimal settings configuration

### DIFF
--- a/.claude/settings/claude-code-defaults.json
+++ b/.claude/settings/claude-code-defaults.json
@@ -1,0 +1,6 @@
+{
+  "model": "claude-3-5-sonnet-20241022",
+  "defaultMode": "acceptEdits",
+  "cleanupPeriodDays": 90,
+  "forceLoginMethod": "claudeai"
+}

--- a/.claude/settings/claude-code-defaults.json
+++ b/.claude/settings/claude-code-defaults.json
@@ -1,5 +1,5 @@
 {
-  "model": "claude-3-5-sonnet-20241022",
+  "model": "claude-opus-4-20250514",
   "defaultMode": "acceptEdits",
   "cleanupPeriodDays": 90,
   "forceLoginMethod": "claudeai"

--- a/docs/claude-code-settings.md
+++ b/docs/claude-code-settings.md
@@ -30,6 +30,12 @@ The configuration script is called automatically:
 ### Global Settings (via `claude config`)
 See `.claude/settings/claude-code-defaults.json` for the current configuration. The settings file is the source of truth and includes:
 
+- **model**: AI model to use (e.g., claude-3-5-sonnet-20241022)
+- **defaultMode**: Default permission mode ("acceptEdits" for auto-accepting)
+- **cleanupPeriodDays**: Chat transcript retention (90 days)
+- **forceLoginMethod**: Authentication method ("claudeai" for Pro/Pro Max accounts)
+
+Additional settings that can be configured:
 - **Visual**: theme, editor mode
 - **Behavior**: auto-updates, verbose output, diff tool
 - **Notifications**: preferred channel, idle thresholds  

--- a/utils/configure-claude-code-settings.sh
+++ b/utils/configure-claude-code-settings.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Configure Claude Code settings from declarative JSON
+
+set -e
+
+# Colors for output
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+# Find the directory containing this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Path to settings file
+SETTINGS_FILE="$REPO_ROOT/.claude/settings/claude-code-defaults.json"
+
+echo "Configuring Claude Code settings..."
+
+# Check if settings file exists
+if [ ! -f "$SETTINGS_FILE" ]; then
+    echo "Settings file not found at $SETTINGS_FILE"
+    exit 1
+fi
+
+# Apply settings using jq to parse JSON
+if command -v jq &> /dev/null; then
+    # Extract and apply each setting
+    while IFS= read -r key && IFS= read -r value; do
+        # Convert camelCase to kebab-case for CLI
+        cli_key=$(echo "$key" | sed 's/\([A-Z]\)/-\1/g' | tr '[:upper:]' '[:lower:]')
+        
+        echo "Setting $cli_key to $value"
+        claude config set --global "$cli_key" "$value" || echo "Warning: Failed to set $cli_key"
+    done < <(jq -r 'to_entries[] | .key, .value' "$SETTINGS_FILE")
+else
+    echo "Error: jq is required to parse settings. Install with: apt-get install jq"
+    exit 1
+fi
+
+echo -e "${GREEN}Claude Code settings applied successfully!${NC}"

--- a/utils/install-claude-code.sh
+++ b/utils/install-claude-code.sh
@@ -95,6 +95,12 @@ setup_claude_code() {
     # Configure MCP servers for Claude Code
     configure_claude_mcp
     
+    # Apply Claude Code settings if configuration script exists
+    if [[ -f "$SCRIPT_DIR/configure-claude-code-settings.sh" ]]; then
+        echo "Applying Claude Code settings..."
+        "$SCRIPT_DIR/configure-claude-code-settings.sh"
+    fi
+    
     return 0
 }
 


### PR DESCRIPTION
## Problem & Solution
**Problem**: Need to configure Claude Code settings for Pro Max accounts without adding excessive complexity
**Solution**: Minimal JSON configuration with just 4 essential settings
**Keywords**: claude code settings, forceLoginMethod, defaultMode, cleanupPeriodDays

## Related Issues
Closes #1015

## Technical Details
**Files changed**: 
- `.claude/settings/claude-code-defaults.json` - Minimal settings (only 6 lines)
- `utils/configure-claude-code-settings.sh` - Simple jq-based configuration script
- `utils/install-claude-code.sh` - Added call to configuration script
- `docs/claude-code-settings.md` - Updated to document the new settings

**Key modifications**: 
- Just 4 settings: model, defaultMode, cleanupPeriodDays, forceLoginMethod
- Simple JSON structure matching existing pattern
- Minimal lines of code added (~50 vs 213 in previous attempt)

## Testing
Verified JSON syntax is valid

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added/updated tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have updated the documentation accordingly