### PR TITLE
docs: add MLflow tracking as concrete example of AI provider agnosticism principle

### DIFF
--- a/knowledge/principles/ai-provider-agnosticism.md
+++ b/knowledge/principles/ai-provider-agnosticism.md
@@ -73,3 +73,19 @@ Historical note: `.claude/command-templates/` are intentionally retired; they re
 - **[OSE](ose.md)**: External perspective prevents vendor lock-in
 
 This principle ensures AI assistant capabilities remain available even when individual providers experience issues, supporting continuous development workflow with triple redundancy.
+
+## Implementation Example: MLflow Session Tracking
+
+The MLflow tracking system demonstrates provider agnosticism by extracting actual commands from transcripts rather than maintaining provider-specific patterns:
+
+**Anti-pattern (N×M complexity):**
+- Different regex patterns for each provider
+- Provider detection logic
+- Maintenance burden grows with each new AI assistant
+
+**Correct pattern (provider-agnostic):**
+- Single parser looks for actual `git`, `gh`, and bash commands
+- No provider detection needed
+- Works automatically with any AI assistant
+
+See: `tracking/parse_session.py:72-95` - Extracts real commands regardless of AI formatting


### PR DESCRIPTION
## Summary
Add the MLflow tracking implementation as a concrete example in the AI provider agnosticism principle documentation.

## Context
We recently implemented truly provider-agnostic MLflow tracking in PR #1328 that demonstrates the principle perfectly by:
- Avoiding N×M complexity (N providers × M patterns)
- Focusing on extracting actual commands rather than provider-specific formatting
- Using a single parser (`tracking/parse_session.py`) for all AI assistants

## Changes
Added a new section "Implementation Example: MLflow Session Tracking" that:
- Shows the anti-pattern (provider-specific regex patterns)
- Documents the correct pattern (provider-agnostic command extraction)
- References the actual implementation with specific line numbers

## Benefits
- Shows a concrete implementation of the principle
- Demonstrates how to avoid the N×M problem
- Provides a reference for future provider-agnostic implementations

## Related
- Closes #1329
- Related to PR #1328: MLflow provider-agnostic implementation