### PR TITLE
fix: add frontmatter descriptions and argument hints to slash commands

### DIFF
--- a/.claude/command-templates/close-issue.md
+++ b/.claude/command-templates/close-issue.md
@@ -1,4 +1,7 @@
+---
+description: Complete and implement a GitHub issue
+argument-hint: <issue-number>
+---
 # Close Issue Command Template
-Complete and implement GitHub issue #{{ ISSUE_NUMBER }}.
 
 {{ INJECT:procedures/close-issue-procedure.md }}

--- a/.claude/command-templates/create-issue.md
+++ b/.claude/command-templates/create-issue.md
@@ -1,4 +1,7 @@
+---
+description: Create a new GitHub issue with intelligent labeling
+argument-hint: [title] [description]
+---
 # Create Issue Command Template
-Create a new GitHub issue with intelligent labeling.
 
 {{ INJECT:procedures/issue-creation-procedure.md }}

--- a/.claude/command-templates/retro.md
+++ b/.claude/command-templates/retro.md
@@ -1,5 +1,7 @@
+---
+description: Mine gleanings through eager evolution of living systems
+---
 # Retro Command Template
-Mine gleanings through eager evolution of living systems.
 
 {{ INJECT:procedures/retro-procedure.md }}
 {{ INJECT:principles/eager-evolution.md }}


### PR DESCRIPTION
## Summary
- Adds YAML frontmatter with description and argument-hint fields to all Claude command templates
- Updates generate-commands.sh to detect and preserve frontmatter during command generation
- Removes duplicate descriptions from template bodies following DRY principle

## Problem Solved
Custom slash commands (`/create-issue`, `/close-issue`, `/retro`) were displaying raw shell commands as descriptions in the Claude Code menu instead of clean, user-friendly descriptions.

## Implementation Details
1. **Command Templates**: Added frontmatter to `.claude/command-templates/`:
   - `create-issue.md`: 
     - description: "Create a new GitHub issue with intelligent labeling"
     - argument-hint: "[title] [description]"
   - `close-issue.md`: 
     - description: "Complete and implement a GitHub issue"
     - argument-hint: "<issue-number>"
   - `retro.md`: 
     - description: "Mine gleanings through eager evolution of living systems"
     - (no argument-hint needed)

2. **Script Update**: Modified `utils/generate-commands.sh` to:
   - Detect frontmatter in generated files
   - Preserve frontmatter and insert logging commands after it
   - Handle files without frontmatter (backward compatible)

3. **DRY Principle**: 
   - Removed duplicate descriptions from template bodies
   - Descriptions now live in ONE place (frontmatter)
   - Cleaner separation of metadata from content

## Test Results
- ✅ Command generation script runs successfully
- ✅ Frontmatter with descriptions and argument hints preserved in all generated commands
- ✅ Logging functionality maintained
- ✅ Backward compatible with commands without frontmatter

Closes #1249