### PR TITLE
fix(setup): remove unnecessary Docker hello-world test

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -587,14 +587,6 @@ if command -v docker &> /dev/null; then
   echo "Testing Docker access..."
   if docker info &>/dev/null; then
     echo -e "${GREEN}✓ Docker is working correctly${NC}"
-    # Only run hello-world if Docker is working - with robust error handling
-    echo "Running Docker hello-world test..."
-    if docker run --rm hello-world &>/dev/null; then
-      echo -e "${GREEN}✓ Docker hello-world test passed${NC}"
-    else
-      echo -e "${YELLOW}Docker hello-world test failed. You may need to restart your system.${NC}"
-      echo "This is not a critical error, continuing with setup..."
-    fi
   else
     echo -e "${YELLOW}Docker is installed but not accessible without sudo.${NC}"
     echo "Please log out and back in, or restart your system to apply group changes."


### PR DESCRIPTION
## Summary

Removes the `docker run --rm hello-world` test from setup.sh that adds no value but takes ~1 second to execute.

## Changes

- Removed 7 lines of Docker hello-world test code
- The `docker info` check above already verifies Docker is working properly

## Benefits

- ✅ Saves ~1 second on every setup run
- ✅ Removes unnecessary network/container operation
- ✅ Simplifies the script
- ✅ Follows the `subtraction-creates-value` principle

## Testing

Ran setup.sh locally and confirmed:
- Docker verification still works via `docker info`
- Setup completes successfully without the hello-world test
- ~1 second faster execution

Closes #1077