### PR TITLE
feat: create Claude Code plugin for sharing commands across repos

### DIFF
--- a/.claude-plugin/commands/close-issue.md
+++ b/.claude-plugin/commands/close-issue.md
@@ -1,0 +1,1 @@
+../../knowledge/procedures/close-issue-procedure.md

--- a/.claude-plugin/commands/create-issue.md
+++ b/.claude-plugin/commands/create-issue.md
@@ -1,0 +1,1 @@
+../../knowledge/procedures/issue-creation-procedure.md

--- a/.claude-plugin/commands/extract-best-frame.md
+++ b/.claude-plugin/commands/extract-best-frame.md
@@ -1,0 +1,1 @@
+../../knowledge/procedures/extract-best-frame-procedure.md

--- a/.claude-plugin/commands/retro.md
+++ b/.claude-plugin/commands/retro.md
@@ -1,0 +1,1 @@
+../../knowledge/procedures/retro-procedure.md

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "name": "dotfiles-marketplace",
+  "owner": {
+    "name": "atxtechbro"
+  },
+  "plugins": [
+    {
+      "name": "dotfiles-commands",
+      "source": ".",
+      "description": "Shared procedures and slash commands from dotfiles knowledge base"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "dotfiles-commands",
+  "description": "Shared procedures and slash commands from dotfiles knowledge base",
+  "version": "1.0.0",
+  "author": {
+    "name": "atxtechbro"
+  }
+}


### PR DESCRIPTION
## Git Statistics
```
.claude-plugin/commands/close-issue.md        |  1 +
.claude-plugin/commands/create-issue.md       |  1 +
.claude-plugin/commands/extract-best-frame.md |  1 +
.claude-plugin/commands/retro.md              |  1 +
.claude-plugin/marketplace.json               | 13 +++++++++++++
.claude-plugin/plugin.json                    |  8 ++++++++
6 files changed, 25 insertions(+)
```

## Summary

Transforms dotfiles into a Claude Code plugin that can be installed in any repo, solving the problem of sharing slash commands across multiple repositories.

**The Problem**: PR #1344 added `/close-issue` via symlink in dotfiles, but other repos (like lifehacking) can't access it. The old command generation system that synced to `~/.claude/commands/` was removed in #1320 for provider-agnostic reasons.

**The Solution**: Use Claude Code's official plugin system introduced in their recent plugins announcement. Dotfiles becomes a shareable plugin that other repos can install.

## What Changed

Created plugin structure:
```
.claude-plugin/
├── plugin.json              # Plugin metadata
├── marketplace.json         # Distribution manifest  
└── commands/                # Symlinked to knowledge base
    ├── close-issue.md      → ../../knowledge/procedures/close-issue-procedure.md
    ├── create-issue.md     → ../../knowledge/procedures/issue-creation-procedure.md
    ├── extract-best-frame.md → ../../knowledge/procedures/extract-best-frame-procedure.md
    └── retro.md           → ../../knowledge/procedures/retro-procedure.md
```

## Benefits

🎯 **Modern Approach**:
- Official Claude Code extension system (vs custom generation scripts)
- Commands shareable across all repos via plugin install
- Per-repo control (install only where needed)

🔧 **Technical**:
- Single source of truth (knowledge base remains authoritative)
- Symlinks ensure zero duplication
- Expandable with agents, hooks, MCP servers later
- Works with both local paths and GitHub distribution

## Installation in Other Repos

**Local (for testing):**
```bash
/plugin marketplace add ~/ppv/pillars/dotfiles
/plugin install dotfiles-commands
```

**GitHub (after merge):**
```bash
/plugin marketplace add atxtechbro/dotfiles
/plugin install dotfiles-commands@atxtechbro
```

## Implementation Notes

This "dotfiles-as-plugin" approach:
- Leverages official Claude Code plugin system vs maintaining custom sync scripts
- Enables sharing of dotfiles setup with other users
- Follows systems-stewardship principle (single source of truth in knowledge base)
- Can be expanded to include custom agents and hooks in the future

## Test Plan

- [x] Create `.claude-plugin/` structure with manifests
- [x] Symlink commands to knowledge base procedures
- [ ] Test local installation in lifehacking repo
- [ ] Verify `/close-issue` autocomplete works after plugin install
- [ ] Test GitHub-based installation after merge

---

**Related**: Continues the work from #1344 (symlink approach) by making it shareable across repos