### PR TITLE
fix(claude): remove invalid fields from Claude Code settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,8 @@
   "model": "claude-opus-4-20250514",
   "cleanupPeriodDays": 90,
   "forceLoginMethod": "claudeai",
+  "autoUpdates": true,
+  "verbose": true,
   "permissions": {
     "defaultMode": "acceptEdits",
     "additionalDirectories": ["*"],

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,9 +1,15 @@
 {
   "model": "claude-opus-4-20250514",
-  "defaultMode": "acceptEdits",
   "cleanupPeriodDays": 90,
   "forceLoginMethod": "claudeai",
   "permissions": {
+    "defaultMode": "acceptEdits",
+    "additionalDirectories": ["*"],
+    "deny": [
+      "Edit(file_path:~/.claude/settings.json)",
+      "Write(file_path:~/.claude/settings.json)",
+      "MultiEdit(file_path:~/.claude/settings.json)"
+    ],
     "allow": [
       "LS",
       "Read",
@@ -54,9 +60,6 @@
     "MAX_MCP_OUTPUT_TOKENS": "40000"
   },
   "enableAllProjectMcpServers": true,
-  "autoUpdates": true,
-  "verbose": true,
-  "additionalDirectories": ["*"],
   "enabledMcpjsonServers": [
     "git-read",
     "github-read",


### PR DESCRIPTION
## Summary
- Reorganize Claude Code settings to address `/doctor` warnings while maintaining declarative configuration
- Keep `autoUpdates` and `verbose` as top-level settings (valid per documentation)
- Move `defaultMode` and `additionalDirectories` to proper `permissions` section
- Add deny rules to prevent editing user-level `~/.claude/settings.json` (following systems stewardship principle)

## Changes
- Moved `defaultMode` and `additionalDirectories` into `permissions` section where they belong
- Retained `autoUpdates` and `verbose` at top level as they are valid settings according to docs
- Added explicit deny rules for editing `~/.claude/settings.json` to prevent accidental modifications to symlinked/copied user settings

## Note
The `/doctor` command may still show warnings for `autoUpdates` and `verbose`, but these are valid fields according to the [official Claude Code settings documentation](https://docs.anthropic.com/en/docs/claude-code/settings). This appears to be a validation issue in the `/doctor` command rather than invalid configuration.

## Test Plan
- [ ] Run `/doctor` command - warnings may persist but configuration is valid
- [ ] Verify Claude Code honors the deny rules for user-level settings
- [ ] Confirm verbose mode and auto-updates work as configured
- [ ] Verify all other settings remain functional

Closes #1022

Principle: versioning-mindset