### PR TITLE
fix(mcp): correct update_secrets_template parameters in Brave Search setup

### DIFF
--- a/mcp/setup-brave-search-mcp.sh
+++ b/mcp/setup-brave-search-mcp.sh
@@ -17,11 +17,11 @@ NC='\033[0m' # No Color
 
 echo "Setting up Brave Search MCP server..."
 
+# Get repository root
+REPO_ROOT=$(get_repo_root)
+
 # Update the secrets template
-update_secrets_template "Brave Search" "
-# ==== BRAVE SEARCH API CREDENTIALS ====
-# Get API key from: https://api.search.brave.com/app/keys
-# export BRAVE_API_KEY=\"your_api_key\""
+update_secrets_template "$REPO_ROOT" "BRAVE_API_KEY" "BRAVE SEARCH API CREDENTIALS" "Get API key from: https://api.search.brave.com/app/keys" 'export BRAVE_API_KEY="your_api_key"'
 
 # Check for required secrets
 if [[ -z "$BRAVE_API_KEY" ]]; then


### PR DESCRIPTION
## Summary
- Fixed incorrect function call parameters in `setup-brave-search-mcp.sh`
- The `update_secrets_template` function requires 5 parameters but was only receiving 2
- This caused a path resolution error: `grep: Brave Search/.bash_secrets.example: No such file or directory`

## Changes
- Added proper repository root retrieval using `$(get_repo_root)`
- Passed all 5 required parameters to `update_secrets_template`:
  - `repo_root`: Repository root path
  - `var_name`: "BRAVE_API_KEY"
  - `section_title`: "BRAVE SEARCH API CREDENTIALS"
  - `comment`: API key instructions
  - `example`: Export statement example

## Test Plan
- [x] Run `./mcp/setup-brave-search-mcp.sh` - completes without errors
- [x] Run `source setup.sh` - Brave Search MCP setup succeeds
- [x] Verify no "No such file or directory" errors appear

Principle: tracer-bullets