### PR TITLE
fix: remove backticks from slash command bash execution

### DIFF
--- a/.claude/command-templates/close-issue.md
+++ b/.claude/command-templates/close-issue.md
@@ -5,12 +5,12 @@ argument-hint: <issue-number>
 
 ## Issue Context
 
-- Issue details: !`gh issue view $1`
+- Issue details: !gh issue view $1
 
 ## Workspace Setup
 
-!`git worktree add "worktrees/$1-issue" -b "$1-issue"`
-!`cd "worktrees/$1-issue"`
+!git worktree add "worktrees/$1-issue" -b "$1-issue"
+!cd "worktrees/$1-issue"
 
 # Close Issue Command Template
 

--- a/.claude/command-templates/create-issue.md
+++ b/.claude/command-templates/create-issue.md
@@ -5,7 +5,7 @@ argument-hint: [title] [description]
 
 ## Available Labels
 
-- Labels: !`gh label list`
+- Labels: !gh label list
 
 # Create Issue Command Template
 


### PR DESCRIPTION
## Summary
Minimal fix to remove backticks from slash command bash execution.

## Problem
Claude Code doesn't expand variables like `$1` inside backticks when using the `\!`command`` syntax. This causes commands like `/close-issue 1235` to fail with:
```
error: unknown switch 's'
```

The issue occurs because the variable isn't expanded, resulting in branch name `-issue` instead of `1235-issue`.

## Solution
Remove backticks from all bash commands in slash command templates:
- `\!`gh issue view $1`` → `\!gh issue view $1`
- `\!`git worktree add "worktrees/$1-issue" -b "$1-issue"`` → `\!git worktree add "worktrees/$1-issue" -b "$1-issue"`
- `\!`cd "worktrees/$1-issue"`` → `\!cd "worktrees/$1-issue"`
- `\!`gh label list`` → `\!gh label list`

## Changes (minimal diff from main)
- `.claude/command-templates/close-issue.md` - Removed backticks only (3 lines)
- `.claude/command-templates/create-issue.md` - Removed backticks only (1 line)

This is the absolute minimal fix - only removing backticks, keeping `$1` variable as-is.

## Test Plan
- [ ] Regenerate slash commands with `./utils/generate-claude-commands.sh`
- [ ] Test `/close-issue 1253` works correctly
- [ ] Verify worktree is created with correct branch name

Closes #1253