### PR TITLE
docs: realign README to emphasize agent orchestration infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ See [Snowball Method](knowledge/principles/snowball-method.md) - compound return
 
 ## Agent Orchestration Infrastructure
 
-This system enables **macro-level agent management** instead of micro-level file editing. The core infrastructure:
+This system enables **macro-level agent management** instead of micro-level file editing - you manage tasks and projects, not lines of code within an IDE. The core infrastructure:
 
 - **Harness-Agnostic Configuration**: Single `.agent-config.yml` defines user preferences, agent settings, and paths - works across Claude Code, Amazon Q, and Codex without duplication (see [config-architecture.md](docs/config-architecture.md))
 - **Reproducible Agent Procedures**: Slash commands in `commands/` directory (`/close-issue`, `/create-issue`, `/extract-best-frame`, `/retro`) enforce consistent workflows across all AI harnesses


### PR DESCRIPTION
## Summary

Realign README to match GitHub description and actual codebase focus: **AI agent orchestration for 100x throughput**.

### Problem
README dedicated 37+ lines to P.P.V philosophy but only 2 lines to the core agent orchestration capability that defines the repo. First-time readers saw "dotfiles with philosophy" instead of "agent orchestration platform."

### Solution
Edited existing sections to emphasize agent infrastructure, making P.P.V a supporting context rather than a hero section.

## Changes

### ✅ Agent-First Tagline (line 3)
- **Before**: "A collection of configuration files for a consistent development environment"
- **After**: "AI agent orchestration infrastructure for 100x throughput. Parallelize agents across any harness..."

### ✅ Agent Infrastructure Expansion (2 lines → 11 lines)
**Before**: Brief mention of tmux + worktrees  
**After**: Detailed breakdown of:
- Harness-agnostic `.agent-config.yml`
- Slash commands in `commands/`
- MLflow telemetry via `bin/claude-with-tracking`
- Parallel execution strategy
- Principle enforcement mechanism

### ✅ P.P.V Condensation (26 lines → 9 lines)
**Before**: Full philosophy with directory tree, interconnected references  
**After**: Terse "where dotfiles live" context - just the three-tier structure

### ✅ 80/20 Philosophy Condensation (11 lines → 8 lines)
**Before**: Extended meditation on serving others, Ecclesiastes references  
**After**: Pragmatic focus on balancing infrastructure vs delivery

## Net Effect
- **-14 lines total** (357 → 343) through strategic condensing
- **Agent infrastructure** is now the hero (11 lines of prime README real estate)
- **P.P.V and philosophy** remain as supporting context
- First-time readers immediately see "this is for orchestrating AI agents"

## Test Plan
- [x] README renders correctly on GitHub
- [x] All internal links still resolve
- [x] Line count reduced while agent emphasis expanded
- [x] Vibe shift complete: from "dotfiles with philosophy" to "agent orchestration platform"