### PR TITLE
fix(claude-code): remove wildcards from MCP permission patterns

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,15 +29,15 @@
       "Bash(check-mcp-logs:*)",
       "Bash(python:*)",
       
-      "mcp__git*",
-      "mcp__github-read*",
+      "mcp__git",
+      "mcp__github-read",
       "mcp__github-write__create_pull_request",
       "mcp__github-write__add_issue_comment",
       "mcp__github-write__update_issue",
       "mcp__brave-search",
       "mcp__filesystem",
       "mcp__gdrive",
-      "mcp__playwright*"
+      "mcp__playwright"
     ],
     "additionalDirectories": ["*"]
   },

--- a/knowledge/principles/permissive-default-surgical-removal.md
+++ b/knowledge/principles/permissive-default-surgical-removal.md
@@ -3,7 +3,7 @@
 Start with maximum capability and transparency, then surgically remove only what violates security or the spilled coffee principle. This inverts traditional security thinking (restrictive by default) in favor of developer experience and visibility.
 
 ## Core Pattern
-- **Wildcards over enumeration**: `mcp__git*` not 27 individual entries
+- **Server-level permissions**: `mcp__git` grants all tools from that server (wildcards not supported)
 - **All access by default**: `additionalDirectories: ["*"]`, `WebFetch(domain:*)`
 - **Full visibility**: `verbose: true`, keep all output transparent
 - **Surgical removal**: Remove only specific dangerous operations like `claude config set`
@@ -18,7 +18,7 @@ Traditional security says "deny all, allow specific" but in a trusted developmen
 ## Examples from Practice
 - Started with `Bash(claude config:*)` → removed only `set` operations
 - Enabled all directories access rather than maintaining allowed lists
-- Kept all MCP servers with wildcards rather than individual permissions
+- Kept all MCP servers with server-level permissions rather than individual tool permissions
 - Disabled telemetry/reporting at the source rather than filtering data
 
 ## Relationship to Other Principles


### PR DESCRIPTION
<!-- 
AUDIENCE: Future AI agents searching for solutions to similar problems
FORMAT: Use keywords, exact error messages, and technical details they'll search for
-->

## Problem & Solution
**Problem**: Claude Code MCP permission patterns with wildcards (e.g., `mcp__git*`) were not being honored. Tools were being blocked despite having wildcard permissions configured.
**Solution**: Remove wildcards from all MCP permission patterns. Claude Code expects server names only, not wildcard patterns.
**Keywords**: MCP permissions, wildcard patterns, Claude Code settings, mcp__git*, mcp__github-read*, tool permissions

## Related Issues
Closes #1030

## Technical Details
**Files changed**: 
- `.claude/settings.json` - Updated MCP permission patterns
- `knowledge/principles/permissive-default-surgical-removal.md` - Updated documentation

**Key modifications**: 
- Changed `"mcp__git*"` → `"mcp__git"`
- Changed `"mcp__github-read*"` → `"mcp__github-read"`
- Changed `"mcp__playwright*"` → `"mcp__playwright"`

**Alternative approaches considered**: 
- Individual tool permissions (e.g., `mcp__git__git_status`) - rejected as too verbose
- Regex patterns - not supported by Claude Code

## Testing
Verified that specifying just the server name (without wildcards) allows all tools from that MCP server:
- `mcp__git` allows all git tools
- `mcp__github-read` allows all github-read tools
- Server-name-only pattern confirmed working in upstream issues #3107 and #2928

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added/updated tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have updated the documentation accordingly (if applicable)