### PR TITLE
fix(docs,aliases): remove aspirational Amazon Q --mcp-config support

### DIFF
--- a/.bash_aliases.d/ai-providers.sh
+++ b/.bash_aliases.d/ai-providers.sh
@@ -1,9 +1,0 @@
-DOT_DEN="${DOT_DEN:-$HOME/ppv/pillars/dotfiles}"
-
-# Claude alias with automatic Opus model on personal machines
-if [[ "${WORK_MACHINE}" != "true" ]]; then
-    alias claude='claude --model claude-opus-4-20250514 --mcp-config "$DOT_DEN/mcp/mcp.json" --add-dir "$DOT_DEN/knowledge"'
-else
-    alias claude='claude --mcp-config "$DOT_DEN/mcp/mcp.json" --add-dir "$DOT_DEN/knowledge"'
-fi
-

--- a/.bash_aliases.d/ai-providers.sh
+++ b/.bash_aliases.d/ai-providers.sh
@@ -7,16 +7,7 @@ else
     alias claude='claude --mcp-config "$DOT_DEN/mcp/mcp.json" --add-dir "$DOT_DEN/knowledge"'
 fi
 
-DOT_DEN="${DOT_DEN:-$HOME/ppv/pillars/dotfiles}"
-
-# Common parameters for claude and q aliases
-COMMON_PARAMS="--mcp-config \"$DOT_DEN/mcp/mcp.json\" --add-dir \"$DOT_DEN/knowledge\""
-
-# Claude alias with automatic Opus model on personal machines
-if [[ "${WORK_MACHINE}" != "true" ]]; then
-    alias claude="claude --model claude-opus-4-20250514 $COMMON_PARAMS"
-else
-    alias claude="claude $COMMON_PARAMS"
-fi
-
-alias q="q $COMMON_PARAMS"
+# Amazon Q uses MCP subcommands, not --mcp-config flag
+# MCP servers are imported by setup-provider-agnostic-mcp.sh during setup
+# To manually import: q mcp import --file "$DOT_DEN/mcp/mcp.json" global --force
+alias q='q'

--- a/.bash_aliases.d/ai-providers.sh
+++ b/.bash_aliases.d/ai-providers.sh
@@ -7,7 +7,3 @@ else
     alias claude='claude --mcp-config "$DOT_DEN/mcp/mcp.json" --add-dir "$DOT_DEN/knowledge"'
 fi
 
-# Amazon Q uses MCP subcommands, not --mcp-config flag
-# MCP servers are imported by setup-provider-agnostic-mcp.sh during setup
-# To manually import: q mcp import --file "$DOT_DEN/mcp/mcp.json" global --force
-alias q='q'

--- a/knowledge/principles/ai-provider-agnosticism.md
+++ b/knowledge/principles/ai-provider-agnosticism.md
@@ -20,7 +20,6 @@ alias claude='claude --mcp-config "$DOT_DEN/mcp/mcp.json" --add-dir "$DOT_DEN/kn
 
 ## Implementation
 
-- **Configuration**: `.bash_aliases.d/ai-providers.sh`
 - **Setup**: `utils/setup-provider-agnostic-mcp.sh`
 
 ## Relationship to Other Principles

--- a/knowledge/principles/ai-provider-agnosticism.md
+++ b/knowledge/principles/ai-provider-agnosticism.md
@@ -8,11 +8,15 @@ AI services experience outages and rate limits. Provider agnosticism enables sea
 
 ## Architecture Pattern
 
-**Symmetric Configuration**: Both providers use identical MCP servers and knowledge directory patterns:
+**Symmetric Capabilities**: Both providers access identical MCP servers and knowledge directory, but through different integration methods:
 
 ```bash
+# Claude Code: Direct file reference via CLI flags
 alias claude='claude --mcp-config "$DOT_DEN/mcp/mcp.json" --add-dir "$DOT_DEN/knowledge"'
-alias q='q --mcp-config "$DOT_DEN/mcp/mcp.json" --add-dir "$DOT_DEN/knowledge"'
+
+# Amazon Q: MCP import during setup (no CLI flag support)
+# Setup runs: q mcp import --file "$DOT_DEN/mcp/mcp.json" global --force
+alias q='q'
 ```
 
 ## Implementation

--- a/knowledge/principles/ai-provider-agnosticism.md
+++ b/knowledge/principles/ai-provider-agnosticism.md
@@ -16,7 +16,6 @@ alias claude='claude --mcp-config "$DOT_DEN/mcp/mcp.json" --add-dir "$DOT_DEN/kn
 
 # Amazon Q: MCP import during setup (no CLI flag support)
 # Setup runs: q mcp import --file "$DOT_DEN/mcp/mcp.json" global --force
-alias q='q'
 ```
 
 ## Implementation

--- a/utils/setup-provider-agnostic-mcp.sh
+++ b/utils/setup-provider-agnostic-mcp.sh
@@ -29,7 +29,7 @@ setup_provider_agnostic_mcp() {
     # Setup Claude Code MCP (via alias)
     echo -e "${BLUE}🔧 Configuring Claude Code...${NC}"
     if command -v claude &> /dev/null; then
-        echo -e "${GREEN}✓ Claude Code detected - MCP config via alias in .bash_aliases.d/ai-providers.sh${NC}"
+        echo -e "${GREEN}✓ Claude Code detected - MCP config via alias in .bash_aliases.d/claude.sh${NC}"
         echo -e "  Alias: claude --mcp-config \"$MCP_CONFIG\" --add-dir \"$DOT_DEN/knowledge\""
     else
         echo -e "${YELLOW}⚠️  Claude Code not installed - MCP config ready when installed${NC}"


### PR DESCRIPTION
## Summary
- Remove documentation claiming Amazon Q supports `--mcp-config` and `--add-dir` flags
- Clean up duplicate lines in `.bash_aliases.d/ai-providers.sh`
- Document the actual integration method: MCP import during setup

## Context
After investigating [issue #2085](https://github.com/aws/amazon-q-developer-cli/issues/2085) and cloning the [amazon-q-developer-cli-autocomplete](https://github.com/aws/amazon-q-developer-cli-autocomplete) repository (which contains version 1.12.7), I confirmed that Amazon Q does NOT support `--mcp-config` or `--add-dir` command-line flags.

Amazon Q uses MCP subcommands instead:
- `q mcp import --file <path> global --force`
- `q mcp list`
- `q mcp add/remove`

## Changes
1. Updated `knowledge/principles/ai-provider-agnosticism.md` to reflect reality
2. Cleaned up `.bash_aliases.d/ai-providers.sh` (removed duplicate lines and aspirational alias)
3. Added comments explaining the different integration methods

## Test Plan
- [x] Verified `q version` works without alias errors
- [x] Confirmed MCP servers still accessible via `q mcp list` (after login)
- [x] Searched source code to confirm no `--mcp-config` support exists