### PR TITLE
fix: remove forced navigation to dotfiles directory in .bashrc

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -156,11 +156,6 @@ if [[ -n "$SSH_CONNECTION" ]]; then
     # This prevents recursive loops when connecting to localhost
     :
 else
-    # Only change to dotfiles directory when NOT in a tmux session (only in interactive shells)
-    if [[ $- == *i* ]] && [ -z "$TMUX" ] && [ -d "$DOT_DEN" ]; then
-        cd "$DOT_DEN" || true
-    fi
-
     # Source Amazon Q environment if installed
     if [ -f "$HOME/.local/bin/env" ]; then
         . "$HOME/.local/bin/env"


### PR DESCRIPTION
## Summary
- Removes the automatic `cd` to `ppv/pillars/dotfiles` that occurred when opening new shells outside tmux
- Restores default behavior where new tmux panes open in the current working directory

## Problem
When opening a new tmux pane, it was automatically navigating to the dotfiles directory regardless of the current working directory. This was undesirable behavior that overrode the default tmux behavior.

## Solution
Removed lines 159-162 from `.bashrc` that contained:
```bash
# Only change to dotfiles directory when NOT in a tmux session (only in interactive shells)
if [[ $- == *i* ]] && [ -z "$TMUX" ] && [ -d "$DOT_DEN" ]; then
    cd "$DOT_DEN" || true
fi
```

The `DOT_DEN` variable (line 148) is kept as it's still used for PATH configuration.

## Test Plan
- [x] Open a new terminal - it should stay in the current directory
- [x] Open new tmux panes - they should open in the current working directory
- [x] Verify PATH still includes `$DOT_DEN/bin` for scripts

Closes #1276