### PR TITLE
fix: restore label validation to prevent gh issue create failures

### DIFF
--- a/knowledge/procedures/issue-creation-procedure.md
+++ b/knowledge/procedures/issue-creation-procedure.md
@@ -41,14 +41,22 @@ Scan issue content for principle alignment:
   - "rapid", "quick test" → tracer-bullets
   - "accumulate", "compound" → snowball-method
 
-## Step 4: Select Labels
+## Step 4: Fetch Available Labels
 
-From the **Available Labels** section above, select appropriate labels based on:
+Before selecting labels, run `gh label list` to get the list of labels that actually exist in the repository.
+
+**CRITICAL**: Only labels from this list can be applied. Using a non-existent label will cause `gh issue create` to fail.
+
+## Step 5: Select Labels
+
+From the labels fetched in Step 4, select appropriate labels based on:
 - Issue type (bug, enhancement, documentation)
 - Principles detected in Step 3
 - Relevant areas (mcp, git, automation, etc.)
 
-## Step 5: Build Issue Content
+**Validation**: Cross-check each selected label against the list from Step 4. Only include labels that exist.
+
+## Step 6: Build Issue Content
 
 ### Template Selection
 
@@ -69,7 +77,7 @@ Based on keywords, link relevant procedures:
 - "git" → Link git-workflow
 - "issue" → Link issue-to-pr-workflow
 
-## Step 6: Preview Issue
+## Step 7: Preview Issue
 
 Present a complete preview showing:
 - **Title**: [proposed title]
@@ -79,7 +87,7 @@ Present a complete preview showing:
 
 Ask for confirmation or modifications.
 
-## Step 7: Create the Issue
+## Step 8: Create the Issue
 
 Upon confirmation:
 1. Create the issue with selected labels


### PR DESCRIPTION
## Summary

- Restores defensive label validation removed in commit 9fd1b3a2
- Prevents `gh issue create` failures when non-existent labels are applied
- Follows the same pattern already working in issue-triage.md

## Problem

Issue #1342 reported that when creating GitHub issues with the `gh` CLI, if a label doesn't exist, the entire `gh issue create` command fails. This forces the user to restart the entire issue creation process, wasting time and tokens.

## Solution

Added explicit validation steps to `knowledge/procedures/issue-creation-procedure.md`:

1. **Step 4: Fetch Available Labels** - Run `gh label list` first
2. **Step 5: Select Labels** - Cross-check selections against fetched list
3. **Validation note** - Only apply labels that exist

The fix is minimal (following the issue's request for "1 line should suffice") while being explicit enough to prevent the failure mode.

## Implementation Details

- Renumbered steps 4-7 to 4-8 to accommodate new validation step
- Added **CRITICAL** callout explaining the failure mode
- Follows same pattern as `.github/workflow-prompts/issue-triage.md:19`

## Test Plan

- [x] Reviewed diff to ensure only procedure changes
- [x] Confirmed step numbering is sequential
- [x] Verified alignment with issue-triage workflow pattern

## Principles Applied

- **tracer-bullets**: Get it working first (minimal defensive fix)
- **subtraction-creates-value**: Minimal addition, maximum impact
- **systems-stewardship**: Maintains single source of truth

Closes #1342