### PR TITLE
fix: remove invalid secret reference from workflow job-level conditional

### DIFF
--- a/.github/workflows/auto-trigger-claude.yml
+++ b/.github/workflows/auto-trigger-claude.yml
@@ -8,8 +8,9 @@ jobs:
   auto-trigger-claude:
     # Gate: only run when Claude Code is explicitly enabled
     # Enable by setting repo variable: CLAUDE_CODE_SUBSCRIPTION=active
-    # Also requires PAT secret to exist (prevents unsolicited comments)
-    if: ${{ vars.CLAUDE_CODE_SUBSCRIPTION == 'active' && secrets.CLAUDE_TRIGGER_PAT != '' }}
+    # Note: Secret existence is validated at step execution time, not in job conditional
+    # (GitHub Actions does not support direct secret references in job-level if conditions)
+    if: ${{ vars.CLAUDE_CODE_SUBSCRIPTION == 'active' }}
     runs-on: ubuntu-latest
     timeout-minutes: 2
     permissions:


### PR DESCRIPTION
## Summary
Fixes #1347 by removing the invalid secret reference from the auto-trigger-claude workflow's job-level conditional.

## Problem
The workflow `.github/workflows/auto-trigger-claude.yml` was failing with:
```
Unrecognized named-value: 'secrets'. Located at position 46 within expression: 
vars.CLAUDE_CODE_SUBSCRIPTION == 'active' && secrets.CLAUDE_TRIGGER_PAT != ''
```

GitHub Actions does not allow direct `secrets` references in job-level `if:` conditions. This is a documented limitation for security reasons.

## Solution
- Removed `&& secrets.CLAUDE_TRIGGER_PAT != ''` from the job-level conditional
- Updated comments to explain secret validation happens at step execution time
- Kept `vars.CLAUDE_CODE_SUBSCRIPTION == 'active'` as the primary gate
- If the secret doesn't exist, the workflow step will fail with a clear GitHub error

## Changes
- `.github/workflows/auto-trigger-claude.yml`: Fixed job-level conditional (line 13)

## Testing
- ✅ YAML syntax validation passes
- ✅ Workflow file structure is valid
- ✅ Aligns with how `claude-implementation.yml` handles secrets

## References
- Root cause analysis: Issue #1347
- Original investigation: Issue #1345
- GitHub Actions runner issue: https://github.com/actions/runner/issues/520
- Community discussion: https://github.com/orgs/community/discussions/26726

## Principles Applied
- **tracer-bullets**: Simple fix that addresses root cause directly
- **subtraction-creates-value**: Removed unnecessary complexity
- **systems-stewardship**: Aligned with existing workflow patterns