### PR TITLE
feat: enable extended thinking mode in Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,7 +11,8 @@
     "DISABLE_TELEMETRY": "1",
     "MCP_TIMEOUT": "30000",
     "MCP_TOOL_TIMEOUT": "60000",
-    "MAX_MCP_OUTPUT_TOKENS": "40000"
+    "MAX_MCP_OUTPUT_TOKENS": "40000",
+    "MAX_THINKING_TOKENS": "121393"
   },
   "includeCoAuthoredBy": false,
   "permissions": {
@@ -63,5 +64,5 @@
     "dotfiles-commands@dotfiles-marketplace": true
   },
   "forceLoginMethod": "claudeai",
-  "alwaysThinkingEnabled": false
+  "alwaysThinkingEnabled": true
 }


### PR DESCRIPTION
## Summary

- Set `alwaysThinkingEnabled: true` to enable thinking mode by default
- Add `MAX_THINKING_TOKENS: 121393` for extended reasoning capacity

## Context

This enables Claude Code to use thinking mode by default and allows for extended thinking capacity with the configured token limit.

Closes #1406