### PR TITLE
feat: add Bash(ls:*) to Claude Code permissions allow list

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -36,6 +36,7 @@
       "Bash(python:*)",
       "Bash(git:*)",
       "Bash(gh:*)",
+      "Bash(ls:*)",
       "Bash(tmux display-message \"[A-Za-z0-9\\s\\-_.:!?,]+\")",
       "mcp__playwright"
     ],


### PR DESCRIPTION
## Summary
- Added `Bash(ls:*)` to the permissions allow list in `.claude/settings.json`
- This allows ls commands to run without prompting for permission

## Test plan
- [x] Added `Bash(ls:*)` to allow list
- [x] Tested various ls commands work without prompts:
  - Simple `ls` commands
  - `ls` with options like `-la`
  - `ls` in pipelines with grep

Closes #1294