### PR TITLE
Revert "fix: add workflows permission to claude-implementation"

### DIFF
--- a/.github/workflows/claude-implementation.yml
+++ b/.github/workflows/claude-implementation.yml
@@ -24,7 +24,6 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
-  workflows: write  # Required for modifying workflow files
 
 jobs:
   claude-assistant:


### PR DESCRIPTION
## Summary
Reverting PR #1177 as testing showed that adding `workflows: write` permission doesn't solve the issue.

## Context
Testing in issue #1178 confirmed that even with the workflows permission added to GITHUB_TOKEN, Claude still cannot modify workflow files. The anthropics/claude-code-action@beta uses its own internal git operations that don't inherit permissions from GITHUB_TOKEN. The GitHub App itself needs the workflows permission, which must be granted by Anthropic.

## Changes
- Remove the unnecessary `workflows: write` permission from claude-implementation.yml

## Detailed Findings
See #1168 for complete test results and analysis of why this permission doesn't help.

Reverts #1177
Supersedes #1179 (was closed)