### PR TITLE
fix: Add contents:write permission to Claude Code Assistant workflow

### DIFF
--- a/.github/workflows/claude-code-assistant.yml
+++ b/.github/workflows/claude-code-assistant.yml
@@ -13,7 +13,7 @@ on:
     types: [created]
 
 permissions:
-  contents: read
+  contents: write
   issues: write
   pull-requests: write
 


### PR DESCRIPTION
## Summary
Fixes permission issue preventing Claude Code Assistant from pushing branches and creating PRs.

## Problem
The workflow had `contents: read` permission, which prevented it from:
- Pushing branches to GitHub  
- Creating commits
- Automatically creating PRs

This was discovered in test issue #1117 where Claude successfully made changes but couldn't push them.

## Solution
Changed permission from `read` to `write`:
```yaml
permissions:
  contents: write      # ✅ Changed from 'read'
  issues: write
  pull-requests: write
```

## Testing
After merge, the workflow will be able to complete the full implementation flow:
1. Make file changes
2. Commit changes
3. Push to branch
4. Create PR automatically

## Related
- Closes #1118
- Test issue that revealed this: #1117
- Similar workflow `claude-issue-implementation.yml` already has correct permissions

Principle: systems-stewardship
Principle: eager-evolution