### PR TITLE
refactor: simplify procedures for MCP experiment #1213

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,6 +5,12 @@
   "includeCoAuthoredBy": false,
   "permissions": {
     "defaultMode": "bypassPermissions",
+    "deny": [
+      "Bash(git push*main*)",
+      "Bash(git push*master*)",
+      "Bash(git add -A*)",
+      "Bash(git add .*)"
+    ],
     "allow": [
       "LS",
       "Read",

--- a/README.md
+++ b/README.md
@@ -328,10 +328,8 @@ claude mcp add my-server -s user /path/to/server
 ### MCP Servers Included
 
 The dotfiles include pre-configured MCP servers for:
-- Git operations (git-mcp-server)
-- GitHub integration (github-mcp-server with read/write split)
 - Brave Search API
-- Filesystem operations
+- Playwright browser automation
 - Google Drive access
 
 ### Claude Model Preferences

--- a/knowledge/procedures/claude-code-tips.md
+++ b/knowledge/procedures/claude-code-tips.md
@@ -16,7 +16,7 @@ Force multiplier discoveries for 1000x Claude Code productivity. Default to one-
 
 ## MCP Server Permissions
 
-- **No wildcards**: Use server names only in permissions (e.g., `"mcp__git"` not `"mcp__git*"`) - wildcards aren't supported despite appearing to work for servers without hyphens
+- **No wildcards**: Use server names only in permissions - wildcards aren't supported despite appearing to work for servers without hyphens
 
 ## Model Configuration
 
@@ -34,13 +34,9 @@ Claude Code has two separate permission systems that behave differently:
 
 ### 2. MCP Server Permissions  
 - **Managed by**: `settings.json` file
-- **Covers**: `mcp__git`, `mcp__github`, `mcp__playwright`, etc.
+- **Covers**: MCP servers like `mcp__playwright`, etc.
 - **Changes**: Only loaded at session start (requires restart)
 - **Confirmed limitation**: Granular permissions don't work - only server-level permissions are supported
-  - ❌ `mcp__github__create_pull_request` - doesn't work
-  - ❌ `mcp__git__git_push` - doesn't work  
-  - ✅ `mcp__github` - works (all-or-nothing for the server)
-  - ✅ `mcp__git` - works (all-or-nothing for the server)
 
 ### Runtime Workspace Access
 - **The `/permissions` Workspace tab** = runtime equivalent of `additionalDirectories`

--- a/knowledge/procedures/close-issue-procedure.md
+++ b/knowledge/procedures/close-issue-procedure.md
@@ -26,7 +26,7 @@ Complete and implement GitHub issue #{{ ISSUE_NUMBER }}.
 
 ## Analyze Issue #{{ ISSUE_NUMBER }}
 <!-- This procedure IS the implementation - executable documentation -->
-First, use `mcp__github__get_issue` to understand the issue and determine the appropriate workflow path.
+First, analyze the issue.
 
 ## Apply to Issue #{{ ISSUE_NUMBER }}
 When following the procedure:

--- a/knowledge/procedures/git-workflow.md
+++ b/knowledge/procedures/git-workflow.md
@@ -1,10 +1,9 @@
 # Git Workflow Rules
 
-Use MCP git tools, follow conventional commits, and maintain branch hygiene to prevent recovery tax.
+Follow conventional commits and maintain branch hygiene to prevent recovery tax.
 
 **When to use**: All git operations in this repository
 **Core rules**: 
-- Use `mcp__git__*` tools (chain with `git_batch`)
 - Conventional commits: `type[scope]: description`
 - Never work on main - always branch first
 **Details**: See [git-workflow-detailed.md](/docs/procedures/git-workflow-detailed.md)

--- a/knowledge/procedures/github-issue-creation.md
+++ b/knowledge/procedures/github-issue-creation.md
@@ -32,7 +32,7 @@ When users request "create a GitHub issue for..." or need to document a new task
 |-----------------|-------------------|------------|
 | "error", "fails", "broken", "bug" | issue.md (bug report) | Steps to reproduce, expected behavior |
 | "feature", "add", "implement", "enhance" | issue.md (enhancement) | Problem statement, proposed solution |
-| "mcp__git", "mcp__github", "tool error" | mcp-tool-error.md | Tool name, error message, reproduction |
+| "tool error" | mcp-tool-error.md | Tool name, error message, reproduction |
 | "procedure", "document process", "ghost" | procedure-documentation.md | Procedure name, steps, trigger |
 | General request | issue.md | Flexible format for any issue type |
 
@@ -44,7 +44,7 @@ When users request "create a GitHub issue for..." or need to document a new task
 
 ## Implementation
 
-Use `mcp__github__create_issue` with:
+Create the issue with:
 - Appropriate labels based on type
 - Cross-referenced procedures in body
 - Clear title following conventions


### PR DESCRIPTION
## Summary
Updates procedures to be tool-agnostic, giving the MCP experiment a fair trial.

## Changes
- Made procedures say WHAT to do, not HOW to do it
- Removed specific mcp__git and mcp__github tool references
- Updated README.md to reflect current MCP server state
- Added safety rules to prevent `git add -A` and `git add .`

## Rationale
Per the principle of not hand-holding, procedures should be principle-oriented rather than prescriptive. This lets Claude Code choose the best tool for the job, whether that's MCP servers or direct CLI.

## Safety Enhancement
Added deny rules for:
- `Bash(git add -A*)`
- `Bash(git add .*)`

This ensures every file addition shows clear intention, preventing accidental commits.

## Related
- Supports experiment #1213
- Follows "subtraction creates value" principle
- Reduces hand-holding in documentation