### PR TITLE
docs: Planning Mode - The mechanical implementation of OSE

### DIFF
--- a/knowledge/principles/ose.md
+++ b/knowledge/principles/ose.md
@@ -47,6 +47,26 @@ How could this NOT be 100x-1000x more productive? You're not just faster - you'r
 - Maintain calm perspective during crisis situations - systems thinking over emotional reactions
 - Grant broad tool permissions - just as managers don't want employees asking permission to staple papers, you shouldn't micromanage agent tool access
 
+## Planning Mode: OSE Mechanically Enforced
+
+Claude Code's planning mode is the mechanical implementation of OSE. Instead of trying to remember to stay elevated, the tool keeps you there:
+
+**Enable OSE by default:**
+```bash
+# In ~/.claude/settings.json
+{
+  "defaultMode": "plan"
+}
+```
+
+**How it enforces OSE:**
+- Forces you to review plans, not watch implementation
+- Prevents "driving" at the code level
+- Enables batch approval of multiple agent plans
+- Shifts your focus from HOW (implementation) to WHAT (requirements)
+
+See [tmux + git worktrees + Claude Code + Planning Mode](../procedures/tmux-git-worktrees-claude-code.md) for the complete workflow that delivers 100x productivity through true parallel agent management.
+
 ## Relationship to Other Principles
 
 - **[Spilled Coffee Principle](../../../README.md)**: OSE prevents the firefighting that creates fragile systems

--- a/knowledge/procedures/tmux-git-worktrees-claude-code.md
+++ b/knowledge/procedures/tmux-git-worktrees-claude-code.md
@@ -1,17 +1,40 @@
-# tmux + git worktrees + Claude Code
+# tmux + git worktrees + Claude Code + Planning Mode
 
-The triumvirate trinity that delivers 100x productivity: tmux orchestrates, git worktrees isolate, Claude Code executes. This is how you manage multiple AI agents in parallel without IDE context switching overhead.
+The quartet that delivers 100x productivity: tmux orchestrates, git worktrees isolate, Claude Code thinks, planning mode keeps you elevated. This is how you manage multiple AI agents in parallel without IDE context switching overhead.
 
-## The Three Components
+## The Four Components
 
 - **tmux**: Multi-session task orchestration with keyboard-driven pane management
 - **git worktrees**: Complete repository isolation per issue (no cross-contamination)  
 - **Claude Code CLI**: Context window management with resuming/branching capabilities
+- **Planning Mode**: Default to thinking over doing - enforces [OSE principle](../principles/ose.md) mechanically
+
+## Planning Mode: The Game Changer
+
+**Enable by default** (recommended):
+```bash
+# In ~/.claude/settings.json
+{
+  "defaultMode": "plan"
+}
+```
+
+**Or activate per-session**: Press `Shift+Tab` before running commands
+
+**What changes:**
+- Claude presents a plan BEFORE acting
+- You review and approve/refine at the planning level
+- No more "driving" at the implementation level
+- Enforces OSE principle - you manage plans, not code
+
+**The shift:**
+- **Old way**: Watch Claude code, interrupt to course-correct
+- **New way**: Review Claude's plan, approve with confidence
 
 ## Core Workflow
 
 **New task received:**
-`tmux pane + /close-issue <number> → automated workflow to PR`
+`tmux pane + /close-issue <number> → Claude presents plan → You approve → automated workflow to PR`
 
 **Parallel isolation:**
 Automatic worktree creation per agent prevents interference between simultaneous tasks.
@@ -36,6 +59,9 @@ Immediate issue creation/resolution cycle maintains snowball method momentum rat
 - **Empowering workflow**: Fix broken windows immediately instead of noting them
 - **Automation**: Slash commands handle worktree creation and management
 - **Joy**: Git-like conversation branching and tmux orchestration feel delightful
+- **Quality through planning**: Better plans mean smaller, focused PRs with less rework
+- **Cognitive load reduction**: Review plans in batches instead of driving implementations serially
+- **OSE enforcement**: Tool keeps you elevated - no more hands-on-keyboard heroics
 
 ## Related Procedures
 


### PR DESCRIPTION
## Summary

Documents the breakthrough discovery that Claude Code's planning mode mechanically enforces the OSE (Outside and Slightly Elevated) principle. This PR captures our working session insights about shifting from "driving" implementations to reviewing plans.

## The Breakthrough

During a working session with Alex and Jonah, we discovered that planning mode fundamentally changes the human-AI interaction model:
- **Old way**: Human "drives" at implementation level, watching Claude code
- **New way**: Human reviews plans at strategic level, approves with confidence

## Changes

### Updated `knowledge/procedures/tmux-git-worktrees-claude-code.md`:
- Added planning mode as the 4th component of the productivity quartet
- Included configuration instructions (`defaultMode: "plan"`)
- Documented the workflow shift
- Added benefits specific to planning mode

### Updated `knowledge/principles/ose.md`:
- New section: "Planning Mode: OSE Mechanically Enforced"
- Shows how the tool enforces the principle
- Configuration example
- Bidirectional link to the procedure

## Why This Matters

This isn't just a tool feature - it's a fundamental shift in how we work with AI agents. Planning mode:
- Enforces OSE by keeping humans at the planning level
- Enables true parallel processing (review multiple plans while agents execute)
- Reduces cognitive load and context switching
- Produces smaller, more focused PRs

As Brent learned from "Work the System" - we're now working ON the system, not IN it.

## Testing

- Verified markdown formatting
- Confirmed bidirectional links work
- Tested with `shift+tab` to activate planning mode
- Successfully used planning mode for actual issue resolution

This documents what we believe is a watershed moment in AI-assisted development workflows.