### PR TITLE
refactor: remove un-reproducible patterns (think-tank, CLAUDE.local.md)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,11 +17,6 @@
 # Machine-specific configuration
 .bash_exports.local
 
-# Personal notes and thinking space
-think-tank/
-
-# Claude Code personal configuration
-CLAUDE.local.md
 # Claude Code local settings (personal overrides, not for source control per Anthropic docs)
 .claude/settings.local.json
 

--- a/docs/mcp-client-integration.md
+++ b/docs/mcp-client-integration.md
@@ -22,7 +22,6 @@ The dotfiles repository provides an AI harness-agnostic system for managing MCP 
 ### 3. AI Harness Context
 - **Source**: `knowledge/` directory automatically configured for each harness
 - **Amazon Q**: Uses symlinked rules directory (`~/.amazonq/rules/`)
-- **Claude Code**: Uses generated `CLAUDE.local.md` files with embedded context
 
 ## Adding a New MCP Client
 
@@ -115,12 +114,7 @@ Create `docs/<client-name>-setup.md` documenting:
 - Create symlink: `~/.clientname/rules` → `~/ppv/pillars/dotfiles/knowledge`
 - Minimal duplication, single source of truth
 
-### Pattern 2: Generated Files (Claude Code)
-- Client expects specific file format
-- Generate `CLIENTNAME.local.md` with embedded content
-- Run generation on each setup
-
-### Pattern 3: Configuration File
+### Pattern 2: Configuration File
 - Client uses JSON/YAML configuration
 - Generate config from `mcp/mcp.template.json` using `generate-mcp-config.sh`
 - Apply environment-specific filtering

--- a/docs/procedures/git-workflow-detailed.md
+++ b/docs/procedures/git-workflow-detailed.md
@@ -35,6 +35,3 @@ When converting a directory to a symlink (or vice versa), it's safer to use diff
 1. Use different names (e.g., rename directory first, then create symlink)
 2. Split into separate commits (remove directory in one commit, add symlink in another)
 3. Create fresh branch from clean state if corruption occurs
-
-## Think-Tank Content in Worktrees
-**CRITICAL**: Never add think-tank notes or personal content to worktree locations. Worktrees are temporary directories that will be deleted when cleanup occurs. Always use the main repository at `/think-tank/` for any persistent personal content, notes, or documentation.

--- a/docs/procedures/worktree-troubleshooting.md
+++ b/docs/procedures/worktree-troubleshooting.md
@@ -23,7 +23,3 @@
 **Problem**: Running setup.sh from worktree creates symlinks that break when worktree is deleted
 **Solution**: Never run `source setup.sh` from worktree - only from main repository
 **Note**: setup.sh automatically detects and fixes broken symlinks from deleted worktrees
-
-### Think-tank content in worktrees
-**Problem**: Personal notes or think-tank content added to worktree gets lost when worktree is deleted
-**Solution**: Always use the main repository at `/think-tank/` for any persistent personal content

--- a/knowledge/principles/no-leaks.md
+++ b/knowledge/principles/no-leaks.md
@@ -7,17 +7,9 @@ Avoid leaking company details into your public dotfiles - it's about respect, no
 **Why this matters**: We want to be responsible practitioners of AI and not ruin a good thing we have going - for ourselves or anyone else. Leaking company details into AI training data hurts everyone's ability to use these tools professionally.
 
 **In practice**:
-- MUST use environment variables: `AWS_PROFILE="${COMPANY_AWS_PROFILE:-default}"` 
-- SHOULD point to gitignored docs: `# See think-tank/aws-setup.md`
+- MUST use environment variables: `AWS_PROFILE="${COMPANY_AWS_PROFILE:-default}"`
 - MAY use public company name in comments and messages
 - MUST NOT hardcode internal identifiers like profile names or server details
-- SHOULD keep comprehensive company-specific documentation in `think-tank/` directory
-- MAY include as much detail as needed in gitignored notes - they stay local and private
-
-**Spilled Coffee Compatibility**: think-tank notes are backed up in company cloud and only accessed on company hardware. AI can easily find think-tank documentation during setup, maintaining 20-minute recovery time. Inline comments create discoverable breadcrumbs.
-
-**Global Force Multiplier**: The `think-tank/` pattern works in ANY repository via global gitignore configuration. This multiplies the impact across your entire professional ecosystem - every repo gets rich company context for AI agents while keeping company details private.
-
-**Remember**: Check and update think-tank documentation when working in these areas - keep the breadcrumbs fresh.
+- MAY add gitignored documentation files if needed for complex setups
 
 Keep company details in your private vaults, not public dotfiles. Your employer didn't agree to have their internal names scattered across GitHub.


### PR DESCRIPTION
## Summary
Subtraction creates value - removing unused infrastructure that never delivered on its promise.

## Changes Made
- ❌ Removed `think-tank/` folder (unused personal workspace)
- ❌ Removed `CLAUDE.local.md` pattern (un-reproducible)
- ✅ Simplified `no-leaks.md` to focus on environment variables (the actual pattern we use)
- ✅ Cleaned up gitignore entries
- ✅ Removed obsolete documentation references

## Impact
**5 files changed, 5 insertions(+), 31 deletions(-)**

## Principle
Keep only reproducible patterns:
- ✅ `.example` files that users copy and customize
- ✅ Templates with clear setup instructions
- ❌ Machine-specific generated files that can't be shared

## Files Changed
1. `.gitignore` - removed think-tank/ and CLAUDE.local.md entries
2. `knowledge/principles/no-leaks.md` - simplified to core principle
3. `docs/procedures/git-workflow-detailed.md` - removed think-tank section
4. `docs/procedures/worktree-troubleshooting.md` - removed think-tank failure mode
5. `docs/mcp-client-integration.md` - removed CLAUDE.local.md pattern

## Test Plan
- [ ] Verify no broken links to removed files
- [ ] Confirm setup.sh still works
- [ ] Check that no-leaks principle is still clear