### PR TITLE
chore(codex): add 4o alias; keep default gpt-5

### DIFF
--- a/.bash_aliases.d/codex.sh
+++ b/.bash_aliases.d/codex.sh
@@ -4,12 +4,11 @@
 # Define the dotfiles location
 DOT_DEN="${DOT_DEN:-$HOME/ppv/pillars/dotfiles}"
 
-# Main alias - default: reasoning-focused 4o
-alias codex='codex -m gpt-4o'
+# Main alias - keep existing default (gpt-5)
+alias codex='codex -m gpt-5'
 
-# Chat-focused alias: empathetic, dialogue-optimized
-# Useful for conversational edits (e.g., refining .md content)
-alias codex-chat='codex -m chatgpt-4o-latest'
+# Optional: 4o variant for dialogue/empathetic tone (useful for .md edits)
+alias codex-4o='codex -m chatgpt-4o-latest'
 
 # Test command - validates knowledge integration
 alias codex-test='codex -p "What is AI provider agnosticism and which three providers have triple redundancy?"'

--- a/.bash_aliases.d/codex.sh
+++ b/.bash_aliases.d/codex.sh
@@ -4,8 +4,12 @@
 # Define the dotfiles location
 DOT_DEN="${DOT_DEN:-$HOME/ppv/pillars/dotfiles}"
 
-# Main alias - specify model via command line
+# Main alias - default: reasoning-focused 4o
 alias codex='codex -m gpt-4o'
+
+# Chat-focused alias: empathetic, dialogue-optimized
+# Useful for conversational edits (e.g., refining .md content)
+alias codex-chat='codex -m chatgpt-4o-latest'
 
 # Test command - validates knowledge integration
 alias codex-test='codex -p "What is AI provider agnosticism and which three providers have triple redundancy?"'

--- a/.bash_aliases.d/codex.sh
+++ b/.bash_aliases.d/codex.sh
@@ -5,7 +5,7 @@
 DOT_DEN="${DOT_DEN:-$HOME/ppv/pillars/dotfiles}"
 
 # Main alias - specify model via command line
-alias codex='codex -m gpt-5'
+alias codex='codex -m gpt-4o'
 
 # Test command - validates knowledge integration
 alias codex-test='codex -p "What is AI provider agnosticism and which three providers have triple redundancy?"'

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -3,7 +3,7 @@
 # Documentation: https://github.com/openai/codex/blob/main/codex-rs/config.md
 
 # Default model configuration
-# Model is specified via command line alias (-m gpt-5)
+# Model is specified via command line alias (-m gpt-4o)
 temperature = 0.7
 max_tokens = 8192  # Match Claude Code's max output tokens for fair comparison
 

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -3,7 +3,7 @@
 # Documentation: https://github.com/openai/codex/blob/main/codex-rs/config.md
 
 # Default model configuration
-# Model is specified via command line alias (-m gpt-4o)
+# Model is specified via command line alias (-m gpt-5)
 temperature = 0.7
 max_tokens = 8192  # Match Claude Code's max output tokens for fair comparison
 

--- a/utils/setup-provider-agnostic-mcp.sh
+++ b/utils/setup-provider-agnostic-mcp.sh
@@ -58,7 +58,7 @@ setup_provider_agnostic_mcp() {
         echo -e "${GREEN}✓ Codex CLI detected - MCP servers configured in TOML${NC}"
         echo -e "  Config: $DOT_DEN/.codex/config.toml"
         echo -e "  Format: TOML with [mcp_servers] sections"
-        echo -e "  Model: gpt-4o (default via alias)"
+        echo -e "  Model: gpt-5-2025-08-07 (default)"
         
         # Sync MCP servers from JSON to TOML if needed
         if [[ -f "$MCP_CONFIG" ]] && command -v jq &> /dev/null; then

--- a/utils/setup-provider-agnostic-mcp.sh
+++ b/utils/setup-provider-agnostic-mcp.sh
@@ -58,7 +58,7 @@ setup_provider_agnostic_mcp() {
         echo -e "${GREEN}✓ Codex CLI detected - MCP servers configured in TOML${NC}"
         echo -e "  Config: $DOT_DEN/.codex/config.toml"
         echo -e "  Format: TOML with [mcp_servers] sections"
-        echo -e "  Model: gpt-5-2025-08-07 (default)"
+        echo -e "  Model: gpt-4o (default via alias)"
         
         # Sync MCP servers from JSON to TOML if needed
         if [[ -f "$MCP_CONFIG" ]] && command -v jq &> /dev/null; then


### PR DESCRIPTION
This PR keeps the default Codex model as gpt-5 (matching current remote behavior) and introduces an optional 4o alias for dialogue-friendly editing.

Changes:
- Restore `.bash_aliases.d/codex.sh` default alias to `gpt-5`
- Add `codex-4o` alias using `chatgpt-4o-latest` for empathetic, conversation-style tasks (e.g., editing Markdown)
- Revert setup message and config comment to reflect gpt-5 as default

Rationale:
- Maintain stability while enabling a convenient chat-optimized mode on demand.