### PR TITLE
feat(mcp): add Playwright health check guidance to dashboard startup

### DIFF
--- a/bin/check-web-health
+++ b/bin/check-web-health
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# =============================================================================
+# Web Service Health Check Guide for Playwright
+# =============================================================================
+# PURPOSE: Guide for using Playwright MCP to verify web services
+# USAGE: Reference this guide when performing health checks in Claude Code
+# =============================================================================
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Get URL from argument
+URL="${1:-http://localhost:8080}"
+
+echo -e "${BLUE}=== Playwright Health Check Guide ===${NC}"
+echo ""
+echo -e "${GREEN}To perform a visual health check of $URL using Claude Code:${NC}"
+echo ""
+echo "1. Basic health check:"
+echo "   ${YELLOW}# Navigate to the service${NC}"
+echo "   Use the browser_navigate tool with url: \"$URL\""
+echo ""
+echo "   ${YELLOW}# Take a screenshot for confirmation${NC}"
+echo "   Use the browser_take_screenshot tool"
+echo ""
+echo "2. Advanced health check:"
+echo "   ${YELLOW}# Wait for specific content${NC}"
+echo "   Use browser_wait_for with text: \"MCP Dashboard\""
+echo ""
+echo "   ${YELLOW}# Check page structure${NC}"
+echo "   Use browser_snapshot to see the page content"
+echo ""
+echo "   ${YELLOW}# Check for console errors${NC}"
+echo "   Use browser_console_messages"
+echo ""
+echo "3. Save results:"
+echo "   ${YELLOW}# Take a full page screenshot${NC}"
+echo "   Use browser_take_screenshot with fullPage: true"
+echo ""
+echo -e "${BLUE}Benefits over curl:${NC}"
+echo "  • Visual confirmation of correct rendering"
+echo "  • JavaScript error detection"
+echo "  • Content verification"
+echo "  • Interactive debugging capability"
+echo ""
+echo -e "${GREEN}Try it now in Claude Code with the commands above!${NC}"

--- a/bin/start-mcp-dashboard
+++ b/bin/start-mcp-dashboard
@@ -5,6 +5,11 @@
 # =============================================================================
 # PURPOSE: Start, stop, restart, and check status of the MCP dashboard
 # USAGE: start-mcp-dashboard [start|stop|restart|status]
+# 
+# HEALTH CHECKS:
+# - Basic: Uses curl to verify dashboard is responding
+# - Enhanced: Use Claude Code with Playwright MCP for visual verification
+#   Run: bash bin/check-web-health <url> (from within Claude Code)
 # =============================================================================
 
 # Configuration
@@ -62,6 +67,13 @@ start_dashboard() {
             echo -e "${GREEN}✓ MCP Dashboard started successfully${NC}"
             echo -e "${BLUE}Dashboard URL: http://localhost:$DASHBOARD_PORT${NC}"
             echo -e "${BLUE}Log file: $DASHBOARD_LOG${NC}"
+            
+            # Suggest enhanced health check option
+            echo ""
+            echo -e "${YELLOW}Tip: For visual verification with Playwright:${NC}"
+            echo -e "  In Claude Code, run: bash bin/check-web-health http://localhost:$DASHBOARD_PORT"
+            echo -e "  Or use Playwright MCP tools directly to navigate and screenshot"
+            
             return 0
         fi
         sleep 1

--- a/examples/playwright-health-check-example.md
+++ b/examples/playwright-health-check-example.md
@@ -1,0 +1,54 @@
+# Playwright Health Check Example
+
+This example shows how to use Playwright MCP tools within Claude Code to perform comprehensive health checks on web services.
+
+## Basic Health Check
+
+When you want to verify a web service is running (e.g., the MCP dashboard), you can use these Playwright MCP commands:
+
+```bash
+# 1. Navigate to the service
+browser_navigate url: "http://localhost:8080"
+
+# 2. Take a screenshot for visual confirmation
+browser_take_screenshot filename: "dashboard-health-check.png"
+
+# 3. Check the page content
+browser_snapshot
+```
+
+## Advanced Health Check
+
+For more comprehensive checks, you can:
+
+```bash
+# 1. Navigate and wait for specific content
+browser_navigate url: "http://localhost:8080"
+browser_wait_for text: "MCP Dashboard"
+
+# 2. Verify specific elements exist
+browser_snapshot
+# Look for specific UI elements in the snapshot
+
+# 3. Take a full-page screenshot
+browser_take_screenshot fullPage: true filename: "dashboard-full.png"
+
+# 4. Check console for errors
+browser_console_messages
+```
+
+## Integration with start-mcp-dashboard
+
+After starting the dashboard with `start-mcp-dashboard start`, you can run these Playwright checks to visually confirm the dashboard is working correctly. This provides more confidence than a simple HTTP check.
+
+## Benefits over curl
+
+- Visual confirmation that the page renders correctly
+- Can detect JavaScript errors
+- Can verify specific content is present
+- Provides screenshots for debugging
+- Can interact with the page if needed
+
+## Usage in Scripts
+
+While these commands are designed for interactive use in Claude Code, you can document the expected health check procedure in your scripts, as shown in the `bin/check-web-health` script.


### PR DESCRIPTION
## Problem & Solution
**Problem**: Basic curl health check doesn't provide visual confirmation or detect rendering issues
**Solution**: Added Playwright MCP integration guidance while keeping curl for backward compatibility
**Keywords**: playwright health check, mcp dashboard verification, visual health check

## Related Issues
Closes #1060

## Technical Details
**Files changed**: 
- `bin/start-mcp-dashboard` - Added Playwright tip after successful startup
- `bin/check-web-health` - New guide script for Playwright health checks
- `examples/playwright-health-check-example.md` - Comprehensive examples

**Key modifications**: 
- Enhanced health check documentation in script header
- Added tip suggesting Playwright verification after curl success
- Created guide script showing how to use Playwright MCP tools
- Provided examples of basic and advanced health checks

**Alternative approaches considered**: 
- Direct Playwright integration (requires Node.js dependencies)
- Calling Claude Code from bash (not possible)
- Replacing curl entirely (breaks backward compatibility)

## Implementation Approach
This follows the snowball method by building on existing work:
- Enhances #1058 (start-mcp-dashboard script) with visual verification option
- Leverages #1059 (setup.sh integration) - tip appears automatically
- Maintains backward compatibility with curl
- Guides users toward more comprehensive health checks

## Testing
```bash
# Start the dashboard and see the new tip
start-mcp-dashboard start

# View the health check guide
bash bin/check-web-health http://localhost:8080

# In Claude Code, follow the guide to:
# 1. Navigate to the dashboard
# 2. Take screenshots
# 3. Check for errors
```

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added/updated tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have updated the documentation accordingly (if applicable)