### PR TITLE
fix(dashboard): use embedded files instead of http.Dir

### DIFF
--- a/mcp-dashboard-go/cmd/server/main.go
+++ b/mcp-dashboard-go/cmd/server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"embed"
+	"io/fs"
 	"log"
 	"net/http"
 	"os"
@@ -46,8 +47,12 @@ func main() {
 		serveWS(hub, w, r)
 	})
 
-	// Serve static files from web directory
-	http.Handle("/", http.FileServer(http.Dir("cmd/server/web")))
+	// Serve static files from embedded web directory
+	webFS, err := fs.Sub(webContent, "web")
+	if err != nil {
+		log.Fatal("Failed to create sub filesystem: ", err)
+	}
+	http.Handle("/", http.FileServer(http.FS(webFS)))
 
 	// API endpoints
 	http.HandleFunc("/api/metrics", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- Fixed MCP dashboard 404 error by using embedded files
- Dashboard now serves static files from embedded `webContent` FS
- Works regardless of current working directory

## Test plan
- [x] Updated `main.go` to use `fs.Sub` and `http.FS`
- [x] Rebuilt dashboard binary
- [x] Tested with `source setup.sh` - dashboard starts successfully
- [x] Verified http://localhost:8080 returns 200 OK (was 404)
- [x] Used Playwright to verify dashboard loads properly

Closes #1070

## Notes
The fix was straightforward - the Go code already had `//go:embed all:web/*` but wasn't using it. Changed from `http.Dir("cmd/server/web")` to use the embedded filesystem.