### PR TITLE
fix: change commands path from ../commands/ to ./commands/

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -5,5 +5,5 @@
   "author": {
     "name": "atxtechbro"
   },
-  "commands": ["../commands/"]
+  "commands": ["./commands/"]
 }


### PR DESCRIPTION
Completes the fix from #1365 which added symlinks but forgot to update plugin.json.

Schema validation requires: `commands.0: must start with './'`

Current: `"../commands/"` ❌  
Fixed: `"./commands/"` ✅

This is the missing piece - PR #1365 added the `.claude-plugin/commands/` symlinks but didn't commit the plugin.json path change.