### PR TITLE
fix(claude): persist environment variables for claude command in new terminals

### DIFF
--- a/.bash_exports
+++ b/.bash_exports
@@ -10,6 +10,12 @@ export RUST_BACKTRACE=full
 : ${QTERM_SESSION_ID:=}
 : ${TTY:=$(tty 2>/dev/null || echo "")}
 
+# Dotfiles root directory (required for claude alias and other tools)
+export DOT_DEN="$HOME/ppv/pillars/dotfiles"
+
+# Global MCP configuration path (required for claude alias)
+export GLOBAL_MCP_CONFIG="$DOT_DEN/mcp/mcp.json"
+
 # Add MCP wrapper scripts to PATH for cross-machine portability
 export PATH="$PATH:$HOME/ppv/pillars/dotfiles/mcp"
 


### PR DESCRIPTION
## Git Statistics
1 file changed, 6 insertions(+)

## 🎯 What This Fixes

The `claude` command was throwing "command not found" in new terminal sessions because required environment variables weren't persisted. This fix ensures Claude Code CLI is immediately available without manual `source setup.sh`.

## 🔧 The Fix

Added two essential exports to `.bash_exports`:
- `DOT_DEN` - Points to dotfiles root directory
- `GLOBAL_MCP_CONFIG` - Points to MCP configuration file

These variables are required by the claude alias in `.bash_aliases.d/claude.sh`.

## ✅ Testing

After applying this fix:
1. Open a new terminal
2. Run `claude --version`
3. Command works immediately! 🎉

## 🌟 Impact

Better developer experience - Claude Code is ready to use in every new terminal, supporting our DevEx principle of keeping joy in the loop.

Closes #1105