### PR TITLE
fix: correct ALL broken Claude Code permission syntax

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,10 +6,10 @@
   "permissions": {
     "defaultMode": "bypassPermissions",
     "deny": [
-      "Bash(git push*main*)",
-      "Bash(git push*master*)",
-      "Bash(git add -A*)",
-      "Bash(git add .*)"
+      "Bash(git push:*main*)",
+      "Bash(git push:*master*)",
+      "Bash(git add -A:*)",
+      "Bash(git add:.*)"
     ],
     "allow": [
       "LS",
@@ -34,8 +34,8 @@
       "Bash(./utils/configure-claude-code-settings.sh:*)",
       "Bash(check-mcp-logs:*)",
       "Bash(python:*)",
-      "Bash(git *)",
-      "Bash(gh *)",
+      "Bash(git:*)",
+      "Bash(gh:*)",
       "mcp__playwright"
     ],
     "additionalDirectories": ["//"]


### PR DESCRIPTION
## Summary
- Fixed ALL broken Bash permission syntax in Claude Code settings.json
- Added missing colon separator to make permissions actually work
- Verified correct syntax against official Anthropic documentation

## Changes
### Deny Section (lines 9-12)
- `git push*main*` → `git push:*main*`
- `git push*master*` → `git push:*master*`
- `git add -A*` → `git add -A:*`
- `git add .*` → `git add:.*`

### Allow Section (lines 37-38)
- `Bash(git *)` → `Bash(git:*)`
- `Bash(gh *)` → `Bash(gh:*)`

## Problem Fixed
The broken syntax (missing colon separator) meant these permission rules had **NO EFFECT**, creating false confidence that commands were configured when they weren't actually working.

## Verification
Correct syntax verified against: https://docs.anthropic.com/en/docs/claude-code/settings

Closes #1220