### PR TITLE
feat(setup): integrate MCP dashboard startup into setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -278,6 +278,23 @@ else
   echo -e "${YELLOW}MCP server setup script not found. Skipping MCP server setup.${NC}"
 fi
 
+# MCP Dashboard setup
+echo -e "${DIVIDER}"
+echo "Setting up MCP Dashboard..."
+
+# Check if start-mcp-dashboard script exists
+if [[ -x "$DOT_DEN/bin/start-mcp-dashboard" ]]; then
+  # Use the start-mcp-dashboard script which handles all checks
+  "$DOT_DEN/bin/start-mcp-dashboard" start
+  # The script handles:
+  # - Checking if dashboard is already running
+  # - Verifying the binary exists
+  # - Starting with proper health checks
+  # - Displaying clear status messages
+else
+  echo -e "${YELLOW}start-mcp-dashboard script not found. Skipping dashboard setup.${NC}"
+fi
+
 # GitLab MCP authentication now handled by @zereight/mcp-gitlab package
 # No additional auth setup needed beyond GITLAB_PERSONAL_ACCESS_TOKEN in ~/.bash_secrets
 


### PR DESCRIPTION
## Problem & Solution
**Problem**: MCP dashboard needed to be started manually after setup. No automatic startup during environment initialization.
**Solution**: Integrated dashboard startup into setup.sh, leveraging the start-mcp-dashboard script for robust startup handling
**Keywords**: mcp dashboard startup, setup.sh integration, automatic dashboard start

## Related Issues
Closes #1059

## Technical Details
**Files changed**: 
- `setup.sh` - Added MCP Dashboard setup section

**Key modifications**: 
- Added dashboard startup section after MCP servers setup (line 281)
- Delegates all checks to the start-mcp-dashboard script
- Non-blocking implementation - setup continues if dashboard fails
- Clear status messages from the helper script

**Alternative approaches considered**: 
- Inline all the checks (too much duplication)
- systemd service (too complex for setup.sh)
- Silent startup (no feedback to user)

## Testing
```bash
# Test with dashboard already running
start-mcp-dashboard start
source setup.sh  # Should detect it's already running

# Test with dashboard not running
start-mcp-dashboard stop
source setup.sh  # Should start the dashboard

# Test with missing binary
mv mcp-dashboard-go/dashboard mcp-dashboard-go/dashboard.bak
source setup.sh  # Should show clear error message
mv mcp-dashboard-go/dashboard.bak mcp-dashboard-go/dashboard
```

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added/updated tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have updated the documentation accordingly (if applicable)