### PR TITLE
feat: standardize Claude model and fix allowed_tools syntax

### DIFF
--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -55,6 +55,6 @@ jobs:
           allowed_tools: "Bash(gh:*)"
           timeout_minutes: "5"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          model: claude-sonnet-4-20250514
+          model: claude-opus-4-1-20250805
           claude_env: |
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-implementation.yml
+++ b/.github/workflows/claude-implementation.yml
@@ -188,7 +188,7 @@ jobs:
         with:
           prompt_file: /tmp/final_prompt.md
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_tools: "Bash(*),LS,Read,Write,Edit,MultiEdit,Glob,Grep,Task,TodoWrite,WebFetch(domain:*),WebSearch,mcp__git,mcp__github"
+          allowed_tools: "Bash:*,LS,Read,Write,Edit,MultiEdit,Glob,Grep,Task,TodoWrite,WebFetch(domain:*),WebSearch"
           timeout_minutes: "30"
           model: claude-opus-4-1-20250805
           claude_env: |

--- a/.github/workflows/claude-implementation.yml
+++ b/.github/workflows/claude-implementation.yml
@@ -190,5 +190,6 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_tools: "Bash(*),LS,Read,Write,Edit,MultiEdit,Glob,Grep,Task,TodoWrite,WebFetch(domain:*),WebSearch,mcp__git,mcp__github"
           timeout_minutes: "30"
+          model: claude-opus-4-1-20250805
           claude_env: |
             GH_TOKEN=${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Standardizes Claude model across workflows and fixes allowed_tools syntax.

## Changes

1. **Model Standardization**
   - Updated both workflows to use `claude-opus-4-1-20250805`
   - Matches local `.claude/settings.json` configuration

2. **Fixed allowed_tools Syntax** 
   - Changed `Bash(*)` to `Bash:*` (proper colon syntax)
   - Removed non-existent MCP tools (`mcp__git`, `mcp__github`)

## Files Updated
- `.github/workflows/auto-label-issues.yml`
- `.github/workflows/claude-implementation.yml`

## Result
Workflows now use consistent Claude Opus 4.1 model matching local development environment.