### PR TITLE
fix: add workflows permission to claude-implementation

### DIFF
--- a/.github/workflows/claude-implementation.yml
+++ b/.github/workflows/claude-implementation.yml
@@ -24,6 +24,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  workflows: write  # Required for modifying workflow files
 
 jobs:
   claude-assistant:


### PR DESCRIPTION
## Summary
- Add `workflows: write` permission to the claude-implementation.yml workflow
- This allows GITHUB_TOKEN to modify workflow files when Claude is triggered

## Context
Testing in #1175 showed that using PAT in checkout doesn't solve the issue because anthropics/claude-code-action@beta uses its own internal git operations. Adding the workflows permission directly to the permissions block is a simpler approach.

## Test Plan
1. Merge this PR
2. Create a test issue asking Claude to modify a workflow file
3. Verify Claude can successfully create a PR with workflow changes

Closes #1168