### PR TITLE
fix(ci): add missing id-token permission to issue triage workflow

### DIFF
--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      id-token: write  # Required for OIDC authentication
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Description

This PR fixes the Dotfiles Issue Triage workflow by adding the missing `id-token: write` permission that is required for OIDC authentication.

## Problem

The workflow has been failing with the following error:
```
error: Error message: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
Failed to setup GitHub token: Error: Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
```

## Solution

Added the `id-token: write` permission to the workflow's permissions section:

```yaml
permissions:
  contents: read
  issues: write
  id-token: write  # Required for OIDC authentication
```

## Testing

The workflow will be tested automatically when new issues are created or edited after this PR is merged.

Closes #1047