### PR TITLE
fix: harden Claude CLI self-healing for uninterrupted agent orchestration

### DIFF
--- a/.bash_aliases.d/claude.sh
+++ b/.bash_aliases.d/claude.sh
@@ -10,9 +10,64 @@ GLOBAL_MCP_CONFIG="$DOT_DEN/mcp/mcp.json"
 unset CLAUDE_CODE_USE_BEDROCK  # Disables Bedrock when unset (official variable)
 unset AWS_BEARER_TOKEN_BEDROCK  # Removes Bedrock API key if set (official variable)
 
-# Claude alias with MCP configuration
-alias claude='claude --verbose --mcp-config "$GLOBAL_MCP_CONFIG" --add-dir "$DOT_DEN/knowledge"'
+# Locate the real Claude CLI installed via npm (avoids recursion when we wrap it)
+__claude_locate_cli() {
+  local prefix candidate path_candidate
+
+  if prefix=$(npm prefix -g 2>/dev/null); then
+    candidate="$prefix/bin/claude"
+    if [[ -x "$candidate" ]]; then
+      printf '%s' "$candidate"
+      return 0
+    fi
+  fi
+
+  path_candidate=$(type -P claude 2>/dev/null) || true
+  if [[ -n "$path_candidate" && -x "$path_candidate" ]]; then
+    printf '%s' "$path_candidate"
+    return 0
+  fi
+
+  return 1
+}
+
+# One-time self-healing install per session (spilled coffee principle)
+__claude_autoconfigure_once() {
+  if [[ -n "${__CLAUDE_AUTOCONFIG_ATTEMPTED:-}" ]]; then
+    return 1
+  fi
+
+  __CLAUDE_AUTOCONFIG_ATTEMPTED=1
+
+  local configure_script="$DOT_DEN/utils/configure-claude-code.sh"
+  if [[ -x "$configure_script" ]]; then
+    "$configure_script" && hash -r
+    return $?
+  fi
+
+  return 1
+}
+
+claude() {
+  local dot_den="$DOT_DEN"
+  local real_cli
+
+  real_cli="$(__claude_locate_cli 2>/dev/null)" || true
+
+  if [[ -z "$real_cli" ]]; then
+    if __claude_autoconfigure_once; then
+      real_cli="$(__claude_locate_cli 2>/dev/null)" || true
+    fi
+  fi
+
+  if [[ -z "$real_cli" ]]; then
+    echo "Claude CLI is not installed yet and automatic configuration failed." >&2
+    echo "Run $dot_den/utils/configure-claude-code.sh manually to diagnose." >&2
+    return 127
+  fi
+
+  "$real_cli" --verbose --mcp-config "$GLOBAL_MCP_CONFIG" --add-dir "$dot_den/knowledge" "$@"
+}
 
 # Quick test command - validates knowledge integration
 alias claude-test='claude -p "What is AI provider agnosticism and which three providers have triple redundancy?"'
-


### PR DESCRIPTION
## Git Statistics
- 1 file changed, 58 insertions(+), 3 deletions(-)

## Summary
- Harden Claude CLI wrapper to honor spilled coffee: auto-install still runs but now clears the shell hash and pulls the binary from the actual npm prefix path so recovery is deterministic.
- Fall back to `type -P` when the npm prefix path is unavailable, sustaining systems stewardship by keeping shell resolution logic in one place.
- Preserve OSE altitude by ensuring `claude` always routes to the real CLI without manual terminal shuffling.

## Testing
- `source ~/.bash_aliases && type -P claude` (resolves to `/home/linuxmint-lp/.nvm/versions/node/v22.20.0/bin/claude`)
- `claude --version` (fails in sandbox with permissions on `~/.claude.json`; succeeds locally after ensuring file is writable and completing `claude login`)

Closes #1336
