### PR TITLE
refactor: rename mlruns to claude-runs for clarity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,8 +87,8 @@ mcp/servers/*/git_mcp_server.py
 # Video processing artifacts
 frames/
 
-# ML experiment tracking
-mlruns/
+# Claude Code session tracking
+claude-runs/
 
 # General output directory
 output/

--- a/bin/start-mlflow
+++ b/bin/start-mlflow
@@ -25,14 +25,14 @@ check_mlflow_running() {
 
 # Function to start MLflow
 start_mlflow_server() {
-  local mlruns_dir="$DOT_DEN/mlruns"
+  local claude_runs_dir="$DOT_DEN/claude-runs"
 
-  # Ensure mlruns directory exists
-  mkdir -p "$mlruns_dir"
+  # Ensure claude-runs directory exists
+  mkdir -p "$claude_runs_dir"
 
   # Start MLflow UI in background using uv run
   nohup uv run --with mlflow mlflow ui \
-    --backend-store-uri "file://$mlruns_dir" \
+    --backend-store-uri "file://$claude_runs_dir" \
     --host 0.0.0.0 \
     --port 5000 \
     > /dev/null 2>&1 &

--- a/knowledge/principles/systems-stewardship.md
+++ b/knowledge/principles/systems-stewardship.md
@@ -23,7 +23,7 @@ The principle of maintaining and improving systems through consistent patterns, 
 - "Vísteme despacio, que tengo prisa" - move deliberately, not frantically
 - **Never let a crisis go to waste**: Each failure becomes input for stronger procedures and prevention systems
 - **Leave cookie crumbs**: Document architectural decisions inline where future engineers encounter them. Git commit messages fade into history; inline comments create discoverable breadcrumbs for faster resolution.
-- **Gitignore as architectural documentation**: Every gitignore entry embeds meaning about system structure. `# MLflow experiment tracking data (regenerated on each run)` tells the story of why `mlruns/` is excluded. Each line is a clue to underlying architecture, not just file exclusion.
+- **Gitignore as architectural documentation**: Every gitignore entry embeds meaning about system structure. `# Claude Code session tracking` tells the story of why `claude-runs/` is excluded. Each line is a clue to underlying architecture, not just file exclusion.
 
 **GitHub Issues as WIP Inventory:**
 - Backlog buildup indicates bottlenecks in the development flow

--- a/tracking/README.md
+++ b/tracking/README.md
@@ -28,7 +28,7 @@ The MLflow tracking UI provides a web interface to view all tracked runs:
 
 ```bash
 # Start MLflow UI (runs on http://localhost:5000)
-mlflow ui --backend-store-uri ~/ppv/pillars/dotfiles/mlruns
+mlflow ui --backend-store-uri ~/ppv/pillars/dotfiles/claude-runs
 
 # Or use the auto-start script
 bin/start-mlflow start

--- a/tracking/parse_session.py
+++ b/tracking/parse_session.py
@@ -25,8 +25,8 @@ from mlflow import log_metric, log_param, log_text, set_tag
 def init_mlflow():
     """Initialize MLflow with local tracking."""
     dotfiles_root = Path(__file__).parent.parent
-    mlflow.set_tracking_uri(f"file://{dotfiles_root}/mlruns")
-    mlflow.set_experiment("ai-sessions")
+    mlflow.set_tracking_uri(f"file://{dotfiles_root}/claude-runs")
+    mlflow.set_experiment("claude-sessions")
 
 
 def parse_session_log(log_path):


### PR DESCRIPTION
## Summary

Renamed the MLflow tracking directory from `mlruns` to `claude-runs` throughout the codebase to better reflect its actual purpose: tracking Claude Code sessions, not generic ML experiments.

The name `mlruns` is MLflow's generic default for ML experiment tracking, but our setup is specifically designed to track Claude Code interactive sessions. The new name `claude-runs` immediately communicates the intent and purpose.

## Changes

- **Directory**: Renamed `mlruns/` → `claude-runs/`
- **bin/start-mlflow**: Updated variable from `mlruns_dir` to `claude_runs_dir` and backend URI
- **tracking/parse_session.py**: 
  - Updated tracking URI to point to `claude-runs/`
  - Renamed experiment from `"ai-sessions"` to `"claude-sessions"`
- **.gitignore**: Updated comment to reflect "Claude Code session tracking"
- **Documentation**: Updated all references in `tracking/README.md` and `systems-stewardship.md`

## Why This Matters

Names should reflect intent. When someone sees `claude-runs/` in the directory listing, they immediately understand what it tracks. This follows the principle of "gitignore as architectural documentation" - every name is a clue to the underlying system.

## Test Plan

- [ ] Verify MLflow UI starts correctly with new directory
- [ ] Run `claude-with-tracking` and confirm sessions log to `claude-runs/`
- [ ] Check MLflow UI shows experiments under "claude-sessions"