### PR TITLE
chore(codex): rely on global AGENTS.md; remove codex alias

### DIFF
--- a/.bash_aliases.d/codex.sh
+++ b/.bash_aliases.d/codex.sh
@@ -9,28 +9,8 @@ DOT_DEN="${DOT_DEN:-$HOME/ppv/pillars/dotfiles}"
 # - Model selection via Codex defaults or ~/.codex/config.toml
 # - Provider-agnostic, minimal surface area
 
-# Model override helper (per Codex docs: --config key=value)
-codexm() {
-  local model="$1"; shift || true
-  codex --config "model=${model}" "$@"
-}
-
-# Convenience profile for 4o (configured in ~/.codex/config.toml)
+# Convenience alias for 4o profile (configured in ~/.codex/config.toml)
 alias codex-4o='codex --profile gpt4o'
-
-# Model override helper using supported config override syntax
-# Usage:
-#   codexm <model> [prompt or flags...]
-# Examples:
-#   codexm chatgpt-4o-latest "Rewrite empathetically"
-#   codexm gpt-5 "Summarize this diff"
-codexm() {
-  local model="$1"; shift || true
-  codex --config "model=${model}" "$@"
-}
-
-# Convenience alias for 4o model (dialogue/empathetic tone)
-alias codex-4o='codex --config model=chatgpt-4o-latest'
 
 # Test command - validates knowledge integration (positional prompt)
 alias codex-test='codex "What is AI provider agnosticism and which three providers have triple redundancy?"'

--- a/.bash_aliases.d/codex.sh
+++ b/.bash_aliases.d/codex.sh
@@ -9,6 +9,29 @@ DOT_DEN="${DOT_DEN:-$HOME/ppv/pillars/dotfiles}"
 # - Model selection via Codex defaults or ~/.codex/config.toml
 # - Provider-agnostic, minimal surface area
 
+# Model override helper (per Codex docs: --config key=value)
+codexm() {
+  local model="$1"; shift || true
+  codex --config "model=${model}" "$@"
+}
+
+# Convenience profile for 4o (configured in ~/.codex/config.toml)
+alias codex-4o='codex --profile gpt4o'
+
+# Model override helper using supported config override syntax
+# Usage:
+#   codexm <model> [prompt or flags...]
+# Examples:
+#   codexm chatgpt-4o-latest "Rewrite empathetically"
+#   codexm gpt-5 "Summarize this diff"
+codexm() {
+  local model="$1"; shift || true
+  codex --config "model=${model}" "$@"
+}
+
+# Convenience alias for 4o model (dialogue/empathetic tone)
+alias codex-4o='codex --config model=chatgpt-4o-latest'
+
 # Test command - validates knowledge integration (positional prompt)
 alias codex-test='codex "What is AI provider agnosticism and which three providers have triple redundancy?"'
 

--- a/.bash_aliases.d/codex.sh
+++ b/.bash_aliases.d/codex.sh
@@ -4,14 +4,13 @@
 # Define the dotfiles location
 DOT_DEN="${DOT_DEN:-$HOME/ppv/pillars/dotfiles}"
 
-# Main alias - keep existing default (gpt-5)
-alias codex='codex -m gpt-5'
+# No default alias for `codex`:
+# - Avoids masking the real binary and version-specific flags
+# - Model selection via Codex defaults or ~/.codex/config.toml
+# - Provider-agnostic, minimal surface area
 
-# Optional: 4o variant for dialogue/empathetic tone (useful for .md edits)
-alias codex-4o='codex -m chatgpt-4o-latest'
-
-# Test command - validates knowledge integration
-alias codex-test='codex -p "What is AI provider agnosticism and which three providers have triple redundancy?"'
+# Test command - validates knowledge integration (positional prompt)
+alias codex-test='codex "What is AI provider agnosticism and which three providers have triple redundancy?"'
 
 # Update knowledge command - regenerates AGENTS.md from knowledge base
 alias codex-update-knowledge='$DOT_DEN/utils/generate-codex-knowledge.sh'

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -54,14 +54,8 @@ preferred_auth_method = "chatgpt"
 # Docs: https://github.com/openai/codex/blob/main/docs/config.md
 # -----------------------------------------------------------------------------
 
-# Define an OpenAI Chat Completions provider and a profile for GPT‑4o.
+# Minimal profile for GPT‑4o (uses built-in OpenAI provider defaults)
 # Invoke with: codex --profile gpt4o "..."
-
-[model_providers.openai-chat-completions]
-name = "OpenAI using Chat Completions"
-base_url = "https://api.openai.com/v1"
-wire_api = "chat"
 
 [profiles.gpt4o]
 model = "gpt-4o"
-model_provider = "openai-chat-completions"

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -34,12 +34,7 @@ env = { FASTMCP_LOG_LEVEL = "ERROR" }
 # args = ["-y", "@modelcontextprotocol/server-github"]
 # env = { GITHUB_TOKEN = "$GITHUB_TOKEN" }
 
-# Fallback models for resilience
-fallback_models = [
-    "gpt-4-turbo",
-    "gpt-4",
-    "gpt-3.5-turbo"
-]
+## Note: no fallback_models here — rely on Codex's own defaults/selection.
 
 # Integration settings
 [integrations]
@@ -50,6 +45,9 @@ git_auto_commit = false
 [permissions]
 allow = ["read", "write", "execute", "mcp"]
 deny = ["network:external", "system:critical"]
+
+# Use ChatGPT subscription-based auth (no API keys)
+preferred_auth_method = "chatgpt"
 
 # -----------------------------------------------------------------------------
 # Model providers and profiles (per Codex docs)
@@ -62,7 +60,6 @@ deny = ["network:external", "system:critical"]
 [model_providers.openai-chat-completions]
 name = "OpenAI using Chat Completions"
 base_url = "https://api.openai.com/v1"
-env_key = "OPENAI_API_KEY"
 wire_api = "chat"
 
 [profiles.gpt4o]

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -50,3 +50,21 @@ git_auto_commit = false
 [permissions]
 allow = ["read", "write", "execute", "mcp"]
 deny = ["network:external", "system:critical"]
+
+# -----------------------------------------------------------------------------
+# Model providers and profiles (per Codex docs)
+# Docs: https://github.com/openai/codex/blob/main/docs/config.md
+# -----------------------------------------------------------------------------
+
+# Define an OpenAI Chat Completions provider and a profile for GPT‑4o.
+# Invoke with: codex --profile gpt4o "..."
+
+[model_providers.openai-chat-completions]
+name = "OpenAI using Chat Completions"
+base_url = "https://api.openai.com/v1"
+env_key = "OPENAI_API_KEY"
+wire_api = "chat"
+
+[profiles.gpt4o]
+model = "gpt-4o"
+model_provider = "openai-chat-completions"


### PR DESCRIPTION
Summary
- Remove default codex alias; avoid masking binary and version-specific flags
- Keep helpers: codex-test and codex-update-knowledge
- Minimal model selection: use profiles only (no custom providers)
- Cleanup: remove non-working `fallback_models`, omit `env_key`, prefer ChatGPT auth

Config changes (~/.codex/config.toml)
- Add [profiles.gpt4o] with model = "gpt-4o"
- Remove [model_providers.*] block (rely on built-in OpenAI provider defaults)
- Remove `fallback_models` block (rely on Codex defaults)
- Do not specify `env_key` (we use ChatGPT subscriptions, not API keys)
- Set `preferred_auth_method = "chatgpt"` (align with subscription auth)

Shell helpers (.bash_aliases.d/codex.sh)
- codex-4o: `codex --profile gpt4o`
- codex-test: quick sanity check (AI provider agnosticism)
- codex-update-knowledge: regenerate `~/.codex/AGENTS.md`

Why
- Use documented mechanisms: profiles and TOML config
- Avoid brittle CLI flags/functions; keep provider-agnostic, minimal surface area
- No API keys: subscription-based auth via `codex login` only
- Subtraction creates value: less config, same capability

Verify
- `source ~/.bashrc`
- `codex-test` (should answer from knowledge)
- `codex-4o "Rewrite empathetically"`
- `codex-update-knowledge` (regenerates `~/.codex/AGENTS.md`)

Docs
- https://github.com/openai/codex/blob/main/docs/config.md
