### PR TITLE
fix: Switch to base action for truly silent issue triage

### DIFF
--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -48,7 +48,7 @@ jobs:
           EOF
 
       - name: Run Claude Code for Issue Triage
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-base-action@beta
         with:
           direct_prompt: ${{ steps.prepare-prompt.outputs.prompt }}
           allowed_tools: "Bash(gh label list),mcp__github-write__get_issue,mcp__github-write__get_issue_comments,mcp__github-write__update_issue,mcp__github-write__search_issues,mcp__github-write__list_issues"


### PR DESCRIPTION
## Git Statistics
```diff
+1 -1 (2 lines changed)
1 file modified - single line change
```

## 🎯 What This PR Does

**One-line fix** that switches from `claude-code-action` to `claude-code-base-action` for truly silent issue triage.

### The Discovery
The official Claude Code repository uses `anthropics/claude-code-base-action@beta` for their triage, which is why they don't get the annoying "Claude Code is working..." comment. We were using the wrong action!

### The Fix
```yaml
# Before (posts comment)
uses: anthropics/claude-code-action@beta

# After (silent operation) 
uses: anthropics/claude-code-base-action@beta
```

## 🧪 Testing

After merge, create a test issue and verify:
- ✅ No automatic "Claude Code is working..." comment
- ✅ Labels still applied correctly
- ✅ Only github-actions[bot] in workflow logs

## 📚 Context

This is the **actual fix** for the issue we tried to work around in #1126 and #1127. Instead of updating docs to explain the comment, we can eliminate it entirely by using the right action.

The base action is designed for headless/automated operations without user interaction - perfect for silent triage.

## Why This Matters

**Subtraction Creates Value** - Removing unnecessary noise from every new issue makes the experience cleaner for users and reduces confusion.

Closes #1128

---
*Generated with Claude Code following tracer bullets methodology*