### PR TITLE
feat: enable Claude thinking mode by default for improved AI reasoning quality

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -63,5 +63,5 @@
     "dotfiles-commands@dotfiles-marketplace": true
   },
   "forceLoginMethod": "claudeai",
-  "alwaysThinkingEnabled": false
+  "alwaysThinkingEnabled": true
 }

--- a/docs/claude-code-settings.md
+++ b/docs/claude-code-settings.md
@@ -39,11 +39,16 @@ See `.claude/settings/claude-code-defaults.json` for the current configuration. 
 Each setting in the JSON file is automatically applied by the configuration script.
 
 ### Project Settings (direct file read)
-See `.claude/settings.local.json` for project-level settings including:
+See `.claude/settings.json` for project-level settings including:
 
 - **Permissions**: allowed and denied tool usage patterns
 - **Environment Variables**: timeout limits, token limits, cost warnings
 - **MCP Servers**: enabled Model Context Protocol servers
+- **AI Behavior**: thinking mode configuration
+
+#### AI Behavior Settings
+- `alwaysThinkingEnabled`: true - Enables Claude's thinking mode by default for improved reasoning on complex tasks
+- `MAX_THINKING_TOKENS` (optional env var): Set token budget for extended thinking (e.g., "10000")
 
 Environment variables configured:
 - `CLAUDE_CODE_MAX_OUTPUT_TOKENS`: 8192 - Maximum tokens in Claude responses


### PR DESCRIPTION
## Git Statistics

2 files changed:
- `.claude/settings.json`: Enable `alwaysThinkingEnabled`
- `docs/claude-code-settings.md`: Document thinking mode configuration

## Summary

Enables Claude's thinking mode by default in the dotfiles repository, ensuring all users get improved reasoning quality from the start without manual configuration.

### What Changed
- Set `alwaysThinkingEnabled: true` in `.claude/settings.json`
- Added AI Behavior Settings section to documentation
- Documented optional `MAX_THINKING_TOKENS` environment variable

### Why This Matters
**For you (the developer):** You get better AI assistance out of the box on complex tasks without remembering to toggle thinking mode.

**For the dotfiles philosophy:** Follows **subtraction-creates-value** (removes manual step) and **developer-experience** (optimizes for joy and effectiveness).

### Testing
✅ Setting change verified in `.claude/settings.json`
✅ Documentation updated with clear examples
✅ Backwards compatible (just changes default behavior)

## Principle Alignment
- **developer-experience** 🎯: Better AI assistance by default
- **subtraction-creates-value** ✂️: Removes need to manually enable thinking mode

Closes #1406