### PR TITLE
feat: upgrade to Claude Sonnet 4.5 for superior coding capabilities

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
-  "model": "claude-opus-4-1-20250805",
+  "model": "claude-sonnet-4-5-20250929",
   "cleanupPeriodDays": 90,
   "forceLoginMethod": "claudeai",
   "includeCoAuthoredBy": false,

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -59,6 +59,6 @@ jobs:
           allowed_tools: "Bash(gh:*)"
           timeout_minutes: "5"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          model: claude-opus-4-1-20250805
+          model: claude-sonnet-4-5-20250929
           claude_env: |
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-implementation.yml
+++ b/.github/workflows/claude-implementation.yml
@@ -190,6 +190,6 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_tools: "Bash:*,LS,Read,Write,Edit,MultiEdit,Glob,Grep,Task,TodoWrite,WebFetch(domain:*),WebSearch"
           timeout_minutes: "30"
-          model: claude-opus-4-1-20250805
+          model: claude-sonnet-4-5-20250929
           claude_env: |
             GH_TOKEN=${{ secrets.GITHUB_TOKEN }}

--- a/knowledge/principles/ai-provider-agnosticism.md
+++ b/knowledge/principles/ai-provider-agnosticism.md
@@ -57,7 +57,7 @@ Historical note: `.claude/command-templates/` are intentionally retired; they re
 ## Provider Capabilities
 
 ### Claude Code (Anthropic)
-- Model: claude-opus-4-1-20250805
+- Model: claude-sonnet-4-5-20250929
 - Strengths: Excellent documentation, developer-friendly ergonomics, complex reasoning
 - MCP: CLI flag support
 


### PR DESCRIPTION
## Summary
Upgrades from Claude Opus 4.1 to the newly released Claude Sonnet 4.5, which offers superior performance despite the naming convention change from "Opus" to "Sonnet".

## Changes
- Updated model ID from `claude-opus-4-1-20250805` to `claude-sonnet-4-5-20250929` in:
  - ✅ `.claude/settings.json`
  - ✅ `knowledge/principles/ai-provider-agnosticism.md`
  - ✅ `.github/workflows/claude-implementation.yml`
  - ✅ `.github/workflows/auto-label-issues.yml`

## Benefits
- **4x longer autonomous operation**: 30+ hours vs 7 hours for Opus 4.1
- **State-of-the-art coding performance**: Best performance on SWE-bench Verified
- **Superior complex task handling**: Described as "best model for complex agents and coding"
- **Latest model support**: Released September 29, 2025

## Note
This is an **upgrade**, not a downgrade. Claude Sonnet 4.5 surpasses Opus 4.1 in capabilities despite moving from the "Opus" to "Sonnet" product line. It has "the highest intelligence across most tasks" according to Anthropic's documentation.

Closes #1340