### PR TITLE
Fix missing GitHub MCP tools in Claude Implementation workflow

### DIFF
--- a/.github/workflows/claude-implementation.yml
+++ b/.github/workflows/claude-implementation.yml
@@ -73,4 +73,4 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          allowed_tools: "Bash(*),LS,Read,Write,Edit,MultiEdit,Glob,Grep,Task,TodoWrite,WebFetch(domain:*),WebSearch,mcp__git,mcp__github"
+          allowed_tools: "Bash(*),LS,Read,Write,Edit,MultiEdit,Glob,Grep,Task,TodoWrite,WebFetch(domain:*),WebSearch,mcp__git,mcp__github,mcp__github__create_pull_request,mcp__github__get_issue,mcp__github__add_issue_comment,mcp__github__update_issue,mcp__github__search_issues,mcp__github__list_pull_requests,mcp__github__merge_pull_request"


### PR DESCRIPTION
## Summary
Enable specific GitHub MCP tools in the Claude Implementation workflow to allow automated PR creation and other GitHub operations.

## Problem
Claude was unable to create pull requests automatically when requested because the `mcp__github__create_pull_request` tool wasn't explicitly allowed in the workflow configuration.

## Solution
Updated `allowed_tools` in `.github/workflows/claude-implementation.yml` to include:
- `mcp__github__create_pull_request` - for creating PRs
- `mcp__github__get_issue` - for reading issue details  
- `mcp__github__add_issue_comment` - for commenting on issues
- `mcp__github__update_issue` - for updating issue status
- `mcp__github__search_issues` - for searching related issues
- `mcp__github__list_pull_requests` - for checking existing PRs
- `mcp__github__merge_pull_request` - for merging PRs

## Testing
After merging, test by creating a new issue and asking Claude to implement it with automatic PR creation.

## Related
- Fixes #1158
- Related to #1157 (where the issue was discovered)

## Principles
- `systems-stewardship`: Maintaining GitHub Actions workflows for reliable automation
- `ose`: Enabling elevated automation without manual intervention