### PR TITLE
fix(workflows): one-line fix - change direct_prompt to prompt

### DIFF
--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Run Claude Code for Issue Triage
         uses: anthropics/claude-code-base-action@beta
         with:
-          direct_prompt: ${{ steps.prepare-prompt.outputs.prompt }}
+          prompt: ${{ steps.prepare-prompt.outputs.prompt }}
           allowed_tools: "Bash(gh label list),mcp__github-write__get_issue,mcp__github-write__get_issue_comments,mcp__github-write__update_issue,mcp__github-write__search_issues,mcp__github-write__list_issues"
           timeout_minutes: "5"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary
Minimal one-line fix for the triage workflow failure. The `claude-code-base-action` doesn't accept `direct_prompt` - it only accepts `prompt` or `prompt_file`.

## The Fix
Changed:
```yaml
direct_prompt: ${{ steps.prepare-prompt.outputs.prompt }}
```
to:
```yaml
prompt: ${{ steps.prepare-prompt.outputs.prompt }}
```

## Root Cause
The error was: `Error: Neither 'prompt' nor 'prompt_file' was provided. At least one is required.`

The base action has different parameter names than the regular action.

## Testing
After merge, create a test issue to verify triage works correctly.

Closes #1131

Principle: subtraction-creates-value