### PR TITLE
fix(github-actions): remove unsupported 'edited' event from workflow

### DIFF
--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -2,7 +2,7 @@ name: Dotfiles Issue Triage
 description: Automatically triage GitHub issues using Claude Code
 on:
   issues:
-    types: [opened, edited]
+    types: [opened]
 
 jobs:
   triage-issue:


### PR DESCRIPTION
<!-- 
AUDIENCE: Future AI agents searching for solutions to similar problems
FORMAT: Use keywords, exact error messages, and technical details they'll search for
-->

## Problem & Solution
<!-- What problem does this solve? Include exact error messages and symptoms -->
**Problem**: The Dotfiles Issue Triage workflow fails when issues are edited with error: `Error: Unsupported issue action: edited`
**Solution**: Remove 'edited' from the workflow triggers since Claude Code Action doesn't support it
**Keywords**: Claude Code Action, Unsupported issue action, edited event, GitHub Actions workflow failure, auto-label-issues

## Related Issues
<!-- Link related issues: Fixes #issue_number, Closes #issue_number -->
Closes #1065

## Technical Details
<!-- Specific changes for AI discovery -->
**Files changed**: `.github/workflows/auto-label-issues.yml`
**Key modifications**: Changed `types: [opened, edited]` to `types: [opened]`
**Alternative approaches considered**: 
- Conditional execution (only run Claude Code step when action is 'opened')
- Wait for upstream fix in Claude Code Action

## Testing
<!-- How to verify this works -->
- Workflow will no longer trigger on issue edits
- Workflow continues to function normally when issues are opened
- No more "Unsupported issue action: edited" errors in workflow logs

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added/updated tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have updated the documentation accordingly (if applicable)

## Principle Applied
**subtraction-creates-value**: Removing the unsupported trigger eliminates the error entirely