### PR TITLE
cleanup: unify MCP config to only Playwright for experiment #1213

### DIFF
--- a/mcp/mcp.json
+++ b/mcp/mcp.json
@@ -1,24 +1,5 @@
 {
   "mcpServers": {
-    "git": {
-      "command": "git-mcp-wrapper.sh",
-      "args": [],
-      "env": {
-        "FASTMCP_LOG_LEVEL": "ERROR"
-      }
-    },
-    "github": {
-      "command": "github-mcp-wrapper.sh",
-      "args": [],
-      "env": {}
-    },
-    "brave-search": {
-      "command": "brave-search-mcp-wrapper.sh",
-      "args": [],
-      "env": {
-        "FASTMCP_LOG_LEVEL": "ERROR"
-      }
-    },
     "playwright": {
       "command": "npx",
       "args": [

--- a/setup.sh
+++ b/setup.sh
@@ -375,6 +375,16 @@ else
   echo -e "${YELLOW}Warning: .claude/settings.json not found. Skipping settings symlink.${NC}"
 fi
 
+# Symlink Claude Desktop MCP config to unified location (experiment #1213)
+if [[ -f "$DOT_DEN/mcp/mcp.json" ]]; then
+  echo "Creating symlink for Claude Desktop MCP config..."
+  # Create ~/.config/claude directory if it doesn't exist
+  mkdir -p "$HOME/.config/claude"
+  # Create symlink to unified MCP config
+  ln -sf "$DOT_DEN/mcp/mcp.json" "$HOME/.config/claude/claude_desktop_config.json"
+  echo -e "${GREEN}✓ Claude Desktop MCP config symlinked to mcp/mcp.json${NC}"
+fi
+
 
 # Node.js setup with NVM
 echo -e "${DIVIDER}"


### PR DESCRIPTION
## Summary
Final cleanup for experiment #1213 - unifies MCP configuration to only include Playwright.

## Changes
- **mcp/mcp.json**: Removed git, github, brave-search servers - only Playwright remains
- **setup.sh**: Added symlink creation for Claude Desktop config

## Configuration Structure
Single source of truth: `mcp/mcp.json`
- Claude Code: reads via `.mcp.json` → `mcp/mcp.json` (existing symlink)  
- Claude Desktop: reads via `~/.config/claude/claude_desktop_config.json` → `mcp/mcp.json` (new symlink)

## Why Only Playwright?
- Git, GitHub, web search: Better handled natively by Claude Code (testing in #1213)
- Playwright: Genuinely useful for browser automation, not just a CLI wrapper

## Related
- Completes experiment #1213
- Follow-up to #1214, #1216, #1217
- If successful, full removal tracked in #1215