### PR TITLE
fix: use "./" instead of "." for marketplace plugin source path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "dotfiles-commands",
-      "source": ".",
+      "source": "./",
       "description": "Shared procedures and slash commands from dotfiles knowledge base"
     }
   ]


### PR DESCRIPTION
## Summary

Fixes critical schema validation error that prevents the plugin marketplace from loading.

### Error
```
Failed to load all marketplaces. Errors: dotfiles-marketplace: Invalid schema: plugins.0.source: Invalid input: must start with "./"
```

### Root Cause
The marketplace.json used `"source": "."` but Claude Code's plugin schema requires relative paths to start with `"./"` not just `"."`.

### The Fix
Changed source from `"."` to `"./"` in `.claude-plugin/marketplace.json`.

Both point to the repo root, but `"./"` satisfies the schema validation requirement.

### Impact
- Marketplace now loads successfully
- Plugin commands can be discovered
- No change to actual path resolution (still repo root)

### Test Plan
1. Merge this PR
2. Update marketplace: `cd ~/.claude/plugins/marketplaces/dotfiles-marketplace && git pull`
3. Run `/plugin` in Claude Code
4. Verify: No schema validation error
5. Verify: dotfiles-marketplace appears in plugin list
6. Verify: Can see and use `/close-issue`, `/retro`, etc.

Related: #1360 (added commands field), #1361 (moved plugin.json to root)