### PR TITLE
fix: correct path and validation issues in AI provider configuration scripts

### DIFF
--- a/utils/configure-amazonq.sh
+++ b/utils/configure-amazonq.sh
@@ -49,7 +49,7 @@ cp "$SOURCE_CONFIG" "$TARGET_CONFIG"
 echo "✅ Global context configuration installed"
 
 # Validate
-if [ -L "$TARGET_RULES" ] && [ -f "$TARGET_CONFIG" ]; then
+if [ -L "$TARGET_KNOWLEDGE" ] && [ -f "$TARGET_CONFIG" ]; then
     echo "✅ Amazon Q global rules setup complete"
 else
     echo "❌ Setup validation failed!"

--- a/utils/configure-codex.sh
+++ b/utils/configure-codex.sh
@@ -18,7 +18,7 @@ NC='\033[0m' # No Color
 
 # Get script directory and paths
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-DOTFILES_DIR="$SCRIPT_DIR"
+DOTFILES_DIR="$(dirname "$SCRIPT_DIR")"
 KNOWLEDGE_DIR="$DOTFILES_DIR/knowledge"
 UTILS_DIR="$DOTFILES_DIR/utils"
 CODEX_DIR="$HOME/.codex"


### PR DESCRIPTION
## Summary
- Fixed incorrect path resolution in `configure-codex.sh` 
- Fixed undefined variable in `configure-amazonq.sh` validation check

## Problems Fixed

### 1. Codex Configuration Path Issue
When running `source setup.sh`, configure-codex.sh was failing with:
```
❌ Knowledge directory not found at: /home/linuxmint-lp/ppv/pillars/dotfiles/utils/knowledge
```

### 2. Amazon Q Validation Failure
The configure-amazonq.sh script was always failing validation with:
```
❌ Setup validation failed\!
```

## Solutions

### configure-codex.sh (line 21)
- Before: `DOTFILES_DIR="$SCRIPT_DIR"`
- After: `DOTFILES_DIR="$(dirname "$SCRIPT_DIR")"`

This ensures the knowledge directory is correctly found at the dotfiles root.

### configure-amazonq.sh (line 52)
- Before: `if [ -L "$TARGET_RULES" ] && [ -f "$TARGET_CONFIG" ]; then`
- After: `if [ -L "$TARGET_KNOWLEDGE" ] && [ -f "$TARGET_CONFIG" ]; then`

Fixed undefined variable `$TARGET_RULES` to use the correct `$TARGET_KNOWLEDGE`.

## Test Plan
- [x] Run `bash utils/configure-codex.sh` - completes successfully
- [x] Run `bash utils/configure-amazonq.sh` - completes successfully  
- [x] Run `source setup.sh` - both configurations complete without errors
- [x] Verify AGENTS.md is generated in ~/.codex/
- [x] Verify Amazon Q symlink is created at ~/.amazonq/rules