### PR TITLE
fix: add git worktree isolation instruction to close-issue procedure

### DIFF
--- a/knowledge/procedures/close-issue-procedure.md
+++ b/knowledge/procedures/close-issue-procedure.md
@@ -21,6 +21,10 @@ Complete and implement GitHub issue #{{ ISSUE_NUMBER }}.
 {{ KNOWLEDGE_BASE }}
 <!-- Note: If you see "{{ KNOWLEDGE_BASE }}" above as literal text, you're running locally and knowledge is already preloaded -->
 
+## Setup Isolated Environment
+Use git worktrees to create an isolated workspace for issue #{{ ISSUE_NUMBER }}.
+This prevents conflicts when multiple agents work in parallel.
+
 ## Core Principle: Target-First Development
 {{ INJECT:principles/tracer-bullets.md }}
 


### PR DESCRIPTION
## Summary
- Added explicit instruction to use git worktrees in the close-issue procedure
- Restores parallel agent isolation that was broken after git MCP server removal
- Uses tool-agnostic approach (just "use git worktrees") for flexibility

## Problem Solved
Multiple Claude Code agents running  in parallel were sharing the same working directory, causing conflicts. This was because:
1. The git MCP server was removed 
2. No worktree creation instructions existed in the procedure
3. Agents had no guidance to create isolated workspaces

## Solution
Added a simple "Setup Isolated Environment" section that instructs agents to use git worktrees for issue #{{ ISSUE_NUMBER }}. This is tool-agnostic - agents can use CLI commands or any available tools.

## Test Plan
- [x] Updated close-issue-procedure.md with worktree instruction
- [ ] Run multiple /close-issue commands in parallel 
- [ ] Verify each creates its own worktree
- [ ] Confirm no interference between agents

Closes #1238