### PR TITLE
Revert: Switch default back to bypassPermissions mode

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,7 @@
   "forceLoginMethod": "claudeai",
   "includeCoAuthoredBy": false,
   "permissions": {
-    "defaultMode": "plan",
+    "defaultMode": "bypassPermissions",
     "deny": [
       "Bash(git push:*main*)",
       "Bash(git push:*master*)",


### PR DESCRIPTION
## Git Statistics
```
1 file changed, 1 insertion(+), 1 deletion(-)
```

## Summary
🔄 Reverts the default mode from `plan` back to `bypassPermissions` after discovering a critical limitation

## The Discovery
After PR #1243, we learned that **plan mode cannot be toggled at runtime**:
- No Shift+Tab toggle (like we expected)
- No `/plan` command to activate on-demand
- Settings change requires full restart

## The Trade-off
Without runtime toggle, we're forced to choose:

| Mode | Pros | Cons |
|------|------|------|
| **Always Plan** | Thoughtful approach to complex tasks | Cumbersome for simple operations |
| **Never Plan** | Fluid, fast workflow | Miss planning benefits when needed |

## Decision
Reverting to `bypassPermissions` until Claude Code adds runtime plan mode toggle because:
- Most operations are simple and benefit from fluid workflow
- Complex tasks can still be approached carefully (just without enforced planning)
- Better to optimize for the common case

## Change
```diff
-    "defaultMode": "plan",
+    "defaultMode": "bypassPermissions",
```

## Future State
Ideal solution would be runtime toggle support in Claude Code:
- Keep `bypassPermissions` as default
- Press Shift+Tab or use `/plan` when complexity warrants planning
- Best of both worlds

## Related
- Reverts #1243
- Discovered limitation while working on #1242
- Consider feature request to Claude Code for runtime toggle

Closes #1245