### PR TITLE
fix(mcp): remove lingering GitLab MCP server references

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -38,7 +38,6 @@ Each MCP integration has its own setup method:
 - `setup-gdrive-mcp.sh` - Sets up Google Drive integration
 - `setup-github-mcp.sh` - Sets up GitHub integration from source
 - `setup-git-mcp.sh` - Sets up Git integration from source
-- `setup-gitlab-mcp.sh` - Sets up external GitLab integration
 
 For custom integrations, run the appropriate setup script:
 

--- a/mcp/setup-all-mcp-servers.sh
+++ b/mcp/setup-all-mcp-servers.sh
@@ -38,7 +38,6 @@ setup_scripts=(
     "setup-github-mcp.sh"
     "setup-git-mcp.sh"
     "setup-filesystem-mcp.sh"
-    "setup-gitlab-mcp.sh"
     "setup-brave-search-mcp.sh"
     # "setup-gdrive-mcp.sh"  # Commented out to improve setup time - run manually when needed
 )


### PR DESCRIPTION
## Summary
- Removed `setup-gitlab-mcp.sh` from the setup scripts array in `setup-all-mcp-servers.sh`
- Removed GitLab MCP server reference from `mcp/README.md`

## Why
The GitLab MCP server was previously removed, but references to its setup script remained, causing a warning message during `source setup.sh` execution.

## Test Plan
- [ ] Run `source setup.sh` and verify no "Warning: setup-gitlab-mcp.sh not found" message appears
- [ ] Verify all other MCP servers still set up correctly

Principle: subtraction-creates-value