### PR TITLE
fix: Update triage prompt to acknowledge automatic comment

### DIFF
--- a/.github/workflow-prompts/issue-triage.md
+++ b/.github/workflow-prompts/issue-triage.md
@@ -1,6 +1,6 @@
 You're an issue triage assistant for GitHub issues. Your task is to analyze the issue and select appropriate labels from the provided list.
 
-IMPORTANT: Don't post any comments or messages to the issue. Your only action should be to apply labels.
+IMPORTANT: The GitHub Action will automatically post a progress comment ("Claude Code is working..."). Don't add any additional comments beyond applying labels. Focus solely on analyzing and labeling the issue.
 
 Issue Information:
 - REPO: {{ REPO }}
@@ -34,13 +34,13 @@ TASK OVERVIEW:
 
 5. Apply the selected labels:
    - Use mcp__github-write__update_issue to apply your selected labels
-   - DO NOT post any comments explaining your decision
+   - DO NOT post any additional comments explaining your decision (the action already posts one)
    - DO NOT communicate directly with users
    - If no labels are clearly applicable, do not apply any labels
 
 IMPORTANT GUIDELINES:
 - Be thorough in your analysis
 - Only select labels from the provided list
-- DO NOT post any comments to the issue
+- DO NOT post any additional comments (the action's automatic comment is sufficient)
 - Your ONLY action should be to apply labels using mcp__github-write__update_issue
 - Focus on principles over implementation details


### PR DESCRIPTION
## Git Statistics
```diff
+3 -3 (6 lines changed)
1 file modified
```

## 🎯 What This PR Does

Updates the issue triage prompt to be **transparent** about the automatic "Claude Code is working..." comment that the GitHub Action always posts, removing misleading instructions that suggested silent operation was possible.

### The Problem
Our prompt said "Don't post any comments" but the `anthropics/claude-code-action@beta` **always** posts a progress comment before executing our instructions. This created false expectations and confusion.

### The Fix
Changed three instances to acknowledge reality:
- ❌ "Don't post any comments" 
- ✅ "Don't add any additional comments (the action already posts one)"

## 📚 Context

This is a **known limitation** in the Claude Code Action: [anthropics/claude-code-action#198](https://github.com/anthropics/claude-code-action/issues/198)

The action doesn't support disabling the progress comment, so we're being transparent about what actually happens rather than pretending we have control we don't have.

## 🧪 Testing

The updated prompt will be used next time a new issue is created. The triage will still work exactly the same, but without the confusion of "why is there a comment when we said no comments?"

## Why This Matters

Aligns with our **transparency-in-agent-work** principle - being honest about system limitations builds trust and reduces confusion.

Small documentation fix but removes a persistent source of confusion.

Closes #1126

---
*Generated with Claude Code following tracer bullets methodology*