### PR TITLE
test(procedures): verify shared template works with /close-issue command

### DIFF
--- a/knowledge/procedures/git-workflow.md
+++ b/knowledge/procedures/git-workflow.md
@@ -8,3 +8,5 @@ Use MCP git tools, follow conventional commits, and maintain branch hygiene to p
 - Conventional commits: `type[scope]: description`
 - Never work on main - always branch first
 **Details**: See [git-workflow-detailed.md](/docs/procedures/git-workflow-detailed.md)
+
+<!-- Test: /close-issue with shared template verified on 2025-08-04 -->


### PR DESCRIPTION
## Test PR for Shared Template Verification 🧪

This PR tests that the `/close-issue` command works correctly with the new shared template structure introduced in PR #1185.

### What Changed
- Added test comment to `knowledge/procedures/git-workflow.md`
- Verified the shared template at `.github/workflow-prompts/issue-implementation.md` is properly injected

### Success Criteria ✅
- [x] `/close-issue` command successfully loaded shared template
- [x] All INJECT patterns worked correctly
- [x] Worktree workflow followed properly
- [x] Conventional commits with principle trailers used
- [x] PR created with proper references

### Test Results
The `/close-issue 1186` command successfully:
1. Injected the universal template from `../../.github/workflow-prompts/issue-implementation.md`
2. Included all required context (tracer-bullets, close-issue-procedure, eager-evolution)
3. Replaced all placeholders correctly (`{{ ISSUE_NUMBER }}` → 1186)
4. Followed established workflows and procedures

### Verification
This proves that both workflows can share the same implementation instructions:
- **Local `/close-issue`**: Uses relative path injection with preloaded knowledge
- **GitHub Actions `@claude`**: Will use the same template with runtime knowledge injection

Closes #1186

## Principles Applied
- **tracer-bullets**: Target-first development with iterative feedback
- **systems-stewardship**: Single source of truth for implementation instructions