### PR TITLE
fix: add GH_TOKEN for Claude PR creation

### DIFF
--- a/.github/workflows/claude-implementation.yml
+++ b/.github/workflows/claude-implementation.yml
@@ -190,3 +190,5 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_tools: "Bash(*),LS,Read,Write,Edit,MultiEdit,Glob,Grep,Task,TodoWrite,WebFetch(domain:*),WebSearch,mcp__git,mcp__github"
           timeout_minutes: "30"
+          claude_env: |
+            GH_TOKEN=${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
One-line fix to enable Claude to create PRs via GitHub CLI.

## Change
```yaml
claude_env: |
  GH_TOKEN=${{ secrets.GITHUB_TOKEN }}
```

## Why
Claude fails with: `gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable`

## Note
`GITHUB_TOKEN` is automatically provided by GitHub Actions - no manual setup needed.

Closes #1223