### PR TITLE
fix(claude-code): remove manual update logic and set configs imperatively

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -55,7 +55,6 @@
     "MAX_MCP_OUTPUT_TOKENS": "40000"
   },
   "enableAllProjectMcpServers": true,
-  "autoUpdates": true,
   "verbose": true,
   "enabledMcpjsonServers": [
     "git-read",

--- a/knowledge/principles/developer-experience.md
+++ b/knowledge/principles/developer-experience.md
@@ -7,3 +7,8 @@ Based on the Third Ideal from The Unicorn Project: "Improvement of Daily Work" -
 - **Bend the machine to our will**: Facilitate control and personal mastery over our development environment
 
 This principle optimizes the human-computer interface, recognizing that joy is a uniquely human emotion worth explicitly pursuing. Yes, we should optimize for joy and use it as a barometer and metric in our white collar work - it shows authenticity and true calling in our craft.
+
+## Classic Bottlenecks to Developer Joy
+
+### PR Review Fatigue
+When diffs are bloated with logging, defensive checks, and colorful echo statements, the joy of reviewing code evaporates. The human reviewer becomes the constraint, and every non-essential line is a tax on their attention. See [PR Readability Contract](pr-readability-contract.md) for how to avoid this anti-pattern.

--- a/knowledge/principles/pr-readability-contract.md
+++ b/knowledge/principles/pr-readability-contract.md
@@ -19,6 +19,29 @@ Design by contract: AI agents are responsible for implementing the requested fun
 - Comprehensive logging
 - Edge case handling
 - "Future-proofing" abstractions
+- **Colorful echo statements**: Multiple colored status messages bloat diffs and fatigue reviewers
+
+### Negative Example: Logging Bloat
+
+**Bad (50% logging noise):**
+```bash
+if command -v claude &> /dev/null; then
+    echo "Configuring Claude Code imperative settings..."
+    claude config set -g autoUpdate true 2>/dev/null || echo -e "${YELLOW}Warning: Could not set autoUpdate${NC}"
+    claude config set -g preferredNotifChannel terminal_bell 2>/dev/null || echo -e "${YELLOW}Warning: Could not set preferredNotifChannel${NC}"
+    echo -e "${GREEN}✓ Claude Code imperative settings configured${NC}"
+fi
+```
+
+**Good (focused on the change):**
+```bash
+if command -v claude &> /dev/null; then
+    claude config set -g autoUpdate true 2>/dev/null
+    claude config set -g preferredNotifChannel terminal_bell 2>/dev/null
+fi
+```
+
+The second version makes the actual change immediately visible. Logging can be added in a separate PR if needed.
 
 ## When to Break the Rule
 

--- a/utils/install-claude-code.sh
+++ b/utils/install-claude-code.sh
@@ -37,43 +37,9 @@ setup_claude_code() {
     
     # Check if Claude Code is already installed
     if command -v claude &> /dev/null; then
-        # Get current version
+        # Get current version for informational purposes
         CURRENT_VERSION=$(claude --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
-        echo "Claude Code is already installed (version: $CURRENT_VERSION)"
-        
-        # Get latest version from npm
-        LATEST_VERSION=$(npm view @anthropic-ai/claude-code version 2>/dev/null || echo "unknown")
-        
-        if [ "$LATEST_VERSION" = "unknown" ]; then
-            echo -e "${YELLOW}Could not determine latest version. Attempting to update anyway...${NC}"
-            if ! npm update -g @anthropic-ai/claude-code; then
-                echo -e "${RED}Failed to update Claude Code. Please try again or check your npm installation.${NC}"
-                return 1
-            fi
-        elif [ "$CURRENT_VERSION" = "$LATEST_VERSION" ]; then
-            echo -e "${GREEN}✓ Claude Code is already up to date (version: $CURRENT_VERSION)${NC}"
-            return 0
-        else
-            # Use proper version comparison to prevent downgrades
-            VERSION_COMPARISON=$(version_compare "$CURRENT_VERSION" "$LATEST_VERSION")
-            
-            if [ "$VERSION_COMPARISON" = "newer" ]; then
-                echo -e "${GREEN}✓ Claude Code local version is newer (local: $CURRENT_VERSION, npm: $LATEST_VERSION)${NC}"
-                return 0
-            elif [ "$VERSION_COMPARISON" = "older" ]; then
-                echo "Updating Claude Code from $CURRENT_VERSION to $LATEST_VERSION..."
-                if ! npm update -g @anthropic-ai/claude-code; then
-                    echo -e "${RED}Failed to update Claude Code. Please try again or check your npm installation.${NC}"
-                    return 1
-                fi
-                
-                NEW_VERSION=$(claude --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
-                echo -e "${GREEN}✓ Claude Code successfully updated to version $NEW_VERSION${NC}"
-            else
-                echo -e "${GREEN}✓ Claude Code is already up to date (version: $CURRENT_VERSION)${NC}"
-                return 0
-            fi
-        fi
+        echo -e "${GREEN}✓ Claude Code is already installed (version: $CURRENT_VERSION)${NC}"
     else
         # Install Claude Code
         echo "Installing Claude Code CLI..."
@@ -104,6 +70,12 @@ configure_claude_mcp() {
     # Get the directory where this script is located
     SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
     DOT_DEN="$(dirname "$SCRIPT_DIR")"
+    
+    # Configure imperative settings
+    if command -v claude &> /dev/null; then
+        claude config set -g autoUpdate true 2>/dev/null
+        claude config set -g preferredNotifChannel terminal_bell 2>/dev/null
+    fi
     
     # Check if .mcp.json exists in the dotfiles repository
     if [[ -f "$DOT_DEN/.mcp.json" ]]; then


### PR DESCRIPTION
## Overview
Removes manual Claude Code update logic and moves autoUpdate/preferredNotifChannel to imperative configuration, following the subtraction-creates-value principle.

## Changes
1. **Removed `autoUpdates` from `.claude/settings.json`** - must be set imperatively
2. **Simplified `utils/install-claude-code.sh`** - removed 40+ lines of update checking/version comparison logic  
3. **Added imperative configuration** - two clean lines for autoUpdate and preferredNotifChannel
4. **Updated knowledge base** - documented PR readability lessons learned

## Before/After
**Before**: 40+ lines of version checking, npm queries, comparison logic  
**After**: 2 lines of imperative config

## Knowledge Updates
- Added negative example to `pr-readability-contract.md` showing how logging bloats diffs
- Added PR review fatigue as classic bottleneck in `developer-experience.md`

Closes #1020