### PR TITLE
Fix: Correct INJECT path in close-issue template

### DIFF
--- a/.claude/command-templates/close-issue.md
+++ b/.claude/command-templates/close-issue.md
@@ -1,4 +1,4 @@
 # Close Issue Command Template
 Complete and implement GitHub issue #{{ ISSUE_NUMBER }}.
 
-{{ INJECT:knowledge/procedures/close-issue-procedure.md }}
+{{ INJECT:procedures/close-issue-procedure.md }}


### PR DESCRIPTION
## Summary
- Fixed the incorrect INJECT path in the close-issue.md template that was causing generate-commands.sh to fail
- Changed `{{ INJECT:knowledge/procedures/close-issue-procedure.md }}` to `{{ INJECT:procedures/close-issue-procedure.md }}`
- This resolves the "Unresolved placeholders" error when running `source setup.sh`

## Problem
The template was using `knowledge/procedures/close-issue-procedure.md` as the injection path, but since the knowledge base is already set to `/path/to/dotfiles/knowledge`, this created a double "knowledge" in the resolved path, resulting in the file not being found.

## Solution
Removed the redundant "knowledge/" prefix from the INJECT path, making it relative to the knowledge base directory as intended.

## Test Plan
- [x] Ran `./utils/generate-commands.sh` - now completes successfully
- [x] Verified all 9 command templates are processed without errors
- [x] Confirmed other templates (create-issue.md, retro.md) already use correct path format