### PR TITLE
feat(shell): default Patchright for Playwright via NODE_PATH alias

### DIFF
--- a/.bash_exports
+++ b/.bash_exports
@@ -28,3 +28,14 @@ fi
 if [ -f "$HOME/ppv/pillars/dotfiles/flywire-notes/bash-config.sh" ]; then
     source "$HOME/ppv/pillars/dotfiles/flywire-notes/bash-config.sh"
 fi
+\n+# Default Patchright backend for Playwright (global, non-intrusive)
+# If a user-level module alias exists at ~/.config/node-module-alias/node_modules,
+# add it to NODE_PATH so that require('playwright') resolves to Patchright.
+# This avoids wrapper scripts and per-repo code changes.
+export PATCHRIGHT_MODULE_ROOT="$HOME/.config/node-module-alias/node_modules"
+if [ -d "$PATCHRIGHT_MODULE_ROOT" ]; then
+    case :$NODE_PATH: in
+        *:$PATCHRIGHT_MODULE_ROOT:*) ;;
+        *) export NODE_PATH="$PATCHRIGHT_MODULE_ROOT:${NODE_PATH}" ;;
+    esac
+fi

--- a/.bash_exports
+++ b/.bash_exports
@@ -28,6 +28,7 @@ fi
 if [ -f "$HOME/ppv/pillars/dotfiles/flywire-notes/bash-config.sh" ]; then
     source "$HOME/ppv/pillars/dotfiles/flywire-notes/bash-config.sh"
 fi
+
 # Default Patchright backend for Playwright (global, non-intrusive)
 # If a user-level module alias exists at ~/.config/node-module-alias/node_modules,
 # add it to NODE_PATH so that require('playwright') resolves to Patchright.

--- a/.bash_exports
+++ b/.bash_exports
@@ -28,7 +28,7 @@ fi
 if [ -f "$HOME/ppv/pillars/dotfiles/flywire-notes/bash-config.sh" ]; then
     source "$HOME/ppv/pillars/dotfiles/flywire-notes/bash-config.sh"
 fi
-\n+# Default Patchright backend for Playwright (global, non-intrusive)
+# Default Patchright backend for Playwright (global, non-intrusive)
 # If a user-level module alias exists at ~/.config/node-module-alias/node_modules,
 # add it to NODE_PATH so that require('playwright') resolves to Patchright.
 # This avoids wrapper scripts and per-repo code changes.


### PR DESCRIPTION
- What: Add NODE_PATH so require('playwright') resolves to Patchright when a user-level alias exists. No wrappers. No per-repo code edits.
- Why: Undetectable CDP/stealth benefits across all tools (incl. @playwright/mcp). Reduces cognitive load; always-on by default.
- Scope: One small block in dotfiles/.bash_exports. Alias directory lives outside the repo.
- Opt-out: unset NODE_PATH or remove ~/.config/node-module-alias.
- Follow-up (optional): npx patchright install chrome for better stealth.

Closes #1263
