### PR TITLE
fix: enable plugin command discovery by adding commands path to manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "author": {
     "name": "atxtechbro"
-  }
+  },
+  "commands": ["./commands/"]
 }


### PR DESCRIPTION
## Git Statistics
<!-- Will be populated automatically -->

## Summary 🎯

Fixed plugin marketplace command discovery that was silently failing. The `dotfiles-commands` plugin installed successfully but Claude Code discovered **0 commands** despite 4 command files existing in `.claude-plugin/commands/`.

### Root Cause
The `plugin.json` manifest was missing the `commands` field that tells Claude Code where to find slash command files. Without this field, the plugin loads but has no commands available.

Debug logs confirmed:
```
[DEBUG] Loading plugin dotfiles-commands from source: "./.claude-plugin"
[DEBUG] Found 1 plugins (1 enabled, 0 disabled)
[DEBUG] Total plugin commands loaded: 0
```

### Solution
Added `"commands": ["./commands/"]` to `.claude-plugin/plugin.json` to specify the command directory relative to the plugin root.

### Impact
Enables cross-repo command sharing via plugin marketplace. Other repos (like lifehacking) can now access shared procedures:
- `/close-issue` - GitHub issue workflow with PR creation
- `/retro` - Retrospective and learnings capture
- `/create-issue` - Issue creation with templates
- `/extract-best-frame` - Video frame extraction

## Changes Made 📝

**Modified Files:**
- `.claude-plugin/plugin.json` - Added `commands` field pointing to `./commands/` directory

## Test Plan ✅

**Before Fix:**
```bash
# In lifehacking repo with plugin enabled
/plugin  # Shows: Status: Enabled, Commands: 0
/close-issue  # Command not found
```

**After Fix:**
1. Update plugin in lifehacking repo: `/plugin` → "Update now"
2. Verify commands discovered: `/plugin` should show Commands: 4
3. Test command execution: `/close-issue` should be recognized and execute
4. Verify symlinks work: Commands should load despite being symlinks to `../../knowledge/procedures/`

## Additional Context 💡

- The symlinks in `.claude-plugin/commands/` work fine - the issue was purely the missing manifest field
- Plugin marketplace installed from GitHub: `https://github.com/atxtechbro/dotfiles.git`
- Commands are properly structured with frontmatter and descriptions
- This follows the plugin manifest spec from Claude Code documentation