### PR TITLE
fix: remove obsolete command generation infrastructure from setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -283,17 +283,8 @@ fi
 
 # GitLab MCP server works via GITLAB_PERSONAL_ACCESS_TOKEN - no glab CLI setup needed
 
-# Generate AI provider commands from templates
-if [[ -f "$DOT_DEN/utils/generate-commands.sh" ]]; then
-  echo "Generating AI provider commands from templates..."
-  "$DOT_DEN/utils/generate-commands.sh"
-elif [[ -f "$DOT_DEN/utils/generate-claude-commands.sh" ]]; then
-  # Fallback to Claude-specific script for backwards compatibility
-  echo "Generating Claude commands from templates (legacy)..."
-  "$DOT_DEN/utils/generate-claude-commands.sh"
-else
-  echo -e "${YELLOW}Command generation script not found. Skipping command generation.${NC}"
-fi
+# Command generation removed - we now use provider-agnostic, slash-free invocation
+# See knowledge/principles/ai-provider-agnosticism.md for details
 
 # Configuration files setup complete
 echo -e "${GREEN}✓ Configuration files setup complete${NC}"


### PR DESCRIPTION
## Summary
- Removes obsolete command generation code that was causing red error text during setup
- Replaces with comment explaining the new provider-agnostic approach
- Aligns with our "subtraction-creates-value" principle

## Details
The setup.sh script was attempting to generate AI provider commands from templates that no longer exist. Per our move to provider-agnostic, slash-free invocation (see knowledge/principles/ai-provider-agnosticism.md), the `.claude/command-templates/` directory was intentionally retired.

Commands are now invoked through natural language using procedures in `knowledge/procedures/`.

## Changes
- Removed lines 286-296 from setup.sh (command generation block)
- Added explanatory comment about the new approach

## Test Plan
- [x] Run `source setup.sh` - no more red error about missing template directory
- [x] Verify setup completes successfully without command generation

Closes #1319