### PR TITLE
docs(claude-code): add MCP wildcard warning and simplify model config

### DIFF
--- a/knowledge/procedures/claude-code-tips.md
+++ b/knowledge/procedures/claude-code-tips.md
@@ -14,8 +14,10 @@ Force multiplier discoveries for 1000x Claude Code productivity. Default to one-
 
 - **ThinkPad conversation navigation**: Hold Escape to view conversation history and fork from any previous message. (ThinkPad users: if Fn Lock is on, toggle with Fn+Esc first)
 
+## MCP Server Permissions
+
+- **No wildcards**: Use server names only in permissions (e.g., `"mcp__git"` not `"mcp__git*"`) - wildcards aren't supported despite appearing to work for servers without hyphens
+
 ## Model Configuration
 
-- **Default model**: Set in `.claude/settings.json` with `"model": "claude-opus-4-20250514"`
-- **Environment variable**: Alternatively use `ANTHROPIC_MODEL` environment variable
-- **CLI flag**: Override per-session with `claude --model opus` or `claude --model claude-opus-4-20250514`
+- **Set in settings.json**: Configure with `"model": "claude-opus-4-20250514"`


### PR DESCRIPTION
## Summary
- Added MCP server permissions section documenting that wildcards aren't supported
- Simplified model configuration section by removing redundant CLI flag and environment variable options
- Applied subtraction-creates-value principle to reduce cognitive overhead

## Context
During investigation of #1030, we discovered that MCP permission wildcards aren't supported by Claude Code, despite appearing to work for servers without hyphens. This PR documents this limitation and also simplifies the model configuration guidance to have one clear way of setting the model.

## Changes
- Added "MCP Server Permissions" section explaining no wildcard support
- Removed CLI flag and environment variable options for model configuration
- Kept only the settings.json approach as the single source of truth

Closes #1032