### PR TITLE
fix: correct plugin directory structure for command discovery

### DIFF
--- a/.claude-plugin/commands/close-issue.md
+++ b/.claude-plugin/commands/close-issue.md
@@ -1,1 +1,0 @@
-../../knowledge/procedures/close-issue-procedure.md

--- a/.claude-plugin/commands/create-issue.md
+++ b/.claude-plugin/commands/create-issue.md
@@ -1,1 +1,0 @@
-../../knowledge/procedures/issue-creation-procedure.md

--- a/.claude-plugin/commands/extract-best-frame.md
+++ b/.claude-plugin/commands/extract-best-frame.md
@@ -1,1 +1,0 @@
-../../knowledge/procedures/extract-best-frame-procedure.md

--- a/.claude-plugin/commands/retro.md
+++ b/.claude-plugin/commands/retro.md
@@ -1,1 +1,0 @@
-../../knowledge/procedures/retro-procedure.md

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "dotfiles-commands",
-      "source": "./.claude-plugin",
+      "source": ".",
       "description": "Shared procedures and slash commands from dotfiles knowledge base"
     }
   ]

--- a/commands/close-issue.md
+++ b/commands/close-issue.md
@@ -1,0 +1,1 @@
+../knowledge/procedures/close-issue-procedure.md

--- a/commands/create-issue.md
+++ b/commands/create-issue.md
@@ -1,0 +1,1 @@
+../knowledge/procedures/issue-creation-procedure.md

--- a/commands/extract-best-frame.md
+++ b/commands/extract-best-frame.md
@@ -1,0 +1,1 @@
+../knowledge/procedures/extract-best-frame-procedure.md

--- a/commands/retro.md
+++ b/commands/retro.md
@@ -1,0 +1,1 @@
+../knowledge/procedures/retro-procedure.md


### PR DESCRIPTION
## Summary

Fixes plugin commands not appearing in Claude Code by moving `commands/` to the correct location per Claude Code plugin specification.

## The Problem

After installing the dotfiles plugin, commands were not appearing in Claude Code's autocomplete:
```
/close-issue   ❌ Not found
/create-issue  ❌ Not found
/retro         ❌ Not found
/extract-best-frame ❌ Not found
```

**Root Cause**: Commands were in `.claude-plugin/commands/` but Claude Code requires `commands/` at repo root level.

## What Changed

**Incorrect Structure** (Before):
```
.claude-plugin/
├── plugin.json
├── marketplace.json
└── commands/           # ❌ Wrong location
    ├── close-issue.md
    ├── create-issue.md
    ├── retro.md
    └── extract-best-frame.md
```

**Correct Structure** (After):
```
.claude-plugin/
├── plugin.json
└── marketplace.json

commands/               # ✅ At repo root
├── close-issue.md
├── create-issue.md
├── retro.md
└── extract-best-frame.md
```

**Changes Made**:
1. Updated `marketplace.json`: source `"./.claude-plugin"` → `"."`
2. Created `commands/` at repo root
3. Moved symlinks from `.claude-plugin/commands/` → `commands/`
4. All commands still symlink to `knowledge/procedures/` (single source of truth)

## Verification

After this PR merges, users can update their plugin:

```bash
# In Claude Code:
/plugin  # Select dotfiles-commands and update
# Restart Claude Code
```

Commands will now appear in autocomplete:
- `/close-issue` ✅
- `/create-issue` ✅  
- `/retro` ✅
- `/extract-best-frame` ✅

## File Changes

```
D  .claude-plugin/commands/close-issue.md
D  .claude-plugin/commands/create-issue.md
D  .claude-plugin/commands/extract-best-frame.md
D  .claude-plugin/commands/retro.md
M  .claude-plugin/marketplace.json
A  commands/close-issue.md
A  commands/create-issue.md
A  commands/extract-best-frame.md
A  commands/retro.md
```

## References

- [Claude Code Plugin Directory Structure](https://docs.claude.com/en/docs/claude-code/plugins-reference)
- Quote: "Ensure `commands/` directory is at the root, not inside `.claude-plugin/`"

---

**Closes #1356**