### PR TITLE
fix: move plugin.json to .claude-plugin and fix commands path

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -5,5 +5,5 @@
   "author": {
     "name": "atxtechbro"
   },
-  "commands": ["./commands/"]
+  "commands": ["../commands/"]
 }


### PR DESCRIPTION
## Summary

Fixes plugin command discovery by placing `plugin.json` in the correct location relative to `marketplace.json`.

### Root Cause
The `source: "./"` field in `marketplace.json` is relative to the marketplace.json location (`.claude-plugin/`), **NOT** the repo root.

When `plugin.json` was at repo root, Claude Code looked in `.claude-plugin/` (where marketplace.json lives), didn't find `plugin.json`, and loaded 0 commands.

Debug logs showed: `Loading plugin dotfiles-commands from source: "./.claude-plugin"` and `Total plugin commands loaded: 0`

### The Fix
1. Moved `plugin.json` from repo root → `.claude-plugin/plugin.json`
2. Updated commands path: `"./commands/"` → `"../commands/"` (go up one dir from .claude-plugin/)

### Path Resolution Now
- Marketplace: `.claude-plugin/marketplace.json`
- Source: `"./"` (means: same dir as marketplace.json)
- Plugin manifest: `.claude-plugin/plugin.json` ✓
- Commands path: `"../commands/"` (relative to plugin.json location)
- Full commands path: `commands/` ✓

### Test Plan
1. Merge this PR
2. Update marketplace: `cd ~/.claude/plugins/marketplaces/dotfiles-marketplace && git pull`
3. Restart Claude Code or start new session
4. Check debug logs: Should show > 0 commands loaded
5. Type `/close` → `/close-issue` appears

Related: #1360 (added commands field), #1361 (initially moved plugin.json), #1362 (fixed source schema), #1363 (documented full issue)