### PR TITLE
fix: Force Claude to CREATE PRs automatically in auto-trigger workflow

### DIFF
--- a/.github/workflows/auto-trigger-claude.yml
+++ b/.github/workflows/auto-trigger-claude.yml
@@ -21,5 +21,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: '@claude Please implement this issue and create a PR.'
+              body: '@claude Please implement this issue and CREATE the pull request automatically.\n\nRemember:\n- CREATE the PR automatically using mcp__github__create_pull_request (not gh cli)\n- Do NOT just provide a link - actually create the PR\n- Do NOT approve the PR (only humans approve)\n\nThis is OSE automation - the PR must be created automatically.'
             });


### PR DESCRIPTION
## Summary
Updates the auto-trigger workflow to explicitly instruct Claude to CREATE pull requests automatically using `mcp__github__create_pull_request`, instead of just providing "Create PR ➔" links.

## Problem
Claude was interpreting the vague instruction "create a PR" as "provide a link to create a PR" rather than actually creating one. This required manual intervention, breaking the Ultimate OSE automation goal.

## Solution
Changed the auto-trigger message from:
```
@claude Please implement this issue and create a PR.
```

To explicit instructions:
```
@claude Please implement this issue and CREATE the pull request automatically.

Remember:
- CREATE the PR automatically using mcp__github__create_pull_request (not gh cli)
- Do NOT just provide a link - actually create the PR
- Do NOT approve the PR (only humans approve)

This is OSE automation - the PR must be created automatically.
```

## Evidence
- **Issue #1141**: When given explicit instructions, Claude successfully created PR #1142
- **Issue #1148 & #1150**: With vague instructions, Claude only provided links

## Testing
After merging, create a test issue to verify Claude actually creates PRs automatically.

Closes #1151

## Principles
- **ose**: Ultimate automation with proper security boundaries
- **subtraction-creates-value**: Remove manual PR creation step