### PR TITLE
Fix auto-trigger to explicitly request PR creation without tool specification

### DIFF
--- a/.github/workflows/auto-trigger-claude.yml
+++ b/.github/workflows/auto-trigger-claude.yml
@@ -21,5 +21,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: '@claude Please implement this issue. The pull request will be created automatically after you complete the implementation.'
+              body: '@claude Please implement this issue and CREATE the pull request (not just a link).\n\nUse the PR template when creating the pull request.'
             });


### PR DESCRIPTION
## Summary
Updates auto-trigger workflow to explicitly tell Claude to CREATE the PR (not just provide a link) without specifying which tool to use.

## Problem
The previous simplified message might lead Claude to just provide a PR creation link instead of actually creating the PR.

## Solution
- Explicitly tell Claude to "CREATE the pull request (not just a link)"
- Don't specify which tool to use (no mcp__github__create_pull_request)
- Add instruction to use the PR template for consistency

This gives Claude flexibility to use whatever PR creation method is available while ensuring a PR actually gets created.

## Testing
After merging, the test issue #1162 should result in Claude actually creating a PR, not just providing a link.

## Related
- Continues the work from #1160 and #1161
- Addresses the concern that Claude might just provide a link instead of creating a PR