### PR TITLE
Provider-agnostic close-issue via Command Lexicon

### DIFF
--- a/docs/procedures/issue-to-pr-detailed-workflow.md
+++ b/docs/procedures/issue-to-pr-detailed-workflow.md
@@ -21,10 +21,11 @@ Every task starts as a GitHub issue:
 
 ### 2. Planning Mode Review
 
-Run `/close-issue <number>` with planning mode (default):
-- Claude analyzes the issue
-- Presents a plan for review
-- You approve, refine, or reject
+Invoke the Close Issue workflow using natural language (provider‑agnostic). Examples:
+- `close-issue <number>`
+- "use the close-issue procedure to close GitHub issue <number>"
+
+The agent analyzes the issue, presents a plan for review, and you approve, refine, or reject.
 
 **Key insight**: This shifts you from "driving" to "managing" - you review plans, not implementation details.
 
@@ -104,3 +105,4 @@ Planning mode should be enabled by default for all users:
 
 - [tmux + git worktrees + Claude Code + Planning Mode](../../knowledge/procedures/tmux-git-worktrees-claude-code.md) - The complete productivity system
 - [OSE Principle](../../knowledge/principles/ose.md) - Why this workflow embodies management over doing
+- [Command Lexicon](../../knowledge/procedures/command-lexicon.md) - Natural language command mapping

--- a/knowledge/procedures/README.md
+++ b/knowledge/procedures/README.md
@@ -17,7 +17,8 @@ This is THE workflow. Everything else supports this core process.
 - `tmux-git-worktrees-claude-code.md` - The 100x productivity system with planning mode
 - `git-workflow.md` - Git conventions and branch management  
 - `worktree-workflow.md` - Git worktree isolation for parallel development
-- `slash-command-generation.md` - How slash commands like `/close-issue` work
+- `command-lexicon.md` - Provider-agnostic natural language command mapping
+- `slash-command-generation.md` - Optional wrappers for commands like `/close-issue`
 
 ### Quality & Improvement
 - `retro-procedure.md` - Systems improvement retro and learning extraction
@@ -35,3 +36,11 @@ This is THE workflow. Everything else supports this core process.
 
 ### Tips & Setup
 - `claude-code-tips.md` - Tips and shortcuts for Claude Code
+
+## Natural Language Invocation
+
+Procedures can be invoked via natural language in any AI provider that loads the knowledge base. For example:
+- "close-issue 123" → maps via Command Lexicon to Close Issue Procedure
+- "use the close-issue procedure to close GitHub issue 123" → same outcome
+
+This removes dependency on provider-specific slash commands while keeping them available as optional wrappers.

--- a/knowledge/procedures/close-issue-procedure.md
+++ b/knowledge/procedures/close-issue-procedure.md
@@ -16,6 +16,22 @@
 #
 # Principle: systems-stewardship (single source of truth, documentation as code)
 
+## Invocation (Provider-Agnostic)
+- Command: "close-issue <number>" (also accepts "close issue <number>")
+- Arguments:
+  - <number>: GitHub issue number
+- Parsing rule: Use the first integer token appearing after the command phrase. If missing or ambiguous, ask the user to confirm the issue number.
+
+Examples:
+- "close-issue 583"
+- "use the close-issue procedure to close GitHub issue 583"
+- "please close issue #583"
+
+Provider Notes:
+- Ask for approval prior to running shell commands
+- Prefer absolute file paths when possible
+- Use Git worktrees for isolation (see Worktree Workflow)
+
 Complete and implement GitHub issue #{{ ISSUE_NUMBER }}.
 
 {{ KNOWLEDGE_BASE }}

--- a/knowledge/procedures/command-lexicon.md
+++ b/knowledge/procedures/command-lexicon.md
@@ -1,0 +1,20 @@
+# Command Lexicon
+
+Provider-agnostic mapping from natural language commands to procedures. Enables using the same commands in Claude Code and OpenAI Codex without relying on provider-specific slash commands.
+
+## close-issue
+- Intent: Complete and implement a GitHub issue and open a PR that references the issue.
+- Invocation: "close-issue <number>" (also accepts "close issue <number>")
+- Arguments:
+  - <number>: GitHub issue number (parsing rule: the first integer token after the command phrase)
+- Variants:
+  - "close issue 123"
+  - "close-issue 123"
+  - "use the close-issue procedure to close GitHub issue 123"
+  - "please close issue #123"
+- Procedure: [close-issue-procedure.md](close-issue-procedure.md)
+- Provider notes:
+  - Ask for approval before executing shell commands
+  - Use absolute paths and follow the Git Worktree Workflow
+  - Ensure PR title/body reference "Closes #<number>"
+


### PR DESCRIPTION
Implements provider-agnostic invocation for Close Issue:

- Natural language commands (e.g., 'close-issue 123') map via Command Lexicon
- Updated procedure with invocation, parsing rule, and provider notes
- Docs updated to prefer NL over provider-specific slash commands

Closes #1307