### PR TITLE
cleanup: remove MCP server build remnants for experiment #1213

### DIFF
--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -30,22 +30,23 @@ jobs:
           echo "$PROMPT_CONTENT" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-      - name: Setup GitHub MCP Server
-        run: |
-          mkdir -p /tmp/mcp-config
-          cat > /tmp/mcp-config/mcp-servers.json << 'EOF'
-          {
-            "mcpServers": {
-              "github": {
-                "command": "node",
-                "args": ["${{ github.workspace }}/mcp/servers/github-mcp-server/dist/index.js"],
-                "env": {
-                  "GITHUB_TOKEN": "${{ secrets.GITHUB_TOKEN }}"
-                }
-              }
-            }
-          }
-          EOF
+      # EXPERIMENT #1213: GitHub MCP Server temporarily disabled
+      # - name: Setup GitHub MCP Server
+      #   run: |
+      #     mkdir -p /tmp/mcp-config
+      #     cat > /tmp/mcp-config/mcp-servers.json << 'EOF'
+      #     {
+      #       "mcpServers": {
+      #         "github": {
+      #           "command": "node",
+      #           "args": ["${{ github.workspace }}/mcp/servers/github-mcp-server/dist/index.js"],
+      #           "env": {
+      #             "GITHUB_TOKEN": "${{ secrets.GITHUB_TOKEN }}"
+      #           }
+      #         }
+      #       }
+      #     }
+      #     EOF
 
       - name: Run Claude Code for Issue Triage
         uses: anthropics/claude-code-base-action@beta

--- a/.github/workflows/claude-implementation.yml
+++ b/.github/workflows/claude-implementation.yml
@@ -73,10 +73,10 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup MCP servers with dependencies
+      - name: Setup environment dependencies
         run: |
-          echo "Setting up MCP servers with all dependencies..."
-          source ./setup.sh
+          echo "Setting up environment dependencies..."
+          source setup.sh  # MCP setup already disabled in setup.sh for experiment #1213
 
       - name: Aggregate knowledge base
         id: knowledge

--- a/README.md
+++ b/README.md
@@ -328,9 +328,9 @@ claude mcp add my-server -s user /path/to/server
 ### MCP Servers Included
 
 The dotfiles include pre-configured MCP servers for:
-- Brave Search API
-- Playwright browser automation
-- Google Drive access
+- Playwright browser automation (for tasks requiring browser interaction)
+
+Note: Git, GitHub, and web search are handled natively by Claude Code (experiment #1213)
 
 ### Claude Model Preferences
 

--- a/mcp/setup-all-mcp-servers.sh
+++ b/mcp/setup-all-mcp-servers.sh
@@ -34,10 +34,11 @@ else
 fi
 
 # Run individual setup scripts
+# EXPERIMENT #1213: All MCP servers temporarily disabled
 setup_scripts=(
-    "setup-github-mcp.sh"
-    "setup-git-mcp.sh"
-    "setup-brave-search-mcp.sh"
+    # "setup-github-mcp.sh"
+    # "setup-git-mcp.sh"
+    # "setup-brave-search-mcp.sh"
 )
 
 failed_setups=()

--- a/setup.sh
+++ b/setup.sh
@@ -266,13 +266,14 @@ else
 fi
 
 # Set up all MCP servers (works in worktrees)
-if [[ -f "$DOT_DEN/mcp/setup-all-mcp-servers.sh" ]]; then
-  echo -e "${DIVIDER}"
-  echo "Setting up MCP servers..."
-  "$DOT_DEN/mcp/setup-all-mcp-servers.sh"
-else
-  echo -e "${YELLOW}MCP server setup script not found. Skipping MCP server setup.${NC}"
-fi
+# EXPERIMENT #1213: Temporarily disabled - testing without MCP servers
+# if [[ -f "$DOT_DEN/mcp/setup-all-mcp-servers.sh" ]]; then
+#   echo -e "${DIVIDER}"
+#   echo "Setting up MCP servers..."
+#   "$DOT_DEN/mcp/setup-all-mcp-servers.sh"
+# else
+#   echo -e "${YELLOW}MCP server setup script not found. Skipping MCP server setup.${NC}"
+# fi
 
 
 # GitLab MCP authentication now handled by @zereight/mcp-gitlab package
@@ -600,21 +601,22 @@ if [[ -f ~/.bash_aliases ]]; then
 fi
 
 # MCP Dashboard setup
-echo -e "${DIVIDER}"
-echo "Setting up MCP Dashboard..."
-
-# Check if start-mcp-dashboard script exists
-if [[ -x "$DOT_DEN/bin/start-mcp-dashboard" ]]; then
-  # Use the start-mcp-dashboard script which handles all checks
-  "$DOT_DEN/bin/start-mcp-dashboard" start
-  # The script handles:
-  # - Checking if dashboard is already running
-  # - Verifying the binary exists
-  # - Starting with proper health checks
-  # - Displaying clear status messages
-else
-  echo -e "${YELLOW}start-mcp-dashboard script not found. Skipping dashboard setup.${NC}"
-fi
+# EXPERIMENT #1213: Temporarily disabled - testing without MCP servers/dashboard
+# echo -e "${DIVIDER}"
+# echo "Setting up MCP Dashboard..."
+# 
+# # Check if start-mcp-dashboard script exists
+# if [[ -x "$DOT_DEN/bin/start-mcp-dashboard" ]]; then
+#   # Use the start-mcp-dashboard script which handles all checks
+#   "$DOT_DEN/bin/start-mcp-dashboard" start
+#   # The script handles:
+#   # - Checking if dashboard is already running
+#   # - Verifying the binary exists
+#   # - Starting with proper health checks
+#   # - Displaying clear status messages
+# else
+#   echo -e "${YELLOW}start-mcp-dashboard script not found. Skipping dashboard setup.${NC}"
+# fi
 
 echo -e "${DIVIDER}"
 echo -e "${GREEN}✅ Dotfiles setup complete!${NC}"


### PR DESCRIPTION
## Summary
Removes all attempts to build MCP servers that we're not using in experiment #1213.

## Changes
- **setup.sh**: Commented out MCP server setup and dashboard (keeps other functionality)
- **setup-all-mcp-servers.sh**: Emptied the setup scripts array
- **claude-implementation.yml**: Fixed to run `source setup.sh` without MCP builds
- **auto-label-issues.yml**: Commented out GitHub MCP server setup
- **README.md**: Updated to show only Playwright remains as MCP server

## Rationale
Experiment #1213 is testing whether well-documented CLI tools work better without MCP wrappers:
- Git operations → native git CLI
- GitHub operations → native gh CLI  
- Web search → Claude Code's native search

This cleanup ensures:
- No attempts to build non-existent servers
- GitHub Actions still work properly
- Clean experiment environment

## Related
- Supports experiment #1213
- Follow-up to #1214 (git hooks) and #1216 (procedure simplification)
- If successful, issue #1215 tracks full removal