### PR TITLE
feat(dashboard): improve UX - always show URL and move to end of setup

### DIFF
--- a/bin/start-mcp-dashboard
+++ b/bin/start-mcp-dashboard
@@ -51,6 +51,7 @@ is_running() {
 start_dashboard() {
     if is_running; then
         echo -e "${YELLOW}MCP Dashboard is already running (PID: $(get_dashboard_pid))${NC}"
+        echo -e "${BLUE}Dashboard URL: http://localhost:$DASHBOARD_PORT${NC}"
         return 0
     fi
     

--- a/setup.sh
+++ b/setup.sh
@@ -278,22 +278,6 @@ else
   echo -e "${YELLOW}MCP server setup script not found. Skipping MCP server setup.${NC}"
 fi
 
-# MCP Dashboard setup
-echo -e "${DIVIDER}"
-echo "Setting up MCP Dashboard..."
-
-# Check if start-mcp-dashboard script exists
-if [[ -x "$DOT_DEN/bin/start-mcp-dashboard" ]]; then
-  # Use the start-mcp-dashboard script which handles all checks
-  "$DOT_DEN/bin/start-mcp-dashboard" start
-  # The script handles:
-  # - Checking if dashboard is already running
-  # - Verifying the binary exists
-  # - Starting with proper health checks
-  # - Displaying clear status messages
-else
-  echo -e "${YELLOW}start-mcp-dashboard script not found. Skipping dashboard setup.${NC}"
-fi
 
 # GitLab MCP authentication now handled by @zereight/mcp-gitlab package
 # No additional auth setup needed beyond GITLAB_PERSONAL_ACCESS_TOKEN in ~/.bash_secrets
@@ -625,6 +609,23 @@ if [[ -f ~/.bash_aliases ]]; then
   # shellcheck disable=SC1090
   source ~/.bash_aliases
   echo -e "${GREEN}✓ Bash aliases loaded successfully${NC}"
+fi
+
+# MCP Dashboard setup
+echo -e "${DIVIDER}"
+echo "Setting up MCP Dashboard..."
+
+# Check if start-mcp-dashboard script exists
+if [[ -x "$DOT_DEN/bin/start-mcp-dashboard" ]]; then
+  # Use the start-mcp-dashboard script which handles all checks
+  "$DOT_DEN/bin/start-mcp-dashboard" start
+  # The script handles:
+  # - Checking if dashboard is already running
+  # - Verifying the binary exists
+  # - Starting with proper health checks
+  # - Displaying clear status messages
+else
+  echo -e "${YELLOW}start-mcp-dashboard script not found. Skipping dashboard setup.${NC}"
 fi
 
 echo -e "${DIVIDER}"


### PR DESCRIPTION
## Summary
- Always display dashboard URL when already running (not just PID)
- Move dashboard setup to end of setup.sh for better developer ergonomics
- Dashboard URL now appears at the bottom of setup output without scrolling

## Test plan
- [x] Updated `start-mcp-dashboard` to show URL when already running
- [x] Moved dashboard setup section from line 281 to line 614 (near end)
- [x] Tested `start-mcp-dashboard start` shows URL when already running
- [x] Verified dashboard setup is one of the last things in setup.sh

## Before
```
MCP Dashboard is already running (PID: 569630)
```

## After
```
MCP Dashboard is already running (PID: 569630)
Dashboard URL: http://localhost:8080
```

Closes #1073

## Notes
This improves developer experience by making the dashboard URL easily accessible without hunting for it in the setup output.