### PR TITLE
feat: add label-based control for Claude auto-implementation

### DIFF
--- a/.github/workflows/auto-trigger-claude.yml
+++ b/.github/workflows/auto-trigger-claude.yml
@@ -1,16 +1,18 @@
 name: Auto-Trigger Claude
-description: Automatically trigger Claude to implement new issues (Ultimate OSE)
+description: Automatically trigger Claude to implement labeled issues (Hybrid OSE)
 on:
   issues:
-    types: [opened]
+    types: [labeled]
 
 jobs:
   auto-trigger-claude:
-    # Gate: only run when Claude Code is explicitly enabled
+    # Gate: only run when Claude Code is explicitly enabled AND the 'claude' label is added
     # Enable by setting repo variable: CLAUDE_CODE_SUBSCRIPTION=active
+    # Add 'claude' label to an issue to queue it for auto-implementation
+    # Note: Manual @claude mentions still work regardless of labels (handled by claude-implementation.yml)
     # Note: Secret existence is validated at step execution time, not in job conditional
     # (GitHub Actions does not support direct secret references in job-level if conditions)
-    if: ${{ vars.CLAUDE_CODE_SUBSCRIPTION == 'active' }}
+    if: ${{ vars.CLAUDE_CODE_SUBSCRIPTION == 'active' && github.event.label.name == 'claude' }}
     runs-on: ubuntu-latest
     timeout-minutes: 2
     permissions:

--- a/knowledge/procedures/auto-trigger-workflow.md
+++ b/knowledge/procedures/auto-trigger-workflow.md
@@ -1,13 +1,22 @@
 # Auto-Trigger Workflow
 
-Enables Ultimate OSE automation where GitHub issues automatically trigger Claude to implement and create PRs with zero manual intervention.
+Enables hybrid OSE automation where GitHub issues can trigger Claude implementation via label or manual mention.
 
 ## How It Works
 
-1. Issue created on GitHub
-2. `.github/workflows/auto-trigger-claude.yml` fires automatically
-3. Claude receives instruction to implement the issue
-4. The `anthropics/claude-code-action` automatically creates the PR after Claude completes the implementation
+### Method 1: Label-Based Auto-Trigger (Opt-In)
+1. Create or open an issue on GitHub
+2. Add the `claude` label to the issue
+3. `.github/workflows/auto-trigger-claude.yml` fires automatically
+4. Claude receives instruction to implement the issue
+5. The `anthropics/claude-code-action` automatically creates the PR after Claude completes the implementation
+
+### Method 2: Manual @claude Mention
+1. Create or open an issue on GitHub
+2. Comment `@claude` in the issue (with optional context)
+3. `.github/workflows/claude-implementation.yml` fires on the mention
+4. Claude receives instruction to implement the issue
+5. The `anthropics/claude-code-action` automatically creates the PR after Claude completes the implementation
 
 ## Key Difference from /close-issue
 
@@ -25,29 +34,55 @@ The `anthropics/claude-code-action@beta` GitHub Action handles PR creation autom
 
 ## Implementation Details
 
-### Workflow Trigger
-The workflow triggers on `issues.opened` events and posts a simple comment:
+### Label-Based Workflow Trigger
+The auto-trigger workflow activates on `issues.labeled` events when:
+- The `claude` label is added to an issue
+- Repository variable `CLAUDE_CODE_SUBSCRIPTION` is set to `active`
+
+It posts this comment to trigger implementation:
 
 ```markdown
-@claude Please implement this issue. The pull request will be created automatically after you complete the implementation.
+@claude Please implement this issue and CREATE AN ACTUAL PULL REQUEST on GitHub.
+
+**IMPORTANT**: You MUST create a real PR on GitHub (not just provide a link to create one). use branch name according to repo guidelines such that branch name contains issue number suffix and is guaranteed to be unique. The PR must be created and visible at github.com/atxtechbro/dotfiles/pulls.
+
+**NOTE**: You now have access to the full knowledge base including all principles (tracer-bullets, versioning-mindset, OSE, etc.) and procedures (git-workflow, worktree-workflow, etc.). Use this context to create high-quality PRs that follow established patterns.
+
+Use the PR template from https://github.com/atxtechbro/dotfiles/blob/main/.github/PULL_REQUEST_TEMPLATE.md when creating the pull request.
 ```
+
+### Manual Mention Workflow Trigger
+The implementation workflow activates on any `@claude` mention in:
+- Issue comments
+- Pull request comments
+- Pull request review comments
+
+No label required - just mention `@claude` with optional context.
 
 ### Why It Works
 The `anthropics/claude-code-action` has built-in PR creation capability. After Claude pushes changes to a branch, the Action automatically creates a PR without Claude needing to call any PR creation tools. This is simpler and more reliable than manual tool invocation.
 
 ## When to Use
 
-### Use Auto-Trigger When:
+### Use Label-Based Auto-Trigger When:
 - Issue requires implementation work
-- Want zero manual intervention 
-- Following Ultimate OSE principles
+- Want to batch-queue multiple issues for automation
+- Want visual indicator of which issues are queued
+- Following Ultimate OSE principles with opt-in control
 - Need audit trail of automated work
+
+### Use Manual @claude Mention When:
+- Want to trigger implementation on-demand
+- Need to provide specific context or constraints
+- Issue doesn't need the `claude` label permanently
+- Quick ad-hoc implementation request
 
 ### Use /close-issue When:
 - Working locally with Claude Code
 - Need interactive discussion during implementation
 - Prefer manual control over PR creation
 - Issue is complex and needs human oversight
+- Testing changes locally before pushing
 
 ## Related Files
 
@@ -55,8 +90,33 @@ The `anthropics/claude-code-action` has built-in PR creation capability. After C
 - Implementation: `.github/workflows/claude-implementation.yml`
 - Local procedure: `knowledge/procedures/close-issue-procedure.md`
 
+## Usage Examples
+
+### Label-Based Triggering
+```bash
+# Add claude label to an issue to queue for auto-implementation
+gh issue edit 123 --add-label "claude"
+
+# Batch-add label to multiple issues
+gh issue list --state open --json number --jq '.[].number' | \
+  xargs -I {} gh issue edit {} --add-label "claude"
+
+# Remove label to prevent auto-trigger
+gh issue edit 123 --remove-label "claude"
+```
+
+### Manual @claude Mention
+```markdown
+# In issue comment:
+@claude Please implement this with focus on performance optimization
+
+# In PR review:
+@claude Can you review this approach and suggest improvements?
+```
+
 ## Principles Applied
 
 - **systems-stewardship**: Document systems for future maintainers
-- **ose**: Ultimate automation with zero manual intervention
+- **ose**: Automated workflows with intentional opt-in control
 - **snowball-method**: Knowledge persistence for compound improvement
+- **subtraction-creates-value**: Removed overly-eager auto-trigger, added intentional control


### PR DESCRIPTION
## Summary

Implements hybrid approach for Claude auto-triggering to address overly-eager auto-implementation behavior.

### Changes

1. **Modified `.github/workflows/auto-trigger-claude.yml`**:
   - Changed trigger from `issues.opened` to `issues.labeled`
   - Added condition to check for `claude` label
   - Updated comments to document hybrid approach

2. **Created `claude` label**:
   - Color: `#7B68EE` (medium slate blue)
   - Description: "Auto-implement this issue with Claude"
   - Provides visual indicator in issue list

3. **Updated `knowledge/procedures/auto-trigger-workflow.md`**:
   - Documented both triggering methods (label-based and manual @claude)
   - Added usage examples for each approach
   - Included batch operation examples
   - Updated "When to Use" guidance

### Benefits

- **Opt-in control**: Issues only auto-implement when `claude` label is added
- **Visual indicators**: Easy to see which issues are queued for automation
- **Batch operations**: Can apply label to multiple issues at once
- **Backward compatible**: Manual `@claude` mentions still work
- **Flexible**: Choose per-issue whether to use label or manual mention

### Usage

**Label-based triggering:**
```bash
gh issue edit 123 --add-label "claude"
```

**Manual triggering:**
Comment `@claude` on any issue (label not required)

## Test Plan

- [ ] Verify auto-trigger workflow no longer fires on new issues
- [ ] Test adding `claude` label triggers workflow
- [ ] Confirm manual `@claude` mentions still work
- [ ] Check batch label operations
- [ ] Validate documentation accuracy

## Related

Closes #1357

## Principles Applied

- **subtraction-creates-value**: Removed overly-eager auto-trigger
- **systems-stewardship**: Documented both triggering methods
- **ose**: Maintained automation with intentional control