### PR TITLE
feat(mcp): default Patchright backend for Playwright MCP

### DIFF
--- a/mcp/mcp.json
+++ b/mcp/mcp.json
@@ -1,10 +1,8 @@
 {
   "mcpServers": {
     "playwright": {
-      "command": "npx",
-      "args": [
-        "@playwright/mcp@latest"
-      ],
+      "command": "patchright-playwright-mcp",
+      "args": [],
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"
       }

--- a/mcp/patchright-shim/node_modules/playwright/index.js
+++ b/mcp/patchright-shim/node_modules/playwright/index.js
@@ -1,0 +1,4 @@
+// Patchright shim for Playwright
+// Resolves require('playwright') to Patchright at runtime.
+module.exports = require('patchright');
+

--- a/mcp/servers/patchright-playwright-mcp
+++ b/mcp/servers/patchright-playwright-mcp
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Wrapper to run @playwright/mcp with Patchright as the default backend.
+# Opt out by setting USE_PATCHRIGHT=0 or USE_PATCHRIGHT=false
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# mcp/servers -> repo root is ../..
+DOT_DEN="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+USE_PATCHRIGHT_VAL="${USE_PATCHRIGHT:-1}"
+if [[ "$USE_PATCHRIGHT_VAL" != "0" && "$USE_PATCHRIGHT_VAL" != "false" ]]; then
+  # Prepend shim node_modules so require('playwright') resolves to Patchright
+  export NODE_PATH="${DOT_DEN}/mcp/patchright-shim/node_modules${NODE_PATH:+:$NODE_PATH}"
+fi
+
+# Execute the community Playwright MCP server
+exec npx @playwright/mcp@latest "$@"
+

--- a/mcp/setup-patchright-shim.sh
+++ b/mcp/setup-patchright-shim.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install Patchright into the local shim so Playwright resolves to Patchright
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SHIM_DIR="$SCRIPT_DIR/patchright-shim"
+
+mkdir -p "$SHIM_DIR"
+
+if [[ ! -f "$SHIM_DIR/package.json" ]]; then
+  (cd "$SHIM_DIR" && npm init -y >/dev/null 2>&1)
+fi
+
+echo "Installing patchright into $SHIM_DIR ..."
+(cd "$SHIM_DIR" && npm install patchright --silent)
+
+echo "Patchright shim ready. Optional: download Chromium once with:\n  npx patchright install chromium"
+


### PR DESCRIPTION
Summary
Default the Playwright MCP server to use an undetectable backend by shimming `require('playwright')` to Patchright, while continuing to run the community `@playwright/mcp` server.

What changed
- Added shim: `mcp/patchright-shim/node_modules/playwright/index.js` resolves Playwright to Patchright.
- Added wrapper: `mcp/servers/patchright-playwright-mcp` sets `NODE_PATH` to the shim (opt‑out with `USE_PATCHRIGHT=0|false`) and executes `npx @playwright/mcp@latest`.
- Updated config: `mcp/mcp.json` now points the Playwright server to the wrapper command.
- Added helper setup: `mcp/setup-patchright-shim.sh` installs the `patchright` package locally in the shim.

Usage
- Default ON: Wrapper enables the shim automatically.
- Toggle OFF: `USE_PATCHRIGHT=0` (or `false`) before launching clients.

Notes
- This keeps the community Playwright MCP server intact; no forks.
- No consumer code changes required; resolution happens via `NODE_PATH`.

Follow‑ups (optional)
- First‑time chromium download: `npx patchright install chromium`.
- If any clients don’t inherit PATH, we can add a per‑client launcher pointing to `mcp/servers/patchright-playwright-mcp`.

Closes #1263
