### PR TITLE
fix(claude): change defaultMode to plan

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,7 @@
   "cleanupPeriodDays": 90,
   "forceLoginMethod": "claudeai",
   "permissions": {
-    "defaultMode": "acceptEdits",
+    "defaultMode": "plan",
     "allow": [
       "LS",
       "Read",


### PR DESCRIPTION
## Summary
- Changed Claude Code's defaultMode from "acceptEdits" to "plan" in settings.json
- Ensures Claude starts in plan mode by default, preventing unintended edits

## Context
The user reported that Claude Code was starting with auto-accept edits enabled instead of plan mode, despite believing they had changed the setting. Investigation revealed the settings.json file still had `"defaultMode": "acceptEdits"`.

## Changes
- Modified `.claude/settings.json` line 6 from `"acceptEdits"` to `"plan"`
- This change will propagate through the symlink created by setup.sh

## Test Plan
- [ ] Run `source setup.sh` to ensure symlink is current
- [ ] Start a new Claude Code session and verify it starts in plan mode
- [ ] Test that edits require explicit confirmation before execution