### PR TITLE
fix: simplify Claude workflow reactions to one per context

### DIFF
--- a/.github/workflows/claude-implementation.yml
+++ b/.github/workflows/claude-implementation.yml
@@ -37,27 +37,25 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             try {
-              // Add reactions to show Claude saw the request and is working on it
-              // 👀 = Claude saw the request
-              const eyesReaction = await github.rest.reactions.createForIssueComment({
+              // Add appropriate reaction based on context
+              let reaction;
+              
+              if (context.payload.issue && !context.payload.issue.pull_request) {
+                // 🚀 = Claude is implementing (for issues)
+                reaction = 'rocket';
+              } else {
+                // 👀 = Claude is reviewing (for PRs)
+                reaction = 'eyes';
+              }
+              
+              const reactionResponse = await github.rest.reactions.createForIssueComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 comment_id: context.payload.comment.id,
-                content: 'eyes'
+                content: reaction
               });
               
-              console.log(`✅ Successfully added 👀 reaction to comment ${context.payload.comment.id}`);
-              
-              // 🚀 = Claude is implementing (for issues only, not PR reviews)
-              if (context.payload.issue && !context.payload.issue.pull_request) {
-                const rocketReaction = await github.rest.reactions.createForIssueComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: context.payload.comment.id,
-                  content: 'rocket'
-                });
-                console.log(`✅ Successfully added 🚀 reaction to comment ${context.payload.comment.id}`);
-              }
+              console.log(`✅ Successfully added ${reaction} reaction to comment ${context.payload.comment.id}`);
             } catch (error) {
               console.error(`❌ Failed to add reaction: ${error.message}`);
               console.error(`Comment ID: ${context.payload.comment.id}`);


### PR DESCRIPTION
## Summary
Simplifies the Claude workflow to show only ONE reaction when @claude is mentioned, removing redundant visual clutter.

## Changes
- **Issues**: Shows 🚀 (rocket) to indicate Claude is implementing
- **PRs**: Shows 👀 (eyes) to indicate Claude is reviewing  
- Removed redundant double reactions for issues
- Cleaner, more maintainable code

## Before
Issues would show both 👀 AND 🚀 reactions (redundant)

## After  
- Issues: Only 🚀
- PRs: Only 👀

Clear visual distinction with minimal UI clutter.

## Testing
- Mention @claude in this PR to see 👀 reaction
- After merge, mention @claude in an issue to see 🚀 reaction

Closes #1135

Principle: subtraction-creates-value