### PR TITLE
fix(mcp): add missing pyproject.toml for git-mcp-server

### DIFF
--- a/mcp/servers/git-mcp-server/pyproject.toml
+++ b/mcp/servers/git-mcp-server/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "atxtechbro-git-mcp-server"
+version = "0.1.0"
+description = "Experimental Git MCP server for dotfiles integration"
+requires-python = ">=3.10"
+dependencies = [
+    "click>=8.1.7",
+    "gitpython>=3.1.43",
+    "mcp>=1.0.0",
+    "pydantic>=2.0.0",
+]
+
+[project.scripts]
+atxtechbro-git-mcp-server = "mcp_server_git:main"


### PR DESCRIPTION
## Description
This PR fixes the git MCP server failing to load after PR #1045 by adding the missing `pyproject.toml` file.

## Problem
After merging PR #1045, the git MCP server showed as "failed" in Claude Code because:
- The `pyproject.toml` file was missing
- The setup script couldn't create the `.venv` virtual environment
- Dependencies couldn't be installed

## Solution
Added the missing `pyproject.toml` with the required dependencies:
- `click>=8.1.7` - CLI framework
- `gitpython>=3.1.43` - Git operations
- `mcp>=1.0.0` - MCP protocol support
- `pydantic>=2.0.0` - Data validation

## Testing
✅ Ran `setup-git-mcp.sh` successfully
✅ Verified `.venv` directory was created
✅ Confirmed all dependencies were installed
✅ Git MCP server now loads without errors

## Related
Closes #1049