### PR TITLE
docs(knowledge): add minimal MCP dashboard documentation

### DIFF
--- a/knowledge/tools/mcp-dashboard.md
+++ b/knowledge/tools/mcp-dashboard.md
@@ -1,0 +1,15 @@
+# MCP Dashboard
+
+Quick web UI for viewing MCP logs at http://localhost:8080
+
+## Start
+```bash
+start-mcp-dashboard start
+```
+
+Automatically starts during `source setup.sh` if Go is available.
+
+## Files
+- Dashboard: `mcp-dashboard-go/`
+- Helper: `bin/start-mcp-dashboard`
+- Logs: `~/mcp-errors.log`, `~/mcp-tool-calls.log`

--- a/knowledge/tools/mcp-dashboard.md
+++ b/knowledge/tools/mcp-dashboard.md
@@ -13,3 +13,7 @@ Automatically starts during `source setup.sh` if Go is available.
 - Dashboard: `mcp-dashboard-go/`
 - Helper: `bin/start-mcp-dashboard`
 - Logs: `~/mcp-errors.log`, `~/mcp-tool-calls.log`
+
+## Playwright Health Check Files
+- Guide: `bin/check-web-health`
+- Example: `examples/playwright-health-check-example.md`

--- a/knowledge/tools/mcp-dashboard.md
+++ b/knowledge/tools/mcp-dashboard.md
@@ -10,7 +10,8 @@ start-mcp-dashboard start
 Automatically starts during `source setup.sh` if Go is available.
 
 ## Files
-- Dashboard: `mcp-dashboard-go/`
+- Dashboard source: `mcp-dashboard-go/`
+- Dashboard binary: `mcp-dashboard-go/dashboard`
 - Helper: `bin/start-mcp-dashboard`
 - Logs: `~/mcp-errors.log`, `~/mcp-tool-calls.log`
 


### PR DESCRIPTION
## Summary
- Adds lightweight documentation for MCP dashboard in knowledge base
- Intentionally minimal to maintain malleability
- Closes #1061

## Test plan
- [x] Documentation is findable in `knowledge/tools/`
- [x] Instructions are clear and concise
- [x] Links to relevant files work