### PR TITLE
fix: use PAT for workflow modifications

### DIFF
--- a/.github/workflows/claude-implementation.yml
+++ b/.github/workflows/claude-implementation.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.CLAUDE_TRIGGER_PAT }}
 
       - uses: anthropics/claude-code-action@beta
         with:


### PR DESCRIPTION
Single line change: `GITHUB_TOKEN` → `CLAUDE_TRIGGER_PAT`

Enables Claude to modify workflow files using PAT with workflow scope.

Closes #1168