### PR TITLE
Fix MCP server availability in GitHub Actions workflow

### DIFF
--- a/.github/workflows/claude-implementation.yml
+++ b/.github/workflows/claude-implementation.yml
@@ -73,6 +73,11 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Setup MCP servers
+        run: |
+          echo "Building MCP servers for Claude..."
+          ./mcp/setup-all-mcp-servers.sh
+
       - name: Aggregate knowledge base
         id: knowledge
         run: |


### PR DESCRIPTION
## Summary
Fixes MCP server availability in GitHub Actions so Claude can create PRs and branches.

## Problem
- Claude successfully loads 72k knowledge base in GitHub Actions
- But fails to create PRs because `mcp__git` and `mcp__github` tools are unavailable
- Workflow includes MCP tools in `allowed_tools` but doesn't build the server binaries

## Solution
Add a single setup step to build MCP servers before Claude execution:
- Leverages existing `setup-all-mcp-servers.sh` script
- Builds Git MCP server (Python virtual environment)
- Compiles GitHub MCP server (Go binary)
- Provides proper error handling and verification

## Testing
Cannot test MCP server availability until this fix is merged and live in the workflow.

Closes #1203