### PR TITLE
fix(config): move permission bypass from CLI flag to settings.json

### DIFF
--- a/.bash_aliases.d/claude.sh
+++ b/.bash_aliases.d/claude.sh
@@ -11,7 +11,7 @@ unset CLAUDE_CODE_USE_BEDROCK  # Disables Bedrock when unset (official variable)
 unset AWS_BEARER_TOKEN_BEDROCK  # Removes Bedrock API key if set (official variable)
 
 # Claude alias with MCP configuration
-alias claude='claude --dangerously-skip-permissions --mcp-config "$GLOBAL_MCP_CONFIG" --add-dir "$DOT_DEN/knowledge"'
+alias claude='claude --mcp-config "$GLOBAL_MCP_CONFIG" --add-dir "$DOT_DEN/knowledge"'
 
 # Quick test command (works on both work and personal)
 alias claude-test='claude -p "What is the capital of Texas?"'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,7 @@
   "forceLoginMethod": "claudeai",
   "includeCoAuthoredBy": false,
   "permissions": {
-    "defaultMode": "plan",
+    "defaultMode": "bypassPermissions",
     "allow": [
       "LS",
       "Read",


### PR DESCRIPTION
## Summary
This PR centralizes Claude Code permission bypass configuration by moving it from a CLI flag to the settings.json configuration file.

## Changes
- Changed `defaultMode` from `"plan"` to `"bypassPermissions"` in `.claude/settings.json`
- Removed `--dangerously-skip-permissions` flag from the claude alias in `.bash_aliases.d/claude.sh`

## Why
- Removes redundancy between CLI flags and settings configuration
- Makes configuration more maintainable and visible  
- Follows the principle of configuration over command-line flags
- Both approaches achieve the same result, but settings.json is cleaner

## Technical Notes
According to Anthropic's documentation, both `--dangerously-skip-permissions` (CLI flag) and `bypassPermissions` (settings mode) achieve the same result - they skip all permission prompts. This change consolidates the configuration in one place.

Closes #1084

**Principle applied**: `subtraction-creates-value` - removing redundancy and simplifying configuration