### PR TITLE
fix: correct MLflow session parsing to count actual tool uses

### DIFF
--- a/tracking/README.md
+++ b/tracking/README.md
@@ -61,14 +61,11 @@ While adding:
 ### What Gets Tracked from Claude Sessions
 
 The session parser extracts:
-- **Commands executed**: Bash, git, and other CLI commands
-- **File operations**: Created, modified, and read
-- **Git operations**: Commits, pushes, branches
-- **Errors encountered**: Failures and error messages
-- **User interactions**: Your inputs and corrections
-- **Plan mode**: Activations and exits
-- **Tool uses**: Claude's function calls
-- **Events**: PR creation, commits, issue procedures
+- **Commands executed**: Actual Bash commands run via Claude's tools (● Bash(...))
+- **Git operations**: Git commands executed through Bash tool
+- **Tool uses**: All Claude tool invocations (Bash, Read, Update, etc.)
+- **User interactions**: Your prompts and inputs
+- **Events**: Issue procedures and key actions
 
 ### Querying Sessions
 
@@ -85,10 +82,10 @@ tags.type = "claude_session"
 ## Session Metrics
 
 Each Claude session tracks:
-- **Execution metrics**: Commands run, files changed, git operations
-- **Quality metrics**: Errors encountered, success/failure
-- **Interaction metrics**: User inputs, plan mode usage
-- **Full transcript**: Complete session log for review
+- **Execution metrics**: Commands run, git operations, tool uses
+- **Interaction metrics**: User prompts and inputs
+- **Success status**: Exit code and overall success
+- **Transcripts**: Both raw and cleaned versions for review
 
 ## MLflow UI Features
 


### PR DESCRIPTION
## Summary
Fixes MLflow session parsing to accurately count metrics and provide readable transcripts.

## Problem
- Git operations were being counted 1500+ times instead of ~5-10
- Transcript was unreadable due to ANSI escape codes
- Terminal redraw bug caused massive text duplication
- Regex patterns matched text mentions, not actual command executions

## Solution
- Look for Claude's actual tool use pattern: `● ToolName(...)`
- Count only actual Bash executions: `● Bash(git ...)`
- Remove duplicate lines from terminal redraws
- Better ANSI/control character stripping
- Store both raw and cleaned transcripts
- Simplify to only metrics that can be accurately counted

## Changes
- Fixed regex patterns to match Claude's tool format
- Added deduplication logic for terminal redraws
- Improved transcript cleaning
- Removed unreliable metrics
- Updated documentation

## Testing
Run a Claude session with tracking and verify in MLflow UI:
```bash
bin/claude-with-tracking "close-issue 1234"
# Complete procedure
# Check http://localhost:5000
```

Expected: ~5-10 git operations, readable transcript
Before: 1500+ git operations, unreadable transcript