### PR TITLE
feat: radicalize Claude GitHub Actions with full tool permissions

### DIFF
--- a/.github/workflows/claude-implementation.yml
+++ b/.github/workflows/claude-implementation.yml
@@ -75,3 +75,4 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_tools: "Bash(*),LS,Read,Write,Edit,MultiEdit,Glob,Grep,Task,TodoWrite,WebFetch(domain:*),WebSearch,mcp__git,mcp__github"


### PR DESCRIPTION
## Summary
Radicalizes Claude's GitHub Actions permissions to match local Claude's `bypassPermissions` intent, enabling true OSE with automatic PR creation.

## Changes
Added `allowed_tools` parameter to `claude-code-action` with full permissions:
```yaml
allowed_tools: "Bash(*),LS,Read,Write,Edit,MultiEdit,Glob,Grep,Task,TodoWrite,WebFetch(domain:*),WebSearch,mcp__git,mcp__github"
```

## Key Benefits
- **Automatic PR Creation**: No more manual "click here to create PR" step
- **True OSE**: Claude operates at manager level, not just branch creator
- **Consistency**: Same radical freedom as local Claude
- **Trust Extension**: We trust Claude locally, now we trust it in Actions

## Tools Now Available
- `mcp__github__create_pull_request` - Automatic PR creation ✨
- `mcp__git` - Full git operations
- `Bash(*)` - Any bash command
- All file operations
- Web tools for research

## Testing
After merge, mention @claude in an issue and verify:
1. Claude creates implementation
2. Claude automatically creates PR (no manual step)
3. Full workflow from issue → PR without human intervention

## Principles
- **OSE**: Outside and Slightly Elevated - manage, don't click
- **Throughput Definition**: AI agent management capability
- **Trust**: Extending local trust to CI/CD

Closes #1138