### PR TITLE
feat: enable Planning Mode by default in Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "defaultMode": "plan",
   "model": "claude-opus-4-1-20250805",
   "cleanupPeriodDays": 90,
   "forceLoginMethod": "claudeai",


### PR DESCRIPTION
## Git Statistics
- 📝 1 file changed
- ➕ 1 insertion

## Summary 🎯
Enable Planning Mode by default in Claude settings to support plan-first workflows.

## Changes Made ✨
- Added `"defaultMode": "plan"` to `.claude/settings.json`
- This ensures all Claude sessions begin in Planning Mode
- One-line modification as expected

## Issue Resolution 🔗
Closes #1234

## Testing 🧪
- ✅ JSON syntax validated
- ✅ Setting follows Claude's configuration schema
- ✅ No breaking changes to existing configuration

## Impact 📊
This change improves the developer experience by:
- Encouraging thoughtful planning before execution
- Reducing potential for unintended modifications
- Aligning with best practices for AI-assisted development