### PR TITLE
Revert "fix: use PAT for workflow modifications"

### DIFF
--- a/.github/workflows/claude-implementation.yml
+++ b/.github/workflows/claude-implementation.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.CLAUDE_TRIGGER_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: anthropics/claude-code-action@beta
         with:


### PR DESCRIPTION
## Summary
Reverting PR #1174 as testing proved it doesn't solve the workflow modification issue.

## What Happened
- Changed checkout to use CLAUDE_TRIGGER_PAT instead of GITHUB_TOKEN
- Claude still got the same error when trying to modify workflow files
- The issue is that `anthropics/claude-code-action@beta` uses its own git operations

## Root Cause
The claude-code-action uses internal git operations that don't inherit the PAT from the checkout step. It needs the GitHub App itself to have workflows permission, which must be granted by Anthropic.

## Next Steps
This is a limitation of the claude-code-action that cannot be fixed with workflow configuration. Options:
1. Accept that Claude can't modify workflow files
2. Wait for Anthropic to add workflows permission to their GitHub App
3. Use a different automation approach for workflow modifications

Related to #1168