### PR TITLE
Fix: Use spilled coffee principle for MCP dependencies

### DIFF
--- a/.github/workflows/claude-implementation.yml
+++ b/.github/workflows/claude-implementation.yml
@@ -73,10 +73,10 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup MCP servers
+      - name: Setup MCP servers with dependencies
         run: |
-          echo "Building MCP servers for Claude..."
-          ./mcp/setup-all-mcp-servers.sh
+          echo "Setting up MCP servers with all dependencies..."
+          source ./setup.sh
 
       - name: Aggregate knowledge base
         id: knowledge


### PR DESCRIPTION
## Spilled Coffee Principle Applied

Replace targeted MCP server setup with full `setup.sh` sourcing to handle ALL dependencies automatically.

## Problem
Previous fix only called `./mcp/setup-all-mcp-servers.sh` but that script requires:
- Go compiler (for GitHub MCP server) 
- Python + uv (for Git MCP server)

These dependencies weren't available in GitHub Actions environment.

## Spilled Coffee Solution  
Use `source ./setup.sh` instead - it's already battle-tested and handles:
- ✅ Auto-installs Go via multiple package managers + fallback
- ✅ Auto-installs uv Python package manager
- ✅ Handles all edge cases we haven't thought of
- ✅ Used daily in local development

## Why This Works
**Embraces the principle**: Make it impossible to fail rather than handling specific failure modes.

The `setup.sh` script already contains all the spilled coffee logic for dependency management across platforms.

## Testing
Will create test issue after merge to verify MCP servers connect properly in GitHub Actions.