### PR TITLE
fix: scope tmux history copy to active pane

### DIFF
--- a/.bash_aliases.d/tmux.sh
+++ b/.bash_aliases.d/tmux.sh
@@ -10,5 +10,17 @@ alias tmux-branch='git checkout - && tmux source-file ~/.tmux.conf && echo "Swit
 # Quick access to tmux cheatsheet
 alias tmux-help="less ~/dotfiles/tmux-cheatsheet.md"
 
-# Copy full tmux pane history (joined lines) to system clipboard
-alias tmux-copy-history='tmux capture-pane -p -J -S -999999 | clipboard_copy'
+# Copy full history from the current (or last) pane to system clipboard
+tmux_copy_history() {
+    local target_pane
+
+    # If we're inside tmux, use the active pane; otherwise fall back to the last active pane
+    if [ -n "$TMUX" ]; then
+        target_pane="$(tmux display-message -p '#{pane_id}')"
+    else
+        target_pane="$(tmux display-message -p -F '#{pane_id}' -t '{last}')"
+    fi
+
+    tmux capture-pane -p -J -S -999999 -t "${target_pane}" | clipboard_copy
+}
+alias tmux-copy-history='tmux_copy_history'


### PR DESCRIPTION
## Git Statistics
- 1 file changed

## Summary
- wrap tmux-copy-history in a helper that targets the active pane when inside tmux and last active pane otherwise
- keep capture options the same while preventing clipboard capture across other panes/sessions

## Testing
- tmux_copy_history (manual) inside tmux
