### PR TITLE
fix(workflows): use prompt_file to handle 72k knowledge base

### DIFF
--- a/.github/workflows/claude-implementation.yml
+++ b/.github/workflows/claude-implementation.yml
@@ -96,19 +96,27 @@ jobs:
           if [ "$IS_ISSUE" == "true" ]; then
             echo "Preparing prompt for issue implementation..."
             
-            # Get issue details
+            # Get issue number (safe - just a number)
             ISSUE_NUMBER="${{ github.event.issue.number }}"
-            ISSUE_TITLE="${{ github.event.issue.title }}"
-            ISSUE_BODY="${{ github.event.issue.body }}"
             
-            # Write all replacement values to temp files to avoid bash expansion issues
+            # Write all values to temp files to avoid bash expansion issues
+            # Use heredoc for user-controlled content to prevent command injection
             cat <<'KNOWLEDGE_EOF' > /tmp/knowledge.txt
           ${{ steps.knowledge.outputs.content }}
           KNOWLEDGE_EOF
             
             echo "$ISSUE_NUMBER" > /tmp/issue_number.txt
-            echo "$ISSUE_TITLE" > /tmp/issue_title.txt
-            echo "$ISSUE_BODY" > /tmp/issue_body.txt
+            
+            # SECURITY: Use heredoc to prevent command injection from issue title
+            cat <<'ISSUE_TITLE_EOF' > /tmp/issue_title.txt
+          ${{ github.event.issue.title }}
+          ISSUE_TITLE_EOF
+            
+            # SECURITY: Use heredoc to prevent command injection from issue body
+            cat <<'ISSUE_BODY_EOF' > /tmp/issue_body.txt
+          ${{ github.event.issue.body }}
+          ISSUE_BODY_EOF
+            
             echo "${{ github.repository }}" > /tmp/repo.txt
             
             # Load the template
@@ -150,27 +158,30 @@ jobs:
           ${{ steps.knowledge.outputs.content }}
           KNOWLEDGE_EOF
             
+            # SECURITY: Use heredoc to prevent command injection from PR comment
+            cat <<'COMMENT_BODY_EOF' > /tmp/comment_body.txt
+          ${{ github.event.comment.body }}
+          COMMENT_BODY_EOF
+            
             # Build the PR review prompt
             {
               cat /tmp/knowledge.txt
               echo ""
               echo "## PR Review Request"
               echo ""
-              echo "The user has requested: ${{ github.event.comment.body }}"
+              echo "The user has requested:"
+              cat /tmp/comment_body.txt
               echo ""
               echo "Please review and respond to this pull request comment with the full context of the codebase principles and procedures available above."
             } > /tmp/final_prompt.md
           fi
           
-          # Output the prompt directly from file to avoid bash variable limits
-          echo "prompt<<EOF" >> $GITHUB_OUTPUT
-          cat /tmp/final_prompt.md >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          # Log final prompt size for debugging
+          echo "Final prompt size: $(wc -c < /tmp/final_prompt.md) characters"
 
       - uses: anthropics/claude-code-base-action@beta
         with:
-          prompt: ${{ steps.prepare-prompt.outputs.prompt }}
+          prompt_file: /tmp/final_prompt.md
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_tools: "Bash(*),LS,Read,Write,Edit,MultiEdit,Glob,Grep,Task,TodoWrite,WebFetch(domain:*),WebSearch,mcp__git,mcp__github"
           timeout_minutes: "30"


### PR DESCRIPTION
## Summary
- Fixed claude-code-base-action workflow failures by switching to file-based prompts
- Removed invalid github_token parameter that was causing action to fail
- Added security improvements to prevent command injection

## Problem

The claude-implementation workflow was failing with two critical issues:

1. **Invalid input 'github_token'**: The claude-code-base-action@beta doesn't accept this parameter
2. **Argument list too long**: The 72k character knowledge base exceeded bash argument limits

## Solution

1. **Removed github_token parameter**: This was causing "Unexpected input" errors
2. **Switched from prompt to prompt_file**: Now writes prompt to `/tmp/final_prompt.md` and uses file-based input
3. **Added security hardening**: All user-controlled inputs now use heredocs to prevent command injection

## Technical Details

- The workflow already wrote the final prompt to `/tmp/final_prompt.md`
- Changed claude-code-base-action to use `prompt_file: /tmp/final_prompt.md`
- Removed unnecessary GITHUB_OUTPUT lines since we're reading directly from file
- Added heredocs for issue title, body, and PR comment body to prevent command injection

## Testing

The workflow will be tested on the next @claude mention in issues or PRs. It should now:
- Successfully load the full 72k knowledge base
- Handle special characters in user input safely
- Complete without "argument list too long" errors

Closes #1198

Principle: tracer-bullets
Principle: systems-stewardship