### PR TITLE
fix(setup): prevent circular symlink at commands/templates/templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ CLAUDE.local.md
 .claude/settings.local.json
 # Setup-generated symlinks (avoid duplicating tracked content)
 .claude/command-templates
+# Circular symlink that keeps appearing (issue #1057)
+commands/templates/templates
 
 # Private SSH keys
 id_rsa

--- a/setup.sh
+++ b/setup.sh
@@ -260,6 +260,13 @@ if [[ -d "$DOT_DEN/commands/templates" ]]; then
   mkdir -p "$DOT_DEN/.claude"
   ln -sf "../commands/templates" "$DOT_DEN/.claude/command-templates"
   echo -e "${GREEN}✓ Created symlink: .claude/command-templates → commands/templates${NC}"
+  
+  # Check for and remove circular symlink (issue #1057)
+  if [[ -L "$DOT_DEN/commands/templates/templates" ]]; then
+    echo -e "${YELLOW}Removing circular symlink: commands/templates/templates${NC}"
+    rm -f "$DOT_DEN/commands/templates/templates"
+    echo "  → Circular symlink removed (see issue #1057)"
+  fi
 fi
 
 # Set up vendor-agnostic MCP configuration

--- a/utils/check-circular-symlink.sh
+++ b/utils/check-circular-symlink.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# =========================================================
+# CIRCULAR SYMLINK DIAGNOSTIC TOOL
+# =========================================================
+# PURPOSE: Monitor for the circular symlink at commands/templates/templates
+# This helps track when and how it gets created (issue #1057)
+# =========================================================
+
+set -euo pipefail
+
+# Get the dotfiles directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOTFILES_DIR="$(dirname "$SCRIPT_DIR")"
+CIRCULAR_SYMLINK="$DOTFILES_DIR/commands/templates/templates"
+LOG_FILE="$HOME/circular-symlink-monitor.log"
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Function to log with timestamp
+log_event() {
+    local message="$1"
+    local timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+    echo "$timestamp: $message" >> "$LOG_FILE"
+}
+
+# Function to check for circular symlink
+check_symlink() {
+    if [[ -L "$CIRCULAR_SYMLINK" ]]; then
+        # It exists - log details
+        local target=$(readlink "$CIRCULAR_SYMLINK")
+        local details="Circular symlink FOUND: $CIRCULAR_SYMLINK -> $target"
+        echo -e "${RED}✗${NC} $details"
+        log_event "$details"
+        
+        # Log additional context
+        log_event "  Current directory: $(pwd)"
+        log_event "  Running user: $(whoami)"
+        log_event "  Parent process: $(ps -p $PPID -o comm=)"
+        
+        # Check if any Claude Code processes are running
+        if pgrep -f "claude" > /dev/null; then
+            log_event "  Claude Code process detected"
+        fi
+        
+        return 1
+    else
+        echo -e "${GREEN}✓${NC} No circular symlink found"
+        return 0
+    fi
+}
+
+# Function to monitor continuously
+monitor_mode() {
+    echo "Monitoring for circular symlink (press Ctrl+C to stop)..."
+    echo "Logging to: $LOG_FILE"
+    log_event "=== Monitor started ==="
+    
+    while true; do
+        if ! check_symlink; then
+            echo -e "${YELLOW}→ Detected at $(date '+%H:%M:%S')${NC}"
+        fi
+        sleep 5
+    done
+}
+
+# Main script
+case "${1:-check}" in
+    check)
+        echo "Checking for circular symlink..."
+        check_symlink
+        ;;
+    monitor)
+        monitor_mode
+        ;;
+    clean)
+        echo "Cleaning up circular symlink if it exists..."
+        if [[ -L "$CIRCULAR_SYMLINK" ]]; then
+            rm -f "$CIRCULAR_SYMLINK"
+            echo -e "${GREEN}✓${NC} Circular symlink removed"
+            log_event "Circular symlink manually removed"
+        else
+            echo "No circular symlink to clean"
+        fi
+        ;;
+    *)
+        echo "Usage: $0 [check|monitor|clean]"
+        echo "  check   - Check once for circular symlink (default)"
+        echo "  monitor - Monitor continuously every 5 seconds"
+        echo "  clean   - Remove circular symlink if it exists"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Description
This PR fixes the recurring circular symlink issue at `commands/templates/templates` that has been appearing across multiple work sessions.

## Problem
- A circular symlink keeps being created: `commands/templates/templates → ../templates`
- Requires manual cleanup before committing
- Clutters git status output

## Solution
1. **Prevention in setup.sh**: Added automatic detection and removal after creating the legitimate symlink
2. **Gitignore entry**: Added `commands/templates/templates` to prevent accidental commits
3. **Diagnostic tool**: Created `utils/check-circular-symlink.sh` for monitoring and cleanup

## Testing
- ✅ Created circular symlink manually
- ✅ Verified diagnostic tool detects it
- ✅ Confirmed setup.sh removes it automatically
- ✅ Tested diagnostic tool's clean command

## Diagnostic Tool Usage
```bash
# Check once
utils/check-circular-symlink.sh check

# Monitor continuously (logs to ~/circular-symlink-monitor.log)
utils/check-circular-symlink.sh monitor

# Clean up if found
utils/check-circular-symlink.sh clean
```

This provides both immediate protection and helps gather data to identify the root cause.

Closes #1057