### PR TITLE
chore(workflows): gate Claude workflows behind repo variable

### DIFF
--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -6,6 +6,10 @@ on:
 
 jobs:
   triage-issue:
+    # Gate: only run when Claude Code is explicitly enabled
+    # Enable by setting repo variable: CLAUDE_CODE_SUBSCRIPTION=active
+    # Also requires OAuth token to be present
+    if: ${{ vars.CLAUDE_CODE_SUBSCRIPTION == 'active' && secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/auto-trigger-claude.yml
+++ b/.github/workflows/auto-trigger-claude.yml
@@ -6,6 +6,10 @@ on:
 
 jobs:
   auto-trigger-claude:
+    # Gate: only run when Claude Code is explicitly enabled
+    # Enable by setting repo variable: CLAUDE_CODE_SUBSCRIPTION=active
+    # Also requires PAT secret to exist (prevents unsolicited comments)
+    if: ${{ vars.CLAUDE_CODE_SUBSCRIPTION == 'active' && secrets.CLAUDE_TRIGGER_PAT != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 2
     permissions:


### PR DESCRIPTION
This PR makes Claude-related workflows inert by default.

Changes:
- Add job-level `if` to both workflows: `${{ vars.CLAUDE_CODE_SUBSCRIPTION == 'active' }}`
- Also require corresponding secrets present (prevents accidental runs)

How to enable later:
- Set repo variable: `CLAUDE_CODE_SUBSCRIPTION=active` (Settings → Actions → Variables)
- Ensure secrets exist:
  - `CLAUDE_CODE_OAUTH_TOKEN` for auto-label triage
  - `CLAUDE_TRIGGER_PAT` for auto-trigger comments

Optional hardening (not included):
- Add per-issue label gate: `contains(github.event.issue.labels.*.name, 'claude-auto')`

This keeps automation quiet while unsubscribed and easy to re-enable later.
