### PR TITLE
feat: add MCP toggle script and git hooks for experiment

### DIFF
--- a/bin/install-git-hooks
+++ b/bin/install-git-hooks
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Install git hooks for the repository
+# Part of MCP server experiment - see issue #1213
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOKS_DIR="$REPO_ROOT/hooks"
+GIT_HOOKS_DIR="$REPO_ROOT/.git/hooks"
+
+echo "Installing git hooks..."
+
+# Install pre-push hook
+if [ -f "$HOOKS_DIR/pre-push" ]; then
+    cp "$HOOKS_DIR/pre-push" "$GIT_HOOKS_DIR/pre-push"
+    chmod +x "$GIT_HOOKS_DIR/pre-push"
+    echo "✓ Installed pre-push hook (prevents pushing to main/master)"
+fi
+
+echo ""
+echo "Git hooks installed successfully!"
+echo "These hooks provide protection while testing without MCP servers."
+echo "See issue #1213 for details."

--- a/bin/toggle-mcp-servers
+++ b/bin/toggle-mcp-servers
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Toggle git and github MCP servers on/off for testing
+# See issue #1213
+
+SETTINGS_FILE="$HOME/.claude/settings.json"
+
+if [ ! -f "$SETTINGS_FILE" ]; then
+    echo "Error: Settings file not found at $SETTINGS_FILE"
+    exit 1
+fi
+
+case "$1" in
+    off)
+        echo "Disabling git and github MCP servers..."
+        # Comment out the MCP servers
+        sed -i 's/^    "git",/    \/\/ "git",      \/\/ Temporarily disabled for testing - see issue #1213/' "$SETTINGS_FILE"
+        sed -i 's/^    "github",/    \/\/ "github",   \/\/ Temporarily disabled for testing - see issue #1213/' "$SETTINGS_FILE"
+        sed -i 's/^      "mcp__git",/      \/\/ "mcp__git",     \/\/ Temporarily disabled for testing - see issue #1213/' "$SETTINGS_FILE"
+        sed -i 's/^      "mcp__github",/      \/\/ "mcp__github",  \/\/ Temporarily disabled for testing - see issue #1213/' "$SETTINGS_FILE"
+        echo "✓ MCP servers disabled - using CLI directly"
+        echo "  Please restart Claude Code for changes to take effect"
+        ;;
+    on)
+        echo "Enabling git and github MCP servers..."
+        # Uncomment the MCP servers
+        sed -i 's/^    \/\/ "git",.*$/    "git",/' "$SETTINGS_FILE"
+        sed -i 's/^    \/\/ "github",.*$/    "github",/' "$SETTINGS_FILE"
+        sed -i 's/^      \/\/ "mcp__git",.*$/      "mcp__git",/' "$SETTINGS_FILE"
+        sed -i 's/^      \/\/ "mcp__github",.*$/      "mcp__github",/' "$SETTINGS_FILE"
+        echo "✓ MCP servers enabled"
+        echo "  Please restart Claude Code for changes to take effect"
+        ;;
+    status)
+        echo "Checking MCP server status..."
+        if grep -q '^\s*"git",' "$SETTINGS_FILE"; then
+            echo "  git MCP: ENABLED"
+        else
+            echo "  git MCP: DISABLED"
+        fi
+        if grep -q '^\s*"github",' "$SETTINGS_FILE"; then
+            echo "  github MCP: ENABLED"
+        else
+            echo "  github MCP: DISABLED"
+        fi
+        ;;
+    *)
+        echo "Usage: toggle-mcp-servers [on|off|status]"
+        echo ""
+        echo "  on     - Enable git and github MCP servers"
+        echo "  off    - Disable git and github MCP servers (use CLI directly)"
+        echo "  status - Show current status of MCP servers"
+        echo ""
+        echo "After toggling, restart Claude Code for changes to take effect."
+        echo "See issue #1213 for details on this experiment."
+        exit 1
+        ;;
+esac

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Pre-push hook to prevent direct pushes to main/master branches
+# Part of MCP server experiment - see issue #1213
+
+protected_branches="^(main|master)$"
+current_branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
+
+# Check if we're pushing to a protected branch
+while read local_ref local_sha remote_ref remote_sha
+do
+    # Extract the branch name from the remote ref
+    remote_branch=$(echo "$remote_ref" | sed -e 's,.*/\(.*\),\1,')
+    
+    if [[ "$remote_branch" =~ $protected_branches ]]; then
+        echo "⛔ Direct push to $remote_branch branch is not allowed!"
+        echo ""
+        echo "Please create a feature branch and use a pull request instead:"
+        echo "  1. git checkout -b feature/your-feature-name"
+        echo "  2. git push -u origin feature/your-feature-name"
+        echo "  3. Create a pull request on GitHub"
+        echo ""
+        echo "This protection is in place while testing without MCP servers."
+        echo "See issue #1213 for details."
+        exit 1
+    fi
+done
+
+exit 0


### PR DESCRIPTION
## Summary
- Added `bin/toggle-mcp-servers` script to easily enable/disable git and github MCP servers
- Added git pre-push hook to prevent direct pushes to main/master branches
- Part of experiment to test Claude Code without MCP wrappers per Anthropic engineer advice

## Related Issue
Closes #1213

## Implementation Details

### Toggle Script
The script provides three commands:
- `toggle-mcp-servers off` - Disable git/github MCP servers
- `toggle-mcp-servers on` - Re-enable git/github MCP servers
- `toggle-mcp-servers status` - Show current state

### Git Hook Protection
Since we use `bypassPermissions` mode (OSE mindset), deny rules don't work. Added:
- `hooks/pre-push` - Prevents direct pushes to main/master
- `bin/install-git-hooks` - Easy installation script

This provides safety while maintaining the OSE approach.

## Testing
- [x] Toggle script created and tested
- [x] Git operations work via Bash tool with MCP servers disabled
- [x] GitHub CLI operations work via Bash tool
- [x] Pre-push hook successfully blocks pushes to main
- [x] Feature branch pushes work normally

## Notes
- Settings changes are local only (not committed)
- MCP server files remain intact for easy re-enablement
- Aligns with "subtraction creates value" principle