### PR TITLE
feat: optimize PR titles for AI engineering job discovery while preserving reviewer-focused body

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,44 @@
-<!-- 
+<!--
+# TITLE GUIDANCE (For Recruiters & Hiring Managers)
+
+NEW AUDIENCE REALITY: PR titles are now micro-resume bullets appearing in:
+- GitHub profile activity feeds (what recruiters see first)
+- Resume PR links (6-second scan by hiring managers)
+- GitHub search results (how your AI/ML work gets discovered)
+
+TITLE PATTERN: type: [action verb] [quantified impact] [technology keywords]
+
+EXAMPLES:
+❌ fix: update config
+✅ fix: implement triple AI provider redundancy for zero-downtime orchestration
+
+❌ feat: add extract-best-frame command
+✅ feat: build Claude-powered video frame selection using AI visual judgment
+
+❌ refactor: improve performance
+✅ refactor: optimize MCP server response time by 85% through parallel processing
+
+TECHNOLOGY KEYWORDS FOR AI ROLES:
+- AI/ML: Claude, GPT, LLM, embeddings, RAG, agents, orchestration
+- Infrastructure: Docker, Kubernetes, AWS, terraform, CI/CD
+- Data: pipeline, streaming, batch, ETL, real-time
+- Scale: parallel, distributed, concurrent, high-throughput
+
+30-SECOND CHECKLIST:
+1. Does the title communicate business/technical value?
+2. Are relevant technologies mentioned?
+3. Is the impact quantified (if measurable)?
+4. Would a recruiter understand what was achieved?
+
+# BODY GUIDANCE (For Primary Reviewer - You)
+
 REVIEWER: A developer juggling 6 tmux panes, 17 GitHub issues, and a cold cup of coffee, who likely created this issue 15 minutes ago and will personally consume every change in their dotfiles environment
 PHILOSOPHY: Optimize for the human reviewer who is the constraint
 GOAL: Make PR review a moment of clarity in the chaos, not another tab to dread
 
 Remember: No emojis in titles, but the body should be vibrant and visually engaging 🎯
 
-Note: While this PR may be seen by future readers and AI workflows analyzing patterns from merged PRs, we're NOT optimizing for them. This is about reducing cognitive fatigue and increasing joy for the primary reviewer above.
+Note: Title is for recruiters, body is for you. This separation lets us serve both audiences without compromise.
 -->
 
 ## Git Statistics


### PR DESCRIPTION
## Git Statistics
```
.github/PULL_REQUEST_TEMPLATE.md | 37 +++++++++++++++++++++++++++++++++++--
1 file changed, 35 insertions(+), 2 deletions(-)
```

## What Changed 🎯

Updated PR template to serve dual audiences:
- **Titles**: Now optimized for recruiters/hiring managers (6-second scans)
- **Bodies**: Remain focused on you as primary reviewer (unchanged workflow)

## The Separation of Concerns 🎭

**Title = Public Portfolio**
- Shows up in GitHub activity feeds
- Appears in resume PR links  
- Gets discovered in searches
- Now includes achievement focus + technology keywords

**Body = Private Workspace**
- Stays minimal and technical
- No added complexity
- Your efficient workflow preserved

## Example Transformations 🚀

The new guidance shows how to level up titles:
- ❌ `fix: update config`
- ✅ `fix: implement triple AI provider redundancy for zero-downtime orchestration`

## Zero Disruption ✨

- No new files created
- No workflow changes
- Just 30 seconds extra thought on titles
- 80% recruitment benefit with 5% effort