### PR TITLE
fix: point plugin directly to knowledge/procedures source of truth

### DIFF
--- a/.claude-plugin/commands/close-issue.md
+++ b/.claude-plugin/commands/close-issue.md
@@ -1,1 +1,0 @@
-../../knowledge/procedures/close-issue-procedure.md

--- a/.claude-plugin/commands/create-issue.md
+++ b/.claude-plugin/commands/create-issue.md
@@ -1,1 +1,0 @@
-../../knowledge/procedures/issue-creation-procedure.md

--- a/.claude-plugin/commands/extract-best-frame.md
+++ b/.claude-plugin/commands/extract-best-frame.md
@@ -1,1 +1,0 @@
-../../knowledge/procedures/extract-best-frame-procedure.md

--- a/.claude-plugin/commands/retro.md
+++ b/.claude-plugin/commands/retro.md
@@ -1,1 +1,0 @@
-../../knowledge/procedures/retro-procedure.md

--- a/.claude-plugin/commands/test-nonsymlink.md
+++ b/.claude-plugin/commands/test-nonsymlink.md
@@ -1,1 +1,0 @@
-../../commands/test-nonsymlink.md

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -5,5 +5,5 @@
   "author": {
     "name": "atxtechbro"
   },
-  "commands": ["./commands/"]
+  "commands": ["../knowledge/procedures/"]
 }


### PR DESCRIPTION
## Summary

This PR fixes the plugin command discovery issue by pointing the plugin directly to the source of truth in `knowledge/procedures/` instead of using an intermediary symlink directory.

## Root Cause

Claude Code's plugin system only loads commands from directories listed in the `commands` array in `plugin.json`. The previous approach used `.claude-plugin/commands/` as an intermediary directory containing symlinks to the actual procedure files in `knowledge/procedures/`. This created unnecessary complexity with multiple layers of symlinks that caused command discovery issues.

## The Fix

- Updated `plugin.json` to change `"commands": ["./commands/"]` to `"commands": ["../knowledge/procedures/"]`
- Removed the entire `.claude-plugin/commands/` directory (5 symlink files deleted)
- Commands now load directly from their single source of truth in `knowledge/procedures/`

## Benefits

- Eliminates complex symlink chains
- Reduces maintenance burden (no need to keep symlinks in sync)
- Commands load directly from their authoritative source
- Simpler, more straightforward architecture

## Changes

- `plugin.json`: Updated commands path from `./commands/` to `../knowledge/procedures/`
- Deleted `.claude-plugin/commands/` directory and all symlinks within it:
  - `close-issue.md`
  - `create-issue.md`
  - `extract-best-frame.md`
  - `retro.md`
  - `test-nonsymlink.md`

## Test Plan

- [ ] Verify plugin commands are discoverable by Claude Code
- [ ] Confirm all procedure commands work as expected
- [ ] Test that commands load from `knowledge/procedures/` without issues