### PR TITLE
refactor: simplify command templates to follow close-issue pattern

### DIFF
--- a/.claude/command-templates/create-issue.md
+++ b/.claude/command-templates/create-issue.md
@@ -1,25 +1,4 @@
----
-name: create-issue
-description: Create GitHub issue with intelligent type detection and template selection
----
+# Create Issue Command Template
+Create a new GitHub issue with intelligent labeling.
 
-# Create GitHub Issue
-
-I'll help you create a GitHub issue with the appropriate template and context.
-
-{{ INJECT:procedures/github-issue-creation.md }}
-
-## Request Analysis
-
-Please provide:
-1. **What you want to create an issue for**
-2. **Any specific details or context**
-3. **Whether this is for dotfiles or another repository**
-
-I'll:
-- Auto-detect the issue type
-- Suggest the best template
-- Link relevant procedures
-- Include appropriate labels
-
-What would you like to create an issue for?
+{{ INJECT:procedures/issue-creation-procedure.md }}

--- a/.claude/command-templates/retro.md
+++ b/.claude/command-templates/retro.md
@@ -1,10 +1,5 @@
----
-name: retro
-description: Mine gleanings through eager evolution of living systems
----
+# Retro Command Template
+Mine gleanings through eager evolution of living systems.
 
-Timeout - let's retro this context and wring out the gleanings.
-
-{{ INJECT:procedures/post-pr-mini-retro.md }}
-
+{{ INJECT:procedures/retro-procedure.md }}
 {{ INJECT:principles/eager-evolution.md }}

--- a/.github/ISSUE_TEMPLATE/close-issue-guide.md
+++ b/.github/ISSUE_TEMPLATE/close-issue-guide.md
@@ -68,7 +68,7 @@ Follow [Git Workflow](../../knowledge/procedures/git-workflow.md) for commit sta
   - If not found, use dotfiles fallback: `~/ppv/pillars/dotfiles/.github/PULL_REQUEST_TEMPLATE.md`
   - Inform which template is being used for transparency
 - Create PR with `mcp__github__create_pull_request` following the discovered template
-- Add "Conduct post-PR mini retro" to your todo list
+- Add "Conduct retro" to your todo list
 
 ### 4. Iterate Based on Feedback
 Keep worktree active for PR adjustments based on the tracer bullets principle. Only cleanup after PR is merged.
@@ -91,4 +91,4 @@ Remember: Act agentically. Make the decision and execute.
 
 - [Issue to PR Workflow](../../knowledge/procedures/issue-to-pr-workflow.md) - High-level workflow overview
 - [Tracer Bullets](../../knowledge/principles/tracer-bullets.md) - Target-first development
-- [Post-PR Mini Retro](../../knowledge/procedures/post-pr-mini-retro.md) - Learning from implementation
+- [Retro Procedure](../../knowledge/procedures/retro-procedure.md) - Learning from implementation

--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,6 @@ think-tank/
 CLAUDE.local.md
 # Claude Code local settings (personal overrides, not for source control per Anthropic docs)
 .claude/settings.local.json
-# Setup-generated symlinks (avoid duplicating tracked content)
-.claude/command-templates
 
 # Private SSH keys
 id_rsa

--- a/docs/procedures/issue-to-pr-detailed-workflow.md
+++ b/docs/procedures/issue-to-pr-detailed-workflow.md
@@ -76,7 +76,7 @@ After merging via GitHub UI:
 ### 7. Optional: Post-PR Retro
 
 For significant work:
-- Run [post-PR mini retro](../../knowledge/procedures/post-pr-mini-retro.md)
+- Run [retro procedure](../../knowledge/procedures/retro-procedure.md)
 - Capture learnings
 - Update procedures if needed
 - Document any ghost procedures discovered - see [Procedure Creation](../../knowledge/procedures/procedure-creation.md)

--- a/knowledge/ai-index.md
+++ b/knowledge/ai-index.md
@@ -20,11 +20,11 @@ Your starting point for understanding and working with this dotfiles repository.
 - Apply [Tracer Bullets](principles/tracer-bullets.md) - Iterative development
 
 ### Handle GitHub Tasks
-- Create issues with [GitHub Issue Creation](procedures/github-issue-creation.md) - Smart template selection
+- Create issues with [Issue Creation Procedure](procedures/issue-creation-procedure.md) - Smart template selection
 - See [Issue to PR Workflow](procedures/issue-to-pr-workflow.md) - High-level flow
 - Follow [Close Issue Procedure](procedures/close-issue-procedure.md) - Detailed steps
-- Use GitHub MCP server for all GitHub operations
-- Remember: Use mcp__github__ tools, not direct API calls
+- Use gh CLI for all GitHub operations
+- Remember: Use `gh` commands for GitHub API interactions
 
 ### Write or Modify Code
 - Check [Coding Conventions](procedures/coding-conventions.md)
@@ -48,7 +48,7 @@ Your starting point for understanding and working with this dotfiles repository.
 - Transform tribal knowledge into systems
 
 ### Run Post-PR Retros
-- See [Post-PR Mini Retro](procedures/post-pr-mini-retro.md)
+- See [Retro Procedure](procedures/retro-procedure.md)
 - Consult [Personalities](personalities/) for perspectives
 
 ### When MCP Tools Don't Work
@@ -67,23 +67,23 @@ When editing these foundational files, keep changes small and easy to approve. A
 
 ## Critical Rules
 
-1. **ALWAYS use MCP tools** instead of bash for git operations
-2. **ALWAYS check git status** before creating branches
-3. **ALWAYS use absolute paths** in file operations
-4. **NEVER commit directly to main** without explicit permission
-5. **NEVER create files** unless absolutely necessary - prefer editing
+1. **ALWAYS check git status** before creating branches
+2. **ALWAYS use absolute paths** in file operations
+3. **NEVER commit directly to main** without explicit permission
+4. **NEVER create files** unless absolutely necessary - prefer editing
+5. **PREFER gh CLI** for GitHub operations (issues, PRs, etc.)
 
 ## Tool Selection Guide
 
 | Task | Use These Tools |
 |------|----------------|
-| Git operations | mcp__git__* tools |
-| GitHub operations | mcp__github__* tools |
+| Git operations | gh CLI or git commands via Bash |
+| GitHub operations | gh CLI commands |
 | File search | Grep, Glob, or Task (for complex searches) |
 | File editing | Edit, MultiEdit |
 | File creation | Write (only when necessary) |
 | Web browsing | mcp__playwright__* tools |
 | Documentation lookup | Read this index first, then specific docs |
-| Run shell commands | Bash (prefer MCP tools when available) |
+| Run shell commands | Bash tool |
 
 Remember: The goal is AI agent management capability for 100x-1000x productivity.

--- a/knowledge/principles/eager-evolution.md
+++ b/knowledge/principles/eager-evolution.md
@@ -19,7 +19,7 @@ Our dotfiles aren't just configuration - they're a **living system** that:
 This principle manifests everywhere:
 - **MCP Error Reporting** → Self-healing feedback loops
 - **Ghost Procedure Capture** → Learning from undocumented patterns
-- **Post-PR Mini Retros** → Mining gleanings from every experience
+- **Retro Procedures** → Mining gleanings from every experience
 - **INJECT patterns** → Single source of truth that evolves
 - **Snowball Method** → Compound learning over time
 - **Worktree failures documented** → Crisis becomes prevention system

--- a/knowledge/procedures/README.md
+++ b/knowledge/procedures/README.md
@@ -20,7 +20,7 @@ This is THE workflow. Everything else supports this core process.
 - `slash-command-generation.md` - How slash commands like `/close-issue` work
 
 ### Quality & Improvement
-- `post-pr-mini-retro.md` - Systems improvement retro after feature PRs
+- `retro-procedure.md` - Systems improvement retro and learning extraction
 - `five-focusing-steps.md` - Identify and optimize constraints
 
 ### Conventions & Standards

--- a/knowledge/procedures/github-issue-creation.md
+++ b/knowledge/procedures/github-issue-creation.md
@@ -18,7 +18,7 @@ When users request "create a GitHub issue for..." or need to document a new task
 2. **Scan for keywords** to link relevant procedures:
    - "MCP" → Link MCP-related procedures
    - "worktree" → Link worktree-workflow
-   - "retro" → Link post-pr-mini-retro
+   - "retro" → Link retro-procedure
    - "git" → Link git-workflow
 
 3. **Auto-populate context**:

--- a/knowledge/procedures/issue-creation-procedure.md
+++ b/knowledge/procedures/issue-creation-procedure.md
@@ -1,0 +1,114 @@
+# Issue Creation Procedure
+# 
+# This IS the implementation - the procedure documents itself by being the code.
+# Used by /create-issue command (via injection)
+#
+# Principle: systems-stewardship (single source of truth, documentation as code)
+# Principle: ose (operational-sensibility-expertise in issue management)
+
+Create a new GitHub issue with validated labels and principle detection.
+
+## Step 1: Gather Issue Details
+
+Please provide:
+1. **What you want to create an issue for**
+2. **Any specific details or context**
+3. **Whether this is for dotfiles or another repository**
+
+If no details provided, prompt interactively for:
+- Issue title
+- Issue description/body
+- Repository (default: atxtechbro/dotfiles)
+
+## Step 2: Analyze Issue Type
+
+Determine issue type based on content:
+- Bug report → Keywords: "error", "fails", "broken", "bug"
+- Feature request → Keywords: "feature", "add", "implement", "enhance"
+- MCP tool error → Keywords: "tool error", "MCP"
+- Procedure documentation → Keywords: "procedure", "document process", "ghost"
+- General enhancement → Default for other requests
+
+## Step 3: Detect Principles
+
+Scan issue content for principle alignment:
+- Direct mentions: "versioning-mindset", "OSE", "subtraction-creates-value"
+- Keywords implying principles:
+  - "simplify", "remove" → subtraction-creates-value
+  - "iterate", "evolve" → versioning-mindset
+  - "maintain", "steward" → systems-stewardship
+  - "developer joy", "DX" → developer-experience
+  - "rapid", "quick test" → tracer-bullets
+  - "accumulate", "compound" → snowball-method
+
+## Step 4: Validate Labels
+
+Fetch all available labels in the repository.
+Check which labels actually exist before attempting to apply them.
+
+Suggested labels based on analysis:
+- Issue type labels (bug, enhancement, documentation)
+- Principle labels (principle:ose, principle:versioning-mindset, etc.)
+- Area labels (mcp, git, automation, etc.)
+
+**CRITICAL**: Only apply labels that exist in the repository.
+Never attempt to apply non-existent labels.
+
+## Step 5: Build Issue Content
+
+### Template Selection
+
+| Issue Type | Template | Key Fields |
+|------------|----------|------------|
+| Bug report | issue.md | Steps to reproduce, expected behavior |
+| Feature request | issue.md | Problem statement, proposed solution |
+| MCP tool error | mcp-tool-error.md | Tool name, error message |
+| Procedure documentation | procedure-documentation.md | Procedure name, steps |
+| General | issue.md | Flexible format |
+
+### Cross-Reference Procedures
+
+Based on keywords, link relevant procedures:
+- "MCP" → Link MCP-related procedures
+- "worktree" → Link worktree-workflow
+- "retro" → Link retro-procedure
+- "git" → Link git-workflow
+- "issue" → Link issue-to-pr-workflow
+
+## Step 6: Preview Issue
+
+Present a complete preview showing:
+- **Title**: [proposed title]
+- **Body**: [formatted content with template]
+- **Labels**: [only validated labels]
+- **Repository**: [target repository]
+
+Ask for confirmation or modifications.
+
+## Step 7: Create the Issue
+
+Upon confirmation:
+1. Create the issue with validated labels only
+2. Return the issue URL
+3. Log the creation for analytics
+
+## Error Handling
+
+If label validation fails:
+- Skip non-existent labels
+- Note which labels were skipped
+- Continue with issue creation using only valid labels
+
+## Principle: subtraction-creates-value
+
+This procedure replaces the auto-label workflow, removing a moving part while gaining:
+- Immediate labeling (no GitHub Actions delay)
+- Reliable label validation
+- Interactive refinement
+- Single source of truth
+
+## See Also
+
+- [Issue to PR Workflow](issue-to-pr-workflow.md)
+- [Close Issue Procedure](close-issue-procedure.md)
+- [Git Workflow](git-workflow.md)

--- a/knowledge/procedures/retro-procedure.md
+++ b/knowledge/procedures/retro-procedure.md
@@ -1,7 +1,6 @@
-# Post-PR Mini Retro
+# Retro Procedure
 
-<<<<<<< HEAD
-After submitting a pull request for feature-related workflows, conduct a mini retro focused on systems improvement. This supports the Snowball Method by capturing learnings and dedicating 20% of time to systems improvement.
+After completing work or submitting a pull request, conduct a retro focused on systems improvement. This supports the Snowball Method by capturing learnings and dedicating 20% of time to systems improvement.
 
 **Wring out the towel**: Extract every drop of learning from each experience - the insights that seem obvious in hindsight are often the most valuable to document. **Never let a crisis go to waste**: Each failure or unexpected challenge becomes raw material for stronger systems and procedures.
 

--- a/knowledge/procedures/tmux-git-worktrees-claude-code.md
+++ b/knowledge/procedures/tmux-git-worktrees-claude-code.md
@@ -67,6 +67,6 @@ Immediate issue creation/resolution cycle maintains snowball method momentum rat
 
 - [Worktree Workflow](worktree-workflow.md) - technical isolation details
 - [Slash Command Generation](slash-command-generation.md) - automation mechanics
-- [Post-PR Mini Retro](post-pr-mini-retro.md) - eager evolution through learning
+- [Retro Procedure](retro-procedure.md) - eager evolution through learning
 
 This workflow transforms development from sequential file-editing to parallel task orchestration - the foundation of the 100x productivity multiplier.


### PR DESCRIPTION
## Summary
Refactors `create-issue` and `retro` command templates to follow the clean, minimal pattern established by `close-issue`.

## Changes
- Created `issue-creation-procedure.md` as self-documenting procedure
- Simplified `create-issue.md` template to just inject the procedure
- Renamed `post-pr-mini-retro.md` to `retro-procedure.md` for general use
- Simplified `retro.md` template removing YAML frontmatter
- Updated all references to post-pr-mini-retro throughout codebase
- Updated ai-index.md removing outdated MCP tool references
- Removed `.claude/command-templates` from gitignore (now source files, not symlinks)

## Principles Applied
- **systems-stewardship**: Single source of truth for each command's logic
- **subtraction-creates-value**: Removed unnecessary YAML frontmatter and duplicate content
- **versioning-mindset**: Evolved from symlink approach to INJECT pattern

## Testing
- Regenerated all commands with `./utils/generate-commands.sh`
- Commands now have clean, consistent structure
- Procedures live in high-visibility knowledge/procedures/

Closes #1247