### PR TITLE
fix: use $ARGUMENTS instead of $1 for slash command variables

### DIFF
--- a/.claude/command-templates/close-issue.md
+++ b/.claude/command-templates/close-issue.md
@@ -5,12 +5,12 @@ argument-hint: <issue-number>
 
 ## Issue Context
 
-- Issue details: !`gh issue view $1`
+- Issue details: !`gh issue view $ARGUMENTS`
 
 ## Workspace Setup
 
-!`git worktree add "worktrees/$1-issue" -b "$1-issue"`
-!`cd "worktrees/$1-issue"`
+!`git worktree add "worktrees/$ARGUMENTS-issue" -b "$ARGUMENTS-issue"`
+!`cd "worktrees/$ARGUMENTS-issue"`
 
 # Close Issue Command Template
 


### PR DESCRIPTION
## Summary
Fixes the bash pre-execution variable passing issue in slash commands.

## Problem
The `/close-issue` command was failing because `$1` doesn't work in bash pre-execution - Claude Code uses `$ARGUMENTS` instead.

## Solution
Changed all instances of `$1` to `$ARGUMENTS` in the close-issue template.

## Testing
- The correct variable is documented in Claude Code docs
- `$ARGUMENTS` properly passes the slash command arguments to bash commands
- Worktree creation now works correctly

Closes #1253