### PR TITLE
feat: two-round frame selection and close-issue docs clarification

### DIFF
--- a/knowledge/procedures/close-issue-procedure.md
+++ b/knowledge/procedures/close-issue-procedure.md
@@ -1,5 +1,8 @@
 # Close Issue Procedure
-# 
+#
+# IMPORTANT: This procedure creates a Pull Request that will auto-close the issue when merged.
+# It does NOT directly close the issue - GitHub closes it automatically via PR merge.
+#
 # This IS the implementation - the procedure documents itself by being the code.
 # Used by both:
 # - Local /close-issue command (via relative path injection)
@@ -47,6 +50,12 @@ Build the solution using tracer bullets - get something working first, then iter
 ## Creating the Pull Request
 
 **IMPORTANT**: This procedure outputs a GitHub Pull Request. The PR must be created, not just planned.
+
+**KEY WORKFLOW**:
+- Create commits with "Closes #issue-number" in the message
+- Create the Pull Request linking to the issue
+- The issue will be automatically closed when the PR is merged
+- Do NOT manually close the issue yourself
 
 See `.github/PULL_REQUEST_TEMPLATE.md` for complete guidance on title patterns and body sections.
 

--- a/knowledge/procedures/extract-best-frame-procedure.md
+++ b/knowledge/procedures/extract-best-frame-procedure.md
@@ -54,6 +54,30 @@ The selection process:
 3. Continue until one frame remains
 4. That frame is saved as the best selfie
 
+## Step 4b: Round 2 - Fine-Grained Selection
+
+After identifying the best frame from Round 1, perform fine-grained refinement:
+
+Calculate the timestamp of the Round 1 winner and extract refined frames:
+!WINNER_NUMBER=$(echo "$BEST_FRAME" | grep -o '[0-9]\+')
+!WINNER_TIME=$((WINNER_NUMBER * 2))  # Since we extracted at 0.5 fps (every 2 seconds)
+!START_TIME=$((WINNER_TIME - 1))
+!mkdir -p "$FRAMES_DIR/round2"
+
+Extract 20 frames at 0.1-second intervals around the winner (±1 second window):
+!ffmpeg -ss $START_TIME -i "$VIDEO_PATH" -t 2 -vf "fps=10" -q:v 2 "$FRAMES_DIR/round2/refined_%03d.jpg" -loglevel error
+!echo "Extracted $(ls -1 "$FRAMES_DIR"/round2/*.jpg | wc -l) refined frames for Round 2"
+
+[Claude will compare the refined frames to find the absolute best moment, capturing micro-expressions and perfect timing]
+
+The refined selection captures:
+- Peak facial expressions and smiles
+- Optimal muscle definition moments
+- Perfect food/cooking action shots
+- Ideal environmental atmosphere
+
+!echo "Round 2 complete: Found best frame with sub-second precision"
+
 ## Step 5: Save the Best Frame
 
 After the selection process, the winning frame will be copied to the output directory:


### PR DESCRIPTION
## Summary
- Implements two-round tournament for extract-best-frame procedure
- Clarifies close-issue procedure documentation

## Changes

### 1. Two-Round Tournament Enhancement
Added Round 2 fine-grained selection to capture perfect moments with sub-second precision.

### 2. Documentation Clarification
Updated close-issue procedure to explicitly state it creates PRs for auto-closure, not direct issue closure.

## Issues Resolved
- Closes #1315 (Two-round tournament feature)
- Closes #1316 (Documentation clarification)

## Test Plan
✅ Tested two-round frame extraction on video file
✅ Successfully extracted refined frames at 0.1-second intervals
✅ Identified superior frame with micro-expression capture