### PR TITLE
cleanup: remove ML artifacts and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,12 @@ mcp/clients/
 # MCP server convenience symlinks (setup-generated executables)
 mcp/servers/*/git_mcp_server.py
 
+# Video processing artifacts
+frames/
+
+# ML experiment tracking
+mlruns/
+
+# General output directory
+output/
+


### PR DESCRIPTION
## Summary
- Removed ~86M of untracked ML/video processing artifacts (directories: `~/`, `frames/`, `mlruns/`, `output/`)
- Removed inactive `mcp-dashboard-go/` directory with stale logs
- Updated `.gitignore` to prevent future accumulation of experiment tracking and output files

## Test plan
- [x] Verified removed directories were untracked/gitignored
- [x] Confirmed `.gitignore` entries prevent future commits of these paths
- [x] No tracked files affected beyond `.gitignore` itself