### PR TITLE
fix: pin active Node version to maintain Claude CLI availability

### DIFF
--- a/.bash_aliases.d/claude.sh
+++ b/.bash_aliases.d/claude.sh
@@ -15,4 +15,5 @@ alias claude='claude --verbose --mcp-config "$GLOBAL_MCP_CONFIG" --add-dir "$DOT
 
 # Quick test command - validates knowledge integration
 alias claude-test='claude -p "What is AI harness agnosticism and which two harnesses are currently configured?"'
-
+# Spill-proof the Claude CLI: pin the active Node version whenever the shell loads
+command -v nvm >/dev/null && current="$(nvm current 2>/dev/null)" && [[ "$current" != "none" && "$current" != "system" ]] && nvm alias default "$current" >/dev/null 2>&1


### PR DESCRIPTION
## Git Statistics
- Issue: #1404

## Summary
- spill-proof the Claude alias by pinning the active nvm Node version whenever aliases load
- avoid the recurring reinstall cycle when nvm advances to a new LTS and drops the  binary

Closes #1404

## Testing
- source ~/.bashrc
- command -v claude
