### PR TITLE
feat(mcp): route Playwright MCP through Patchright by default

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -23,8 +23,8 @@ log_file = "~/.codex/logs/codex.log"
 # Note: Codex uses 'mcp_servers' (underscore) not 'mcpServers' (camelCase)
 
 [mcp_servers.playwright]
-command = "npx"
-args = ["@playwright/mcp@latest"]
+command = "/home/linuxmint-lp/ppv/pillars/dotfiles/mcp/patchright-playwright-mcp.sh"
+args = []
 env = { FASTMCP_LOG_LEVEL = "ERROR" }
 
 # Additional MCP servers can be added here

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -23,7 +23,7 @@ log_file = "~/.codex/logs/codex.log"
 # Note: Codex uses 'mcp_servers' (underscore) not 'mcpServers' (camelCase)
 
 [mcp_servers.playwright]
-command = "/home/linuxmint-lp/ppv/pillars/dotfiles/mcp/patchright-playwright-mcp.sh"
+command = "patchright-playwright-mcp"
 args = []
 env = { FASTMCP_LOG_LEVEL = "ERROR" }
 

--- a/mcp/mcp.json
+++ b/mcp/mcp.json
@@ -1,10 +1,8 @@
 {
   "mcpServers": {
     "playwright": {
-      "command": "npx",
-      "args": [
-        "@playwright/mcp@latest"
-      ],
+      "command": "/home/linuxmint-lp/ppv/pillars/dotfiles/mcp/patchright-playwright-mcp.sh",
+      "args": [],
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"
       }

--- a/mcp/mcp.json
+++ b/mcp/mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "playwright": {
-      "command": "/home/linuxmint-lp/ppv/pillars/dotfiles/mcp/patchright-playwright-mcp.sh",
+      "command": "patchright-playwright-mcp",
       "args": [],
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"

--- a/mcp/patchright-playwright-mcp.sh
+++ b/mcp/patchright-playwright-mcp.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Wrapper to launch Playwright MCP through Patchright by default.
+#
+# Behavior:
+# - Default enables Patchright shim by setting NODE_PATH to the shim dir
+# - Opt-out by setting USE_PATCHRIGHT=0 or USE_PATCHRIGHT=false
+# - Optional debug: USE_PATCHRIGHT_DEBUG=1 prints shim activation to stderr
+# - Override underlying command with PLAYWRIGHT_MCP_CMD if needed
+
+USE_PATCHRIGHT="${USE_PATCHRIGHT:-1}"
+if [[ "${USE_PATCHRIGHT}" != "0" && "${USE_PATCHRIGHT,,}" != "false" ]]; then
+  export NODE_PATH="/home/linuxmint-lp/ppv/pillars/dotfiles/mcp/patchright-shim/node_modules${NODE_PATH+:$NODE_PATH}"
+  export USE_PATCHRIGHT_DEBUG="${USE_PATCHRIGHT_DEBUG:-0}"
+fi
+
+CMD="${PLAYWRIGHT_MCP_CMD:-npx}"
+
+if [[ "$CMD" == "npx" ]]; then
+  exec npx "@playwright/mcp@latest" "$@"
+else
+  exec "$CMD" "$@"
+fi
+

--- a/mcp/patchright-playwright-mcp.sh
+++ b/mcp/patchright-playwright-mcp.sh
@@ -9,9 +9,13 @@ set -euo pipefail
 # - Optional debug: USE_PATCHRIGHT_DEBUG=1 prints shim activation to stderr
 # - Override underlying command with PLAYWRIGHT_MCP_CMD if needed
 
+# Resolve repository-local paths dynamically (no hardcoded absolute paths)
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
+SHIM_NODE_MODULES="$SCRIPT_DIR/patchright-shim/node_modules"
+
 USE_PATCHRIGHT="${USE_PATCHRIGHT:-1}"
 if [[ "${USE_PATCHRIGHT}" != "0" && "${USE_PATCHRIGHT,,}" != "false" ]]; then
-  export NODE_PATH="/home/linuxmint-lp/ppv/pillars/dotfiles/mcp/patchright-shim/node_modules${NODE_PATH+:$NODE_PATH}"
+  export NODE_PATH="${SHIM_NODE_MODULES}${NODE_PATH+:$NODE_PATH}"
   export USE_PATCHRIGHT_DEBUG="${USE_PATCHRIGHT_DEBUG:-0}"
 fi
 
@@ -22,4 +26,3 @@ if [[ "$CMD" == "npx" ]]; then
 else
   exec "$CMD" "$@"
 fi
-

--- a/mcp/patchright-shim/node_modules/playwright/index.js
+++ b/mcp/patchright-shim/node_modules/playwright/index.js
@@ -1,0 +1,17 @@
+'use strict';
+
+// Patchright shim for Playwright
+// When NODE_PATH includes this directory, any require('playwright')
+// will resolve to Patchright instead, enabling undetectable Chromium.
+
+if (process.env.USE_PATCHRIGHT_DEBUG === '1') {
+  try {
+    // eslint-disable-next-line no-console
+    console.error('[patchright-shim] Replacing require("playwright") with Patchright');
+  } catch (_) {
+    // ignore if console unavailable in host
+  }
+}
+
+module.exports = require('patchright');
+

--- a/mcp/setup-all-mcp-servers.sh
+++ b/mcp/setup-all-mcp-servers.sh
@@ -58,6 +58,15 @@ done
 # Create servers directory if it doesn't exist
 mkdir -p "$MCP_DIR/servers"
 
+# Ensure patchright-playwright-mcp is available on PATH for portability
+WRAPPER_SRC="$MCP_DIR/patchright-playwright-mcp.sh"
+DEST_DIR="${HOME}/.local/bin"
+DEST_LINK="${DEST_DIR}/patchright-playwright-mcp"
+mkdir -p "${DEST_DIR}"
+if [ ! -e "${DEST_LINK}" ]; then
+    ln -s "${WRAPPER_SRC}" "${DEST_LINK}" || true
+fi
+
 # Summary
 echo -e "\n${GREEN}MCP Server Setup Summary:${NC}"
 echo "- Working directory: $REPO_ROOT"


### PR DESCRIPTION
feat(mcp): route Playwright MCP through Patchright by default

Summary
- Make Patchright the default undetectable backend for any Playwright MCP usage launched via dotfiles.
- Non-invasive: implemented as shim + wrapper; no app code changes.

Changes
- Add Patchright shim that intercepts require('playwright') → Patchright.
- Add wrapper script and point Playwright MCP to it in configs:
  - mcp/mcp.json, .mcp.json
  - .codex/config.toml
- Default enabled; provide simple opt-out flag.

Usage
- Default: Patchright enabled.
- Opt-out: set USE_PATCHRIGHT=0 (or false) to use vanilla Playwright.
- Optional debug: USE_PATCHRIGHT_DEBUG=1 prints shim activation to stderr.

Dependencies (not auto-installed)
- Install Patchright in shim dir and Chromium once:
  - cd mcp/patchright-shim && npm init -y && npm i patchright
  - npx patchright install chromium
- Playwright MCP can run via npx (current config) or be installed locally if desired.

Verification
- List MCP tools to confirm server runs via wrapper.
- Navigate to about:blank and screenshot using mcp__playwright__* tools.

Notes
- No references to private apps; this is general dotfiles MCP wiring.
- Flag-driven approach keeps behavior reversible and minimal.
