### PR TITLE
fix(workflows): Enable Claude to modify workflow files

### DIFF
--- a/.github/actions/auto-trigger-claude/README.md
+++ b/.github/actions/auto-trigger-claude/README.md
@@ -1,0 +1,147 @@
+# Auto Trigger Claude Action
+
+A reusable composite GitHub Action that automatically triggers Claude to implement issues when they're created. This action is designed to be used across multiple repositories without duplication.
+
+## Features
+
+- ✅ **User Authorization**: Only allows specified users to trigger Claude
+- 🔧 **Configurable**: Customize PR templates, messages, and allowed users per repository
+- 🔒 **Secure**: Requires explicit token passing, no hardcoded secrets
+- 📦 **Reusable**: Use across all your repositories without copying workflow files
+
+## Usage
+
+### Basic Usage (in your repository)
+
+Create `.github/workflows/auto-trigger-claude.yml` in your repository:
+
+```yaml
+name: Auto-Trigger Claude
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  auto-trigger-claude:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    
+    steps:
+      - name: Auto-trigger Claude
+        uses: atxtechbro/dotfiles/.github/actions/auto-trigger-claude@main
+        with:
+          github-token: ${{ secrets.CLAUDE_TRIGGER_PAT }}
+          allowed-users: 'atxtechbro'  # Your GitHub username
+```
+
+### Advanced Usage
+
+```yaml
+- name: Auto-trigger Claude
+  uses: atxtechbro/dotfiles/.github/actions/auto-trigger-claude@main
+  with:
+    github-token: ${{ secrets.CLAUDE_TRIGGER_PAT }}
+    allowed-users: 'atxtechbro,trusted-contributor,another-user'
+    pr-template-url: 'https://github.com/myorg/myrepo/blob/main/.github/PULL_REQUEST_TEMPLATE.md'
+    custom-message: |
+      Additional context for this repository:
+      - Follow our coding standards at /docs/standards.md
+      - Run tests with `npm test` before creating PR
+```
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `github-token` | GitHub token with permissions to comment on issues | Yes | - |
+| `allowed-users` | Comma-separated list of GitHub usernames allowed to trigger Claude | No | `atxtechbro` |
+| `pr-template-url` | URL to the PR template Claude should use | No | Auto-detects from repository |
+| `custom-message` | Custom message to append to the Claude trigger comment | No | Empty |
+| `issue-number` | Issue number to comment on | No | Current issue |
+| `repository` | Repository in owner/repo format | No | Current repository |
+
+## Required Secrets
+
+Each repository using this action needs to configure:
+
+1. **`CLAUDE_TRIGGER_PAT`**: A GitHub Personal Access Token with `issues:write` permission
+   - Go to GitHub Settings → Developer settings → Personal access tokens
+   - Create a token with `repo` scope
+   - Add it to your repository secrets
+
+2. **`CLAUDE_CODE_OAUTH_TOKEN`**: Required if using claude-implementation workflow
+   - Obtained from Claude Code setup
+   - Add to repository secrets for Claude to create PRs
+
+## Security
+
+- **User Authorization**: Only users listed in `allowed-users` can trigger Claude
+- **No Hardcoded Secrets**: All tokens must be explicitly passed from the calling workflow
+- **Graceful Failures**: Unauthorized attempts exit gracefully without errors
+
+## Examples
+
+### Multiple Authorized Users
+
+```yaml
+- uses: atxtechbro/dotfiles/.github/actions/auto-trigger-claude@main
+  with:
+    github-token: ${{ secrets.CLAUDE_TRIGGER_PAT }}
+    allowed-users: 'atxtechbro,teammate1,teammate2'
+```
+
+### Custom PR Template per Repository
+
+```yaml
+- uses: atxtechbro/dotfiles/.github/actions/auto-trigger-claude@main
+  with:
+    github-token: ${{ secrets.CLAUDE_TRIGGER_PAT }}
+    pr-template-url: 'https://github.com/myorg/templates/blob/main/PR_TEMPLATE.md'
+```
+
+### With Repository-Specific Instructions
+
+```yaml
+- uses: atxtechbro/dotfiles/.github/actions/auto-trigger-claude@main
+  with:
+    github-token: ${{ secrets.CLAUDE_TRIGGER_PAT }}
+    custom-message: |
+      This is a Python repository. Please:
+      - Use Black for formatting
+      - Include type hints
+      - Add unit tests for new functions
+```
+
+## Versioning
+
+For stability, you can pin to a specific commit or tag:
+
+```yaml
+# Pin to specific commit
+uses: atxtechbro/dotfiles/.github/actions/auto-trigger-claude@38c7caa
+
+# Pin to tag (when available)
+uses: atxtechbro/dotfiles/.github/actions/auto-trigger-claude@v1.0.0
+
+# Always use latest from main branch
+uses: atxtechbro/dotfiles/.github/actions/auto-trigger-claude@main
+```
+
+## Troubleshooting
+
+### Claude not triggering
+
+1. Check that the user creating the issue is in `allowed-users`
+2. Verify `CLAUDE_TRIGGER_PAT` secret is set in repository settings
+3. Check workflow runs for authorization messages
+
+### Permission errors
+
+Ensure your PAT has the required scopes:
+- `repo` (full control of private repositories)
+- Or at minimum: `public_repo` and `issues` for public repositories
+
+## License
+
+Part of the atxtechbro/dotfiles repository. See repository license for details.

--- a/.github/actions/auto-trigger-claude/action.yml
+++ b/.github/actions/auto-trigger-claude/action.yml
@@ -1,0 +1,100 @@
+name: 'Auto Trigger Claude'
+description: 'Automatically trigger Claude to implement issues across repositories'
+author: 'atxtechbro'
+
+inputs:
+  github-token:
+    description: 'GitHub token with permissions to comment on issues (typically secrets.CLAUDE_TRIGGER_PAT)'
+    required: true
+  allowed-users:
+    description: 'Comma-separated list of GitHub usernames allowed to trigger Claude (e.g., "atxtechbro,trusted-user")'
+    required: false
+    default: 'atxtechbro'
+  pr-template-url:
+    description: 'URL to the PR template Claude should use'
+    required: false
+    default: 'https://github.com/${{ github.repository }}/blob/main/.github/PULL_REQUEST_TEMPLATE.md'
+  custom-message:
+    description: 'Custom message to append to the Claude trigger comment'
+    required: false
+    default: ''
+  issue-number:
+    description: 'Issue number to comment on (defaults to current issue)'
+    required: false
+    default: '${{ github.event.issue.number }}'
+  repository:
+    description: 'Repository in owner/repo format (defaults to current repository)'
+    required: false
+    default: '${{ github.repository }}'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Check user authorization
+      shell: bash
+      run: |
+        # Convert comma-separated list to array
+        IFS=',' read -ra ALLOWED_USERS <<< "${{ inputs.allowed-users }}"
+        
+        # Check if current user is in allowed list
+        USER_ALLOWED=false
+        for user in "${ALLOWED_USERS[@]}"; do
+          # Trim whitespace
+          user=$(echo "$user" | xargs)
+          if [ "$user" == "${{ github.event.issue.user.login }}" ]; then
+            USER_ALLOWED=true
+            break
+          fi
+        done
+        
+        if [ "$USER_ALLOWED" != "true" ]; then
+          echo "❌ User ${{ github.event.issue.user.login }} is not authorized to trigger Claude"
+          echo "Authorized users: ${{ inputs.allowed-users }}"
+          exit 0  # Exit gracefully without error
+        fi
+        
+        echo "✅ User ${{ github.event.issue.user.login }} is authorized to trigger Claude"
+
+    - name: Auto-trigger Claude implementation
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          // Parse repository input
+          const [owner, repo] = '${{ inputs.repository }}'.split('/');
+          
+          // Build the comment body
+          let commentBody = `@claude Please implement this issue and CREATE AN ACTUAL PULL REQUEST on GitHub.
+
+          **IMPORTANT**: You MUST create a real PR on GitHub (not just provide a link to create one). The PR must be created and visible at github.com/${owner}/${repo}/pulls.`;
+          
+          // Add PR template reference if provided
+          const prTemplateUrl = '${{ inputs.pr-template-url }}';
+          if (prTemplateUrl && prTemplateUrl !== '') {
+            commentBody += `\n\nUse the PR template from ${prTemplateUrl} when creating the pull request.`;
+          }
+          
+          // Add custom message if provided
+          const customMessage = `${{ inputs.custom-message }}`;
+          if (customMessage && customMessage !== '') {
+            commentBody += `\n\n${customMessage}`;
+          }
+          
+          // Create the comment
+          try {
+            await github.rest.issues.createComment({
+              owner: owner,
+              repo: repo,
+              issue_number: parseInt('${{ inputs.issue-number }}'),
+              body: commentBody
+            });
+            
+            console.log(`✅ Successfully triggered Claude for issue #${{ inputs.issue-number }} in ${owner}/${repo}`);
+          } catch (error) {
+            console.error(`❌ Failed to trigger Claude: ${error.message}`);
+            throw error;
+          }
+
+branding:
+  icon: 'message-circle'
+  color: 'purple'

--- a/.github/workflows/auto-trigger-claude.yml
+++ b/.github/workflows/auto-trigger-claude.yml
@@ -12,14 +12,12 @@ jobs:
       issues: write
 
     steps:
+      - name: Checkout repository (for composite action)
+        uses: actions/checkout@v4
+        
       - name: Auto-trigger Claude implementation
-        uses: actions/github-script@v7
+        uses: ./.github/actions/auto-trigger-claude
         with:
           github-token: ${{ secrets.CLAUDE_TRIGGER_PAT }}
-          script: |
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: '@claude Please implement this issue and CREATE AN ACTUAL PULL REQUEST on GitHub.\n\n**IMPORTANT**: You MUST create a real PR on GitHub (not just provide a link to create one). The PR must be created and visible at github.com/atxtechbro/dotfiles/pulls.\n\nUse the PR template from https://github.com/atxtechbro/dotfiles/blob/main/.github/PULL_REQUEST_TEMPLATE.md when creating the pull request.'
-            });
+          allowed-users: 'atxtechbro'
+          pr-template-url: 'https://github.com/atxtechbro/dotfiles/blob/main/.github/PULL_REQUEST_TEMPLATE.md'

--- a/.github/workflows/claude-implementation.yml
+++ b/.github/workflows/claude-implementation.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   claude-assistant:
-    if: contains(github.event.comment.body, '@claude')
+    if: contains(github.event.comment.body, '@claude') && github.event.comment.user.login == 'atxtechbro'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/claude-implementation.yml
+++ b/.github/workflows/claude-implementation.yml
@@ -24,6 +24,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  workflows: write    # Required for modifying workflow files
 
 jobs:
   claude-assistant:
@@ -67,7 +68,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use PAT instead of GITHUB_TOKEN to allow workflow modifications
+          # PAT needs 'repo' and 'workflow' scopes
+          token: ${{ secrets.CLAUDE_TRIGGER_PAT }}
 
       - uses: anthropics/claude-code-action@beta
         with:


### PR DESCRIPTION
## Summary
Fixes Claude's inability to modify GitHub Actions workflow files by implementing the PAT workaround.

## Problem Solved
Claude was getting this error when trying to modify `.github/workflows/*.yml` files:
```
refusing to allow a GitHub App to create or update workflow .github/workflows/auto-trigger-claude.yml without workflows permission
```

## Solution
Since we can't modify Anthropic's GitHub App permissions, this PR implements the PAT workaround:

1. **Added `workflows: write` permission** to the workflow
2. **Switched to PAT for checkout** instead of GITHUB_TOKEN
3. **Added clear comments** explaining why PAT is needed

## Changes
- Modified `.github/workflows/claude-implementation.yml`:
  - Added `workflows: write` to permissions block
  - Changed checkout to use `${{ secrets.CLAUDE_TRIGGER_PAT }}`
  - Added explanatory comments

## Required Configuration
For this to work, `CLAUDE_TRIGGER_PAT` must have:
- `repo` scope (full repository access)
- `workflow` scope (modify workflow files)

## Test Plan
- [ ] Claude can successfully create PRs that modify workflow files
- [ ] No more "refusing to allow" errors
- [ ] Existing functionality still works

Closes #1168