### PR TITLE
fix: Use PAT to enable workflow chaining for auto-trigger

### DIFF
--- a/.github/workflows/auto-trigger-claude.yml
+++ b/.github/workflows/auto-trigger-claude.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Auto-trigger Claude implementation
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.CLAUDE_TRIGGER_PAT }}
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,


### PR DESCRIPTION
## Summary
One-line fix to enable the complete automation chain by using PAT instead of GITHUB_TOKEN.

## The Problem
The auto-trigger workflow was commenting as github-actions[bot], which doesn't trigger other workflows (GitHub security feature to prevent loops).

## The Solution
Use `CLAUDE_TRIGGER_PAT` (already configured) to make comments appear from the user account, which WILL trigger claude-implementation.yml.

## Changes
```diff
- github-token: ${{ secrets.GITHUB_TOKEN }}
+ github-token: ${{ secrets.CLAUDE_TRIGGER_PAT }}
```

## Result
✅ Complete automation chain:
1. Issue created
2. Auto-trigger comments as USER (not bot)
3. Claude responds with 🚀
4. Claude implements and creates PR
5. Zero manual steps!

## Testing
After merge:
1. Create test issue
2. Verify comment appears from @atxtechbro (not github-actions[bot])
3. Verify Claude gets triggered
4. Verify PR gets created automatically

This completes the Ultimate OSE vision!

Closes #1146