### PR TITLE
fix: eliminate double symlinks for plugin command discovery

### DIFF
--- a/.claude-plugin/commands/close-issue.md
+++ b/.claude-plugin/commands/close-issue.md
@@ -1,1 +1,1 @@
-../../commands/close-issue.md
+../../knowledge/procedures/close-issue-procedure.md

--- a/.claude-plugin/commands/create-issue.md
+++ b/.claude-plugin/commands/create-issue.md
@@ -1,1 +1,1 @@
-../../commands/create-issue.md
+../../knowledge/procedures/issue-creation-procedure.md

--- a/.claude-plugin/commands/extract-best-frame.md
+++ b/.claude-plugin/commands/extract-best-frame.md
@@ -1,1 +1,1 @@
-../../commands/extract-best-frame.md
+../../knowledge/procedures/extract-best-frame-procedure.md

--- a/.claude-plugin/commands/retro.md
+++ b/.claude-plugin/commands/retro.md
@@ -1,1 +1,1 @@
-../../commands/retro.md
+../../knowledge/procedures/retro-procedure.md


### PR DESCRIPTION
## Summary

This PR fixes the Claude Code plugin command discovery issue by eliminating double symlinks. The symlinks in `.claude-plugin/commands/` now point directly to files in `knowledge/procedures/` instead of going through intermediate symlinks in `commands/`.

## Root Cause

Claude Code plugin doesn't follow double symlinks (symlink → symlink → file). Previously, the structure was:
```
.claude-plugin/commands/retro.md → ../../commands/retro.md → ../../knowledge/procedures/retro-procedure.md
```

This double indirection prevented the plugin from discovering and loading commands.

## Fix

Updated all symlinks in `.claude-plugin/commands/` to point directly to their target files:

- **close-issue.md**: `../../commands/close-issue.md` → `../../knowledge/procedures/close-issue-procedure.md`
- **create-issue.md**: `../../commands/create-issue.md` → `../../knowledge/procedures/issue-creation-procedure.md`
- **extract-best-frame.md**: `../../commands/extract-best-frame.md` → `../../knowledge/procedures/extract-best-frame-procedure.md`
- **retro.md**: `../../commands/retro.md` → `../../knowledge/procedures/retro-procedure.md`

## Test Plan

- [ ] Verify plugin commands are discovered: Run Claude Code and check that custom commands appear
- [ ] Test each command works correctly
- [ ] Confirm symlinks resolve properly: `ls -la .claude-plugin/commands/`

## Impact

This ensures the Claude Code plugin can properly discover and execute custom commands, making the plugin fully functional.