### PR TITLE
fix: scope tmux history copy to visible pane

### DIFF
--- a/.bash_aliases.d/tmux.sh
+++ b/.bash_aliases.d/tmux.sh
@@ -10,5 +10,20 @@ alias tmux-branch='git checkout - && tmux source-file ~/.tmux.conf && echo "Swit
 # Quick access to tmux cheatsheet
 alias tmux-help="less ~/dotfiles/tmux-cheatsheet.md"
 
-# Copy full tmux pane history (joined lines) to system clipboard
-alias tmux-copy-history='tmux capture-pane -p -J -S -999999 | clipboard_copy'
+# Copy visible history from the active (or last) pane to the system clipboard
+tmux_copy_history() {
+    local target_pane
+
+    if [ -n "$TMUX" ]; then
+        target_pane="$(tmux display-message -p '#{pane_id}')"
+    else
+        if ! target_pane="$(tmux display-message -p -F '#{pane_id}' -t '{last}' 2>/dev/null)"; then
+            echo "tmux-copy-history: no tmux session found" >&2
+            return 1
+        fi
+    fi
+
+    # -S -0 captures from the top of the visible pane (respects a recent clear)
+    tmux capture-pane -p -J -S -0 -t "${target_pane}" | clipboard_copy
+}
+alias tmux-copy-history='tmux_copy_history'


### PR DESCRIPTION
## Git Statistics
- 1 file changed

## Summary
- adjust tmux-copy-history to use the active pane (or last active when run outside tmux)
- limit capture to the visible pane contents (-S -0) so clearing the screen drops prior scrollback
- keep clipboard piping via clipboard_copy for cross-platform support

## Testing
- tmux_copy_history (manual) inside tmux
