### PR TITLE
docs: add MLflow tracking to Snowball Method principle

### DIFF
--- a/knowledge/principles/snowball-method.md
+++ b/knowledge/principles/snowball-method.md
@@ -8,4 +8,6 @@ The "snowball method" focuses on continuous knowledge accumulation and compoundi
 - Compounding returns: Small improvements accumulate and multiply rather than remaining isolated
 - Reduced cognitive load: Less need to "re-learn" or "re-discover" previous solutions
 
+With MLflow tracking, we transform ephemeral Claude sessions into queryable history, enabling kaizen continuous improvement. Each tracked session provides insights to debug failures and improve the next, turning isolated interactions into a compounding knowledge base where every session makes future sessions better.
+
 This principle ensures that our development environment continuously improves over time.

--- a/knowledge/principles/snowball-method.md
+++ b/knowledge/principles/snowball-method.md
@@ -8,6 +8,6 @@ The "snowball method" focuses on continuous knowledge accumulation and compoundi
 - Compounding returns: Small improvements accumulate and multiply rather than remaining isolated
 - Reduced cognitive load: Less need to "re-learn" or "re-discover" previous solutions
 
-With MLflow tracking, we transform ephemeral Claude sessions into queryable history, enabling kaizen continuous improvement. Each tracked session provides insights to debug failures and improve the next, turning isolated interactions into a compounding knowledge base where every session makes future sessions better.
+With MLflow tracking, we transform ephemeral Claude sessions into queryable history. This enables kaizen continuous improvement. Each tracked session provides insights to debug failures and improve the next. We turn isolated interactions into a compounding knowledge base. Every session makes future sessions better.
 
 This principle ensures that our development environment continuously improves over time.


### PR DESCRIPTION
## Summary
Adds a paragraph to the Snowball Method principle documentation explaining how MLflow session tracking enhances continuous improvement.

## Changes
- Updated `knowledge/principles/snowball-method.md` to include MLflow tracking benefits
- Explains how tracked sessions create queryable history for kaizen improvement

## Context
This documentation update reflects the new MLflow tracking workflow introduced in PR #1317, which enables session observability while preserving full Claude CLI interactivity.

Closes #1322