### PR TITLE
fix(workflows): use file-based replacement for ~72k knowledge injection

### DIFF
--- a/.github/workflows/claude-implementation.yml
+++ b/.github/workflows/claude-implementation.yml
@@ -101,25 +101,51 @@ jobs:
             ISSUE_TITLE="${{ github.event.issue.title }}"
             ISSUE_BODY="${{ github.event.issue.body }}"
             
-            # Load the procedure (which IS the implementation)
-            TEMPLATE=$(cat knowledge/procedures/close-issue-procedure.md)
+            # Write knowledge to temp file (already safely in GITHUB_OUTPUT)
+            cat <<'KNOWLEDGE_EOF' > /tmp/knowledge.txt
+          ${{ steps.knowledge.outputs.content }}
+          KNOWLEDGE_EOF
             
-            # Replace placeholders
-            PROMPT="${TEMPLATE//\{\{ KNOWLEDGE_BASE \}\}/${{ steps.knowledge.outputs.content }}}"
+            # Load the template
+            TEMPLATE_FILE="knowledge/procedures/close-issue-procedure.md"
+            
+            # Use awk to safely replace the KNOWLEDGE_BASE placeholder with file content
+            awk '
+              /\{\{ KNOWLEDGE_BASE \}\}/ {
+                while ((getline line < "/tmp/knowledge.txt") > 0) {
+                  print line
+                }
+                close("/tmp/knowledge.txt")
+                next
+              }
+              {print}
+            ' "$TEMPLATE_FILE" > /tmp/prompt_with_knowledge.md
+            
+            # Now do simple replacements on the result
+            PROMPT=$(cat /tmp/prompt_with_knowledge.md)
             PROMPT="${PROMPT//\{\{ ISSUE_NUMBER \}\}/$ISSUE_NUMBER}"
             PROMPT="${PROMPT//\{\{ ISSUE_TITLE \}\}/$ISSUE_TITLE}"
             PROMPT="${PROMPT//\{\{ ISSUE_BODY \}\}/$ISSUE_BODY}"
             PROMPT="${PROMPT//\{\{ REPO \}\}/${{ github.repository }}}"
           else
             echo "Preparing prompt for PR review..."
-            # For PR reviews, use the comment directly with knowledge context
-            PROMPT="${{ steps.knowledge.outputs.content }}
+            # For PR reviews, write knowledge to temp file then concatenate
+            cat <<'KNOWLEDGE_EOF' > /tmp/knowledge.txt
+          ${{ steps.knowledge.outputs.content }}
+          KNOWLEDGE_EOF
             
-            ## PR Review Request
+            # Build the PR review prompt
+            {
+              cat /tmp/knowledge.txt
+              echo ""
+              echo "## PR Review Request"
+              echo ""
+              echo "The user has requested: ${{ github.event.comment.body }}"
+              echo ""
+              echo "Please review and respond to this pull request comment with the full context of the codebase principles and procedures available above."
+            } > /tmp/pr_prompt.md
             
-            The user has requested: ${{ github.event.comment.body }}
-            
-            Please review and respond to this pull request comment with the full context of the codebase principles and procedures available above."
+            PROMPT=$(cat /tmp/pr_prompt.md)
           fi
           
           # Output the prompt


### PR DESCRIPTION
## Summary
Fixes the GitHub Actions workflow failure when injecting ~72k character knowledge base content.

## Problem
- Bash string replacement (`${VAR//pattern/replacement}`) breaks with large multi-line content containing special characters
- Workflow was failing at "Prepare implementation prompt" step when trying to inject the full knowledge base
- Error: `/home/runner/work/_temp/11111.sh: line 108: bad substitution`

## Solution
Replace unsafe bash string replacement with file-based approach using awk:
1. Write knowledge content to temp file using heredoc
2. Use awk to safely replace `{{ KNOWLEDGE_BASE }}` placeholder by reading from file
3. Handle other simple replacements (`ISSUE_NUMBER`, etc.) separately on the result

## Changes
- Updated `.github/workflows/claude-implementation.yml` to use awk-based replacement
- Applied same pattern to both issue implementation and PR review prompts
- No changes to the knowledge aggregation itself (still ~72k characters)

## Testing
- The awk approach handles special characters, quotes, and newlines correctly
- Simple test case verified locally showing the replacement works
- This unblocks test issue #1188 which will verify the full knowledge injection

Closes #1189

Principle: tracer-bullets
Principle: systems-stewardship