### PR TITLE
fix: add YAML front matter to procedures for plugin command discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,8 @@ Share slash commands across repos via Claude Code's plugin system.
 /plugin install dotfiles-commands@atxtechbro
 ```
 
+**Then restart Claude Code** for commands to appear in autocomplete.
+
 Commands symlink to `knowledge/procedures/` for single source of truth.
 
 ## Global MCP Configuration

--- a/knowledge/procedures/close-issue-procedure.md
+++ b/knowledge/procedures/close-issue-procedure.md
@@ -1,3 +1,7 @@
+---
+description: Close GitHub issue with PR workflow
+---
+
 # Close Issue Procedure
 #
 # IMPORTANT: This procedure creates a Pull Request that will auto-close the issue when merged.

--- a/knowledge/procedures/extract-best-frame-procedure.md
+++ b/knowledge/procedures/extract-best-frame-procedure.md
@@ -1,3 +1,7 @@
+---
+description: Extract best frame from video using AI
+---
+
 # Extract Best Frame Procedure
 #
 # This procedure extracts frames from a video and uses the agent's visual judgment

--- a/knowledge/procedures/issue-creation-procedure.md
+++ b/knowledge/procedures/issue-creation-procedure.md
@@ -1,5 +1,9 @@
+---
+description: Create GitHub issue with validated labels
+---
+
 # Issue Creation Procedure
-# 
+#
 # This IS the implementation - the procedure documents itself by being the code.
 # Used by /create-issue command (via injection)
 #

--- a/knowledge/procedures/retro-procedure.md
+++ b/knowledge/procedures/retro-procedure.md
@@ -1,3 +1,7 @@
+---
+description: Run retrospective to capture learnings
+---
+
 # Retro Procedure
 
 After completing work or submitting a pull request, conduct a retro focused on systems improvement. This supports the Snowball Method by capturing learnings and dedicating 20% of time to systems improvement.


### PR DESCRIPTION
## Summary

Fixes plugin command discovery by adding required YAML front matter to all procedure files.

## The Problem

Plugin was installed and enabled but commands weren't appearing in autocomplete:
```
◉ dotfiles-commands  (enabled but commands invisible)
```

**Root Cause**: Claude Code requires YAML front matter for command discovery:
```yaml
---
description: Command description here
---
```

Without this, procedure files are invisible to the plugin system.

## What Changed

Added YAML front matter to all procedures:
- `close-issue-procedure.md`: "Close GitHub issue with PR workflow"
- `issue-creation-procedure.md`: "Create GitHub issue with validated labels"  
- `extract-best-frame-procedure.md`: "Extract best frame from video using AI"
- `retro-procedure.md`: "Run retrospective to capture learnings"

Updated README to note: **"Then restart Claude Code"** after plugin install.

## Verification

After merge, test in lifehacking repo:
```bash
# In Claude Code:
/plugin marketplace remove dotfiles-marketplace
/plugin marketplace add https://github.com/atxtechbro/dotfiles
/plugin install dotfiles-commands@atxtechbro
# Exit and restart Claude Code
# Type /close-issue to verify autocomplete
```

Commands should now appear with their descriptions.

## File Changes

```
knowledge/procedures/close-issue-procedure.md        +3
knowledge/procedures/issue-creation-procedure.md     +3  
knowledge/procedures/extract-best-frame-procedure.md +3
knowledge/procedures/retro-procedure.md              +3
README.md                                            +2
```

---

**Fixes**: Command discovery issue from PR #1352
**Blocks**: Testing in lifehacking repo until merged