### PR TITLE
fix: use symlink to satisfy Claude Code path requirements

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -5,5 +5,5 @@
   "author": {
     "name": "atxtechbro"
   },
-  "commands": ["../knowledge/procedures/"]
+  "commands": ["./procedures/"]
 }

--- a/.claude-plugin/procedures
+++ b/.claude-plugin/procedures
@@ -1,0 +1,1 @@
+../knowledge/procedures


### PR DESCRIPTION
## Summary
This PR fixes the Claude Code plugin loading error by using a symlink to satisfy path requirements.

## Problem
Claude Code requires command paths in `plugin.json` to start with `./` and not `../`. The previous configuration used `"../knowledge/procedures/"` which violated this requirement.

## Solution
1. Created a symlink at `.claude-plugin/procedures` that points to `../knowledge/procedures`
2. Updated `plugin.json` to use `"./procedures/"` instead of `"../knowledge/procedures/"`

## Benefits
- Satisfies Claude Code's path validation requirements
- Maintains single source of truth (actual procedures remain in `knowledge/procedures/`)
- Plugin now loads correctly without errors

## Test Plan
- [x] Verified symlink created correctly: `.claude-plugin/procedures -> ../knowledge/procedures`
- [x] Updated `plugin.json` to use relative path starting with `./`
- [x] Confirmed this approach satisfies Claude Code's path requirements